### PR TITLE
Update `tx` and `query` cli commands

### DIFF
--- a/module.go
+++ b/module.go
@@ -159,7 +159,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "CreateVault",
 					Use:       "create [admin] [underlying_asset] [share_denom]",
-					Alias:     []string{"c"},
+					Alias:     []string{"c", "new"},
 					Short:     "Create a new vault",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},

--- a/module.go
+++ b/module.go
@@ -158,7 +158,8 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
 				{
 					RpcMethod: "CreateVault",
-					Use:       "create-vault [admin] [underlying_asset] [share_denom]",
+					Use:       "create [admin] [underlying_asset] [share_denom]",
+					Alias:     []string{"c"},
 					Short:     "Create a new vault",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -169,6 +170,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "SwapIn",
 					Use:       "swap-in [owner] [vault_address] [assets]",
+					Alias:     []string{"si"},
 					Short:     "Deposit underlying assets into a vault to mint shares",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "owner"},
@@ -179,6 +181,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "SwapOut",
 					Use:       "swap-out [owner] [vault_address] [assets]",
+					Alias:     []string{"so"},
 					Short:     "Withdraw underlying assets from a vault by burning shares",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "owner"},
@@ -198,6 +201,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "UpdateInterestRate",
 					Use:       "update-interest-rate [admin] [vault_address] [new_rate]",
+					Alias:     []string{"uir"},
 					Short:     "Update the current interest rate for a vault",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -208,6 +212,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "UpdateMinInterestRate",
 					Use:       "update-min-interest-rate [admin] [vault_address] [min_rate]",
+					Alias:     []string{"umir"},
 					Short:     "Set or clear the minimum allowable interest rate for a vault",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -218,6 +223,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "UpdateMaxInterestRate",
 					Use:       "update-max-interest-rate [admin] [vault_address] [max_rate]",
+					Alias:     []string{"umaxir"},
 					Short:     "Set or clear the maximum allowable interest rate for a vault",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -228,6 +234,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "DepositInterestFunds",
 					Use:       "deposit-interest-funds [admin] [vault_address] [amount]",
+					Alias:     []string{"dif"},
 					Short:     "Deposit funds into a vault for paying interest",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -238,6 +245,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "WithdrawInterestFunds",
 					Use:       "withdraw-interest-funds [admin] [vault_address] [amount]",
+					Alias:     []string{"wif"},
 					Short:     "Withdraw unused interest funds from a vault",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -248,6 +256,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "DepositPrincipalFunds",
 					Use:       "deposit-principal-funds [admin] [vault_address] [amount]",
+					Alias:     []string{"dpf"},
 					Short:     "Deposit principal funds into the vault’s marker",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -258,6 +267,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "WithdrawPrincipalFunds",
 					Use:       "withdraw-principal-funds [admin] [vault_address] [amount]",
+					Alias:     []string{"wpf"},
 					Short:     "Withdraw principal funds from the vault’s marker",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -268,6 +278,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "ToggleSwapIn",
 					Use:       "toggle-swap-in [admin] [vault_address] [enabled]",
+					Alias:     []string{"tsi"},
 					Short:     "Enable or disable swap-in operations for a vault",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -278,6 +289,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "ToggleSwapOut",
 					Use:       "toggle-swap-out [admin] [vault_address] [enabled]",
+					Alias:     []string{"tso"},
 					Short:     "Enable or disable swap-out operations for a vault",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -295,15 +307,18 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "Params",
 					Use:       "params",
 					Short:     "Query the current module parameters",
+					Alias:     []string{"p"},
 				},
 				{
 					RpcMethod: "Vaults",
-					Use:       "vaults",
+					Use:       "list",
+					Alias:     []string{"l", "ls"},
 					Short:     "Query all vaults",
 				},
 				{
 					RpcMethod: "Vault",
-					Use:       "vault [vault_address]",
+					Use:       "get [vault_address]",
+					Alias:     []string{"g"},
 					Short:     "Query a specific vault's configuration and state",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "vault_address"},
@@ -312,6 +327,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "TotalAssets",
 					Use:       "total-assets [vault_address]",
+					Alias:     []string{"ta"},
 					Short:     "Query the total assets held by a specific vault",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "vault_address"},
@@ -320,6 +336,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "EstimateSwapIn",
 					Use:       "estimate-swap-in [vault_address] [assets]",
+					Alias:     []string{"esi"},
 					Short:     "Estimate the number of shares received for a given deposit",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "vault_address"},
@@ -329,6 +346,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "EstimateSwapOut",
 					Use:       "estimate-swap-out [vault_address] [assets]",
+					Alias:     []string{"eso"},
 					Short:     "Estimate the amount of underlying assets received for a given withdrawal",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "vault_address"},


### PR DESCRIPTION
Updated vault CLI commands to simplify usage and add common aliases.

* Shortened redundant commands (`create-vault` → `create`, `vaults` → `list`, `vault` → `get`)
* Added shorthand aliases for frequent commands (`l`, `g`, `si`, `so`, etc.)
