### PR TITLE
Interest Rate Documentation

### DIFF
--- a/api/v1/events.pulsar.go
+++ b/api/v1/events.pulsar.go
@@ -9468,7 +9468,7 @@ type EventVaultReconcile struct {
 	PrincipalBefore *v1beta1.Coin `protobuf:"bytes,2,opt,name=principal_before,json=principalBefore,proto3" json:"principal_before,omitempty"`
 	// principal_after is the principal amount after applying interest.
 	PrincipalAfter *v1beta1.Coin `protobuf:"bytes,3,opt,name=principal_after,json=principalAfter,proto3" json:"principal_after,omitempty"`
-	// rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing interest rate (APY) for the period.
+	// rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing interest rate (APY) for the period.
 	Rate string `protobuf:"bytes,4,opt,name=rate,proto3" json:"rate,omitempty"`
 	// time is the payout duration in seconds.
 	Time int64 `protobuf:"varint,5,opt,name=time,proto3" json:"time,omitempty"`
@@ -9546,9 +9546,9 @@ type EventVaultInterestChange struct {
 
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// current_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the actual interest rate (APY) the vault is using.
+	// current_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual interest rate (APY) the vault is using.
 	CurrentRate string `protobuf:"bytes,2,opt,name=current_rate,json=currentRate,proto3" json:"current_rate,omitempty"`
-	// desired_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the the interest rate (APY) the admin wants to use.
+	// desired_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the the interest rate (APY) the admin wants to use.
 	DesiredRate string `protobuf:"bytes,3,opt,name=desired_rate,json=desiredRate,proto3" json:"desired_rate,omitempty"`
 }
 
@@ -9933,7 +9933,7 @@ type EventMinInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
+	// min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
@@ -9989,7 +9989,7 @@ type EventMaxInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
+	// max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }

--- a/api/v1/events.pulsar.go
+++ b/api/v1/events.pulsar.go
@@ -9468,7 +9468,7 @@ type EventVaultReconcile struct {
 	PrincipalBefore *v1beta1.Coin `protobuf:"bytes,2,opt,name=principal_before,json=principalBefore,proto3" json:"principal_before,omitempty"`
 	// principal_after is the principal amount after applying interest.
 	PrincipalAfter *v1beta1.Coin `protobuf:"bytes,3,opt,name=principal_after,json=principalAfter,proto3" json:"principal_after,omitempty"`
-	// rate is a decimal string (e.g., "0.9" for 90%) representing interest rate for the period.
+	// rate is a decimal string (e.g., "0.9" for 90%) representing interest rate (APY) for the period.
 	Rate string `protobuf:"bytes,4,opt,name=rate,proto3" json:"rate,omitempty"`
 	// time is the payout duration in seconds.
 	Time int64 `protobuf:"varint,5,opt,name=time,proto3" json:"time,omitempty"`
@@ -9546,9 +9546,9 @@ type EventVaultInterestChange struct {
 
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// current_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate the vault is using.
+	// current_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate (APY) the vault is using.
 	CurrentRate string `protobuf:"bytes,2,opt,name=current_rate,json=currentRate,proto3" json:"current_rate,omitempty"`
-	// desired_rate is a decimal string (e.g., "0.9" for 90%) representing the the interest rate the admin wants to use.
+	// desired_rate is a decimal string (e.g., "0.9" for 90%) representing the the interest rate (APY) the admin wants to use.
 	DesiredRate string `protobuf:"bytes,3,opt,name=desired_rate,json=desiredRate,proto3" json:"desired_rate,omitempty"`
 }
 
@@ -9933,7 +9933,7 @@ type EventMinInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// min_rate is the newly set minimum interest rate as a decimal string (e.g., "0.9" for 90%).
+	// min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90%).
 	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
@@ -9989,7 +9989,7 @@ type EventMaxInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// max_rate is the newly set maximum interest rate as a decimal string (e.g., "0.9" for 90%).
+	// max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }

--- a/api/v1/events.pulsar.go
+++ b/api/v1/events.pulsar.go
@@ -9468,7 +9468,7 @@ type EventVaultReconcile struct {
 	PrincipalBefore *v1beta1.Coin `protobuf:"bytes,2,opt,name=principal_before,json=principalBefore,proto3" json:"principal_before,omitempty"`
 	// principal_after is the principal amount after applying interest.
 	PrincipalAfter *v1beta1.Coin `protobuf:"bytes,3,opt,name=principal_after,json=principalAfter,proto3" json:"principal_after,omitempty"`
-	// rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing interest rate (APY) for the period.
+	// rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing annual interest rate for the period.
 	Rate string `protobuf:"bytes,4,opt,name=rate,proto3" json:"rate,omitempty"`
 	// time is the payout duration in seconds.
 	Time int64 `protobuf:"varint,5,opt,name=time,proto3" json:"time,omitempty"`
@@ -9546,9 +9546,9 @@ type EventVaultInterestChange struct {
 
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// current_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual interest rate (APY) the vault is using.
+	// current_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual annual interest rate the vault is using.
 	CurrentRate string `protobuf:"bytes,2,opt,name=current_rate,json=currentRate,proto3" json:"current_rate,omitempty"`
-	// desired_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the the interest rate (APY) the admin wants to use.
+	// desired_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the the annual interest rate the admin wants to use.
 	DesiredRate string `protobuf:"bytes,3,opt,name=desired_rate,json=desiredRate,proto3" json:"desired_rate,omitempty"`
 }
 
@@ -9933,7 +9933,7 @@ type EventMinInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
+	// min_rate is the newly set minimum annual interest rate as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
@@ -9989,7 +9989,7 @@ type EventMaxInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
+	// max_rate is the newly set maximum annual interest rate as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }

--- a/api/v1/events.pulsar.go
+++ b/api/v1/events.pulsar.go
@@ -9468,7 +9468,7 @@ type EventVaultReconcile struct {
 	PrincipalBefore *v1beta1.Coin `protobuf:"bytes,2,opt,name=principal_before,json=principalBefore,proto3" json:"principal_before,omitempty"`
 	// principal_after is the principal amount after applying interest.
 	PrincipalAfter *v1beta1.Coin `protobuf:"bytes,3,opt,name=principal_after,json=principalAfter,proto3" json:"principal_after,omitempty"`
-	// rate is a decimal string (e.g., "0.9" for 90%) representing interest rate (APY) for the period.
+	// rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing interest rate (APY) for the period.
 	Rate string `protobuf:"bytes,4,opt,name=rate,proto3" json:"rate,omitempty"`
 	// time is the payout duration in seconds.
 	Time int64 `protobuf:"varint,5,opt,name=time,proto3" json:"time,omitempty"`
@@ -9546,9 +9546,9 @@ type EventVaultInterestChange struct {
 
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// current_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate (APY) the vault is using.
+	// current_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the actual interest rate (APY) the vault is using.
 	CurrentRate string `protobuf:"bytes,2,opt,name=current_rate,json=currentRate,proto3" json:"current_rate,omitempty"`
-	// desired_rate is a decimal string (e.g., "0.9" for 90%) representing the the interest rate (APY) the admin wants to use.
+	// desired_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the the interest rate (APY) the admin wants to use.
 	DesiredRate string `protobuf:"bytes,3,opt,name=desired_rate,json=desiredRate,proto3" json:"desired_rate,omitempty"`
 }
 
@@ -9933,7 +9933,7 @@ type EventMinInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90%).
+	// min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
 	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
@@ -9989,7 +9989,7 @@ type EventMaxInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90%).
+	// max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }

--- a/api/v1/events.pulsar.go
+++ b/api/v1/events.pulsar.go
@@ -9468,7 +9468,7 @@ type EventVaultReconcile struct {
 	PrincipalBefore *v1beta1.Coin `protobuf:"bytes,2,opt,name=principal_before,json=principalBefore,proto3" json:"principal_before,omitempty"`
 	// principal_after is the principal amount after applying interest.
 	PrincipalAfter *v1beta1.Coin `protobuf:"bytes,3,opt,name=principal_after,json=principalAfter,proto3" json:"principal_after,omitempty"`
-	// rate is the interest rate for the period.
+	// rate is a decimal string (e.g., "0.9" for 90%) representing interest rate for the period.
 	Rate string `protobuf:"bytes,4,opt,name=rate,proto3" json:"rate,omitempty"`
 	// time is the payout duration in seconds.
 	Time int64 `protobuf:"varint,5,opt,name=time,proto3" json:"time,omitempty"`
@@ -9546,9 +9546,9 @@ type EventVaultInterestChange struct {
 
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// current_rate is the interest rate actual rate the vault is using.
+	// current_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate the vault is using.
 	CurrentRate string `protobuf:"bytes,2,opt,name=current_rate,json=currentRate,proto3" json:"current_rate,omitempty"`
-	// desired_rate is the interest rate the admin wants to use.
+	// desired_rate is a decimal string (e.g., "0.9" for 90%) representing the the interest rate the admin wants to use.
 	DesiredRate string `protobuf:"bytes,3,opt,name=desired_rate,json=desiredRate,proto3" json:"desired_rate,omitempty"`
 }
 
@@ -9933,7 +9933,8 @@ type EventMinInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// min_rate is the newly set minimum interest rate (as string, can be "").
+	// min_rate is the newly set minimum interest rate as a decimal string (e.g., "0.9" for 90%).
+	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
 
@@ -9988,7 +9989,8 @@ type EventMaxInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// max_rate is the newly set maximum interest rate (as string, can be "").
+	// max_rate is the newly set maximum interest rate as a decimal string (e.g., "0.9" for 90%).
+	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }
 

--- a/api/v1/tx.pulsar.go
+++ b/api/v1/tx.pulsar.go
@@ -11535,7 +11535,7 @@ type MsgUpdateMaxInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose maximum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
+	// max_rate is the maximum allowable annual interest rate for the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }
@@ -11607,7 +11607,7 @@ func (*MsgUpdateMaxInterestRateResponse) Descriptor() ([]byte, []int) {
 	return file_vault_v1_tx_proto_rawDescGZIP(), []int{9}
 }
 
-// MsgUpdateInterestRateRequest is the request message for updating the interest rate (APY) of a vault.
+// MsgUpdateInterestRateRequest is the request message for updating the annual interest rate of a vault.
 type MsgUpdateInterestRateRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -11617,7 +11617,7 @@ type MsgUpdateInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
+	// new_rate is the new annual interest rate for the the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	NewRate string `protobuf:"bytes,3,opt,name=new_rate,json=newRate,proto3" json:"new_rate,omitempty"`
 }
 

--- a/api/v1/tx.pulsar.go
+++ b/api/v1/tx.pulsar.go
@@ -11454,7 +11454,7 @@ type MsgUpdateMinInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose minimum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// min_rate is the minimum allowable interest rate(APY) for the vault as a decimal string (e.g., "0.9" for 90%).
+	// min_rate is the minimum allowable interest rate(APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
 	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
@@ -11535,7 +11535,7 @@ type MsgUpdateMaxInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose maximum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90%).
+	// max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }
@@ -11617,7 +11617,7 @@ type MsgUpdateInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90%).
+	// new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
 	NewRate string `protobuf:"bytes,3,opt,name=new_rate,json=newRate,proto3" json:"new_rate,omitempty"`
 }
 

--- a/api/v1/tx.pulsar.go
+++ b/api/v1/tx.pulsar.go
@@ -11454,7 +11454,7 @@ type MsgUpdateMinInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose minimum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// min_rate is the minimum allowable interest rate for the vault as a decimal string (e.g., "0.9" for 90%).
+	// min_rate is the minimum allowable interest rate(APY) for the vault as a decimal string (e.g., "0.9" for 90%).
 	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
@@ -11535,7 +11535,7 @@ type MsgUpdateMaxInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose maximum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// max_rate is the maximum allowable interest rate for the vault as a decimal string (e.g., "0.9" for 90%).
+	// max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }
@@ -11607,7 +11607,7 @@ func (*MsgUpdateMaxInterestRateResponse) Descriptor() ([]byte, []int) {
 	return file_vault_v1_tx_proto_rawDescGZIP(), []int{9}
 }
 
-// MsgUpdateInterestRateRequest is the request message for updating the interest rate of a vault.
+// MsgUpdateInterestRateRequest is the request message for updating the interest rate (APY) of a vault.
 type MsgUpdateInterestRateRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -11617,7 +11617,7 @@ type MsgUpdateInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// new_rate is the new interest rate for the the vault as a decimal string (e.g., "0.9" for 90%).
+	// new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90%).
 	NewRate string `protobuf:"bytes,3,opt,name=new_rate,json=newRate,proto3" json:"new_rate,omitempty"`
 }
 

--- a/api/v1/tx.pulsar.go
+++ b/api/v1/tx.pulsar.go
@@ -11454,7 +11454,7 @@ type MsgUpdateMinInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose minimum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// min_rate is the minimum allowable interest rate(APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
+	// min_rate is the minimum allowable interest rate(APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
@@ -11535,7 +11535,7 @@ type MsgUpdateMaxInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose maximum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
+	// max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }
@@ -11617,7 +11617,7 @@ type MsgUpdateInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
+	// new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	NewRate string `protobuf:"bytes,3,opt,name=new_rate,json=newRate,proto3" json:"new_rate,omitempty"`
 }
 

--- a/api/v1/tx.pulsar.go
+++ b/api/v1/tx.pulsar.go
@@ -11454,8 +11454,8 @@ type MsgUpdateMinInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose minimum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// The minimum allowable interest rate for the vault.
-	// Provide an empty string ("") to disable the minimum interest rate limit.
+	// min_rate is the minimum allowable interest rate for the vault as a decimal string (e.g., "0.9" for 90%).
+	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
 
@@ -11535,8 +11535,8 @@ type MsgUpdateMaxInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose maximum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// The maximum allowable interest rate for the vault.
-	// Provide an empty string ("") to disable the maximum interest rate limit.
+	// max_rate is the maximum allowable interest rate for the vault as a decimal string (e.g., "0.9" for 90%).
+	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }
 
@@ -11617,7 +11617,7 @@ type MsgUpdateInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// new_rate is the new interest rate for the vault, expressed as an APY string (e.g., "-5.00" for -5%).
+	// new_rate is the new interest rate for the the vault as a decimal string (e.g., "0.9" for 90%).
 	NewRate string `protobuf:"bytes,3,opt,name=new_rate,json=newRate,proto3" json:"new_rate,omitempty"`
 }
 

--- a/api/v1/tx_grpc.pb.go
+++ b/api/v1/tx_grpc.pb.go
@@ -45,11 +45,11 @@ type MsgClient interface {
 	SwapIn(ctx context.Context, in *MsgSwapInRequest, opts ...grpc.CallOption) (*MsgSwapInResponse, error)
 	// SwapOut exchanges vault shares for underlying assets by withdrawing from a vault.
 	SwapOut(ctx context.Context, in *MsgSwapOutRequest, opts ...grpc.CallOption) (*MsgSwapOutResponse, error)
-	// UpdateMinInterestRate sets the minimum allowed interest rate for a vault.
+	// UpdateMinInterestRate sets the minimum allowed interest rate (APY) for a vault.
 	UpdateMinInterestRate(ctx context.Context, in *MsgUpdateMinInterestRateRequest, opts ...grpc.CallOption) (*MsgUpdateMinInterestRateResponse, error)
-	// UpdateMaxInterestRate sets the maximum allowed interest rate for a vault.
+	// UpdateMaxInterestRate sets the maximum allowed interest rate (APY) for a vault.
 	UpdateMaxInterestRate(ctx context.Context, in *MsgUpdateMaxInterestRateRequest, opts ...grpc.CallOption) (*MsgUpdateMaxInterestRateResponse, error)
-	// UpdateInterestRate allows the interest admin to update the current interest rate within limits.
+	// UpdateInterestRate allows the interest admin to update the current interest rate (APY) within limits.
 	UpdateInterestRate(ctx context.Context, in *MsgUpdateInterestRateRequest, opts ...grpc.CallOption) (*MsgUpdateInterestRateResponse, error)
 	// DepositInterestFunds allows depositing funds into the vault for paying interest.
 	DepositInterestFunds(ctx context.Context, in *MsgDepositInterestFundsRequest, opts ...grpc.CallOption) (*MsgDepositInterestFundsResponse, error)
@@ -205,11 +205,11 @@ type MsgServer interface {
 	SwapIn(context.Context, *MsgSwapInRequest) (*MsgSwapInResponse, error)
 	// SwapOut exchanges vault shares for underlying assets by withdrawing from a vault.
 	SwapOut(context.Context, *MsgSwapOutRequest) (*MsgSwapOutResponse, error)
-	// UpdateMinInterestRate sets the minimum allowed interest rate for a vault.
+	// UpdateMinInterestRate sets the minimum allowed interest rate (APY) for a vault.
 	UpdateMinInterestRate(context.Context, *MsgUpdateMinInterestRateRequest) (*MsgUpdateMinInterestRateResponse, error)
-	// UpdateMaxInterestRate sets the maximum allowed interest rate for a vault.
+	// UpdateMaxInterestRate sets the maximum allowed interest rate (APY) for a vault.
 	UpdateMaxInterestRate(context.Context, *MsgUpdateMaxInterestRateRequest) (*MsgUpdateMaxInterestRateResponse, error)
-	// UpdateInterestRate allows the interest admin to update the current interest rate within limits.
+	// UpdateInterestRate allows the interest admin to update the current interest rate (APY) within limits.
 	UpdateInterestRate(context.Context, *MsgUpdateInterestRateRequest) (*MsgUpdateInterestRateResponse, error)
 	// DepositInterestFunds allows depositing funds into the vault for paying interest.
 	DepositInterestFunds(context.Context, *MsgDepositInterestFundsRequest) (*MsgDepositInterestFundsResponse, error)

--- a/api/v1/tx_grpc.pb.go
+++ b/api/v1/tx_grpc.pb.go
@@ -45,11 +45,11 @@ type MsgClient interface {
 	SwapIn(ctx context.Context, in *MsgSwapInRequest, opts ...grpc.CallOption) (*MsgSwapInResponse, error)
 	// SwapOut exchanges vault shares for underlying assets by withdrawing from a vault.
 	SwapOut(ctx context.Context, in *MsgSwapOutRequest, opts ...grpc.CallOption) (*MsgSwapOutResponse, error)
-	// UpdateMinInterestRate sets the minimum allowed interest rate (APY) for a vault.
+	// UpdateMinInterestRate sets the minimum allowed annual interest rate for a vault.
 	UpdateMinInterestRate(ctx context.Context, in *MsgUpdateMinInterestRateRequest, opts ...grpc.CallOption) (*MsgUpdateMinInterestRateResponse, error)
-	// UpdateMaxInterestRate sets the maximum allowed interest rate (APY) for a vault.
+	// UpdateMaxInterestRate sets the maximum allowed annual interest rate for a vault.
 	UpdateMaxInterestRate(ctx context.Context, in *MsgUpdateMaxInterestRateRequest, opts ...grpc.CallOption) (*MsgUpdateMaxInterestRateResponse, error)
-	// UpdateInterestRate allows the interest admin to update the current interest rate (APY) within limits.
+	// UpdateInterestRate allows the interest admin to update the current annual interest rate within limits.
 	UpdateInterestRate(ctx context.Context, in *MsgUpdateInterestRateRequest, opts ...grpc.CallOption) (*MsgUpdateInterestRateResponse, error)
 	// DepositInterestFunds allows depositing funds into the vault for paying interest.
 	DepositInterestFunds(ctx context.Context, in *MsgDepositInterestFundsRequest, opts ...grpc.CallOption) (*MsgDepositInterestFundsResponse, error)
@@ -205,11 +205,11 @@ type MsgServer interface {
 	SwapIn(context.Context, *MsgSwapInRequest) (*MsgSwapInResponse, error)
 	// SwapOut exchanges vault shares for underlying assets by withdrawing from a vault.
 	SwapOut(context.Context, *MsgSwapOutRequest) (*MsgSwapOutResponse, error)
-	// UpdateMinInterestRate sets the minimum allowed interest rate (APY) for a vault.
+	// UpdateMinInterestRate sets the minimum allowed annual interest rate for a vault.
 	UpdateMinInterestRate(context.Context, *MsgUpdateMinInterestRateRequest) (*MsgUpdateMinInterestRateResponse, error)
-	// UpdateMaxInterestRate sets the maximum allowed interest rate (APY) for a vault.
+	// UpdateMaxInterestRate sets the maximum allowed annual interest rate for a vault.
 	UpdateMaxInterestRate(context.Context, *MsgUpdateMaxInterestRateRequest) (*MsgUpdateMaxInterestRateResponse, error)
-	// UpdateInterestRate allows the interest admin to update the current interest rate (APY) within limits.
+	// UpdateInterestRate allows the interest admin to update the current annual interest rate within limits.
 	UpdateInterestRate(context.Context, *MsgUpdateInterestRateRequest) (*MsgUpdateInterestRateResponse, error)
 	// DepositInterestFunds allows depositing funds into the vault for paying interest.
 	DepositInterestFunds(context.Context, *MsgDepositInterestFundsRequest) (*MsgDepositInterestFundsResponse, error)

--- a/api/v1/vault.pulsar.go
+++ b/api/v1/vault.pulsar.go
@@ -1546,15 +1546,15 @@ type VaultAccount struct {
 	UnderlyingAssets []string `protobuf:"bytes,3,rep,name=underlying_assets,json=underlyingAssets,proto3" json:"underlying_assets,omitempty"`
 	// admin is the address that has administrative privileges over the vault.
 	Admin string `protobuf:"bytes,4,opt,name=admin,proto3" json:"admin,omitempty"`
-	// current_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate (APY) currently being applied.
+	// current_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the actual interest rate (APY) currently being applied.
 	// This may be adjusted programmatically (e.g., due to lack of funds).
 	CurrentInterestRate string `protobuf:"bytes,5,opt,name=current_interest_rate,json=currentInterestRate,proto3" json:"current_interest_rate,omitempty"`
-	// desired_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the target interest rate (APY) that the vault intends to apply.
+	// desired_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the target interest rate (APY) that the vault intends to apply.
 	DesiredInterestRate string `protobuf:"bytes,6,opt,name=desired_interest_rate,json=desiredInterestRate,proto3" json:"desired_interest_rate,omitempty"`
-	// min_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the lowest interest rate (APY) the admin is allowed to set.
+	// min_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the lowest interest rate (APY) the admin is allowed to set.
 	// If unset (empty string), there is no lower limit.
 	MinInterestRate string `protobuf:"bytes,7,opt,name=min_interest_rate,json=minInterestRate,proto3" json:"min_interest_rate,omitempty"`
-	// max_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the highest interest rate (APY) the admin is allowed to set.
+	// max_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the highest interest rate (APY) the admin is allowed to set.
 	// If unset (empty string), there is no upper limit.
 	MaxInterestRate string `protobuf:"bytes,8,opt,name=max_interest_rate,json=maxInterestRate,proto3" json:"max_interest_rate,omitempty"`
 	// swap_in_enabled indicates whether users are allowed to deposit into the vault.

--- a/api/v1/vault.pulsar.go
+++ b/api/v1/vault.pulsar.go
@@ -1546,15 +1546,15 @@ type VaultAccount struct {
 	UnderlyingAssets []string `protobuf:"bytes,3,rep,name=underlying_assets,json=underlyingAssets,proto3" json:"underlying_assets,omitempty"`
 	// admin is the address that has administrative privileges over the vault.
 	Admin string `protobuf:"bytes,4,opt,name=admin,proto3" json:"admin,omitempty"`
-	// current_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate currently being applied.
+	// current_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate (APY) currently being applied.
 	// This may be adjusted programmatically (e.g., due to lack of funds).
 	CurrentInterestRate string `protobuf:"bytes,5,opt,name=current_interest_rate,json=currentInterestRate,proto3" json:"current_interest_rate,omitempty"`
-	// desired_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the target interest rate that the vault intends to apply.
+	// desired_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the target interest rate (APY) that the vault intends to apply.
 	DesiredInterestRate string `protobuf:"bytes,6,opt,name=desired_interest_rate,json=desiredInterestRate,proto3" json:"desired_interest_rate,omitempty"`
-	// min_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the lowest interest rate the admin is allowed to set.
+	// min_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the lowest interest rate (APY) the admin is allowed to set.
 	// If unset (empty string), there is no lower limit.
 	MinInterestRate string `protobuf:"bytes,7,opt,name=min_interest_rate,json=minInterestRate,proto3" json:"min_interest_rate,omitempty"`
-	// max_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the highest interest rate the admin is allowed to set.
+	// max_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the highest interest rate (APY) the admin is allowed to set.
 	// If unset (empty string), there is no upper limit.
 	MaxInterestRate string `protobuf:"bytes,8,opt,name=max_interest_rate,json=maxInterestRate,proto3" json:"max_interest_rate,omitempty"`
 	// swap_in_enabled indicates whether users are allowed to deposit into the vault.

--- a/api/v1/vault.pulsar.go
+++ b/api/v1/vault.pulsar.go
@@ -1546,15 +1546,15 @@ type VaultAccount struct {
 	UnderlyingAssets []string `protobuf:"bytes,3,rep,name=underlying_assets,json=underlyingAssets,proto3" json:"underlying_assets,omitempty"`
 	// admin is the address that has administrative privileges over the vault.
 	Admin string `protobuf:"bytes,4,opt,name=admin,proto3" json:"admin,omitempty"`
-	// current_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual interest rate (APY) currently being applied.
+	// current_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual annual interest rate currently being applied.
 	// This may be adjusted programmatically (e.g., due to lack of funds).
 	CurrentInterestRate string `protobuf:"bytes,5,opt,name=current_interest_rate,json=currentInterestRate,proto3" json:"current_interest_rate,omitempty"`
-	// desired_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the target interest rate (APY) that the vault intends to apply.
+	// desired_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the target annual interest rate that the vault intends to apply.
 	DesiredInterestRate string `protobuf:"bytes,6,opt,name=desired_interest_rate,json=desiredInterestRate,proto3" json:"desired_interest_rate,omitempty"`
-	// min_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the lowest interest rate (APY) the admin is allowed to set.
+	// min_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the lowest annual interest rate the admin is allowed to set.
 	// If unset (empty string), there is no lower limit.
 	MinInterestRate string `protobuf:"bytes,7,opt,name=min_interest_rate,json=minInterestRate,proto3" json:"min_interest_rate,omitempty"`
-	// max_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the highest interest rate (APY) the admin is allowed to set.
+	// max_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the highest annual interest rate the admin is allowed to set.
 	// If unset (empty string), there is no upper limit.
 	MaxInterestRate string `protobuf:"bytes,8,opt,name=max_interest_rate,json=maxInterestRate,proto3" json:"max_interest_rate,omitempty"`
 	// swap_in_enabled indicates whether users are allowed to deposit into the vault.

--- a/api/v1/vault.pulsar.go
+++ b/api/v1/vault.pulsar.go
@@ -1546,15 +1546,15 @@ type VaultAccount struct {
 	UnderlyingAssets []string `protobuf:"bytes,3,rep,name=underlying_assets,json=underlyingAssets,proto3" json:"underlying_assets,omitempty"`
 	// admin is the address that has administrative privileges over the vault.
 	Admin string `protobuf:"bytes,4,opt,name=admin,proto3" json:"admin,omitempty"`
-	// current_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the actual interest rate (APY) currently being applied.
+	// current_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual interest rate (APY) currently being applied.
 	// This may be adjusted programmatically (e.g., due to lack of funds).
 	CurrentInterestRate string `protobuf:"bytes,5,opt,name=current_interest_rate,json=currentInterestRate,proto3" json:"current_interest_rate,omitempty"`
-	// desired_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the target interest rate (APY) that the vault intends to apply.
+	// desired_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the target interest rate (APY) that the vault intends to apply.
 	DesiredInterestRate string `protobuf:"bytes,6,opt,name=desired_interest_rate,json=desiredInterestRate,proto3" json:"desired_interest_rate,omitempty"`
-	// min_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the lowest interest rate (APY) the admin is allowed to set.
+	// min_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the lowest interest rate (APY) the admin is allowed to set.
 	// If unset (empty string), there is no lower limit.
 	MinInterestRate string `protobuf:"bytes,7,opt,name=min_interest_rate,json=minInterestRate,proto3" json:"min_interest_rate,omitempty"`
-	// max_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the highest interest rate (APY) the admin is allowed to set.
+	// max_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the highest interest rate (APY) the admin is allowed to set.
 	// If unset (empty string), there is no upper limit.
 	MaxInterestRate string `protobuf:"bytes,8,opt,name=max_interest_rate,json=maxInterestRate,proto3" json:"max_interest_rate,omitempty"`
 	// swap_in_enabled indicates whether users are allowed to deposit into the vault.

--- a/api/v1/vault.pulsar.go
+++ b/api/v1/vault.pulsar.go
@@ -1546,15 +1546,15 @@ type VaultAccount struct {
 	UnderlyingAssets []string `protobuf:"bytes,3,rep,name=underlying_assets,json=underlyingAssets,proto3" json:"underlying_assets,omitempty"`
 	// admin is the address that has administrative privileges over the vault.
 	Admin string `protobuf:"bytes,4,opt,name=admin,proto3" json:"admin,omitempty"`
-	// current_interest_rate is the actual interest rate currently being applied.
+	// current_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate currently being applied.
 	// This may be adjusted programmatically (e.g., due to lack of funds).
 	CurrentInterestRate string `protobuf:"bytes,5,opt,name=current_interest_rate,json=currentInterestRate,proto3" json:"current_interest_rate,omitempty"`
-	// desired_interest_rate is the target interest rate that the vault intends to apply.
+	// desired_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the target interest rate that the vault intends to apply.
 	DesiredInterestRate string `protobuf:"bytes,6,opt,name=desired_interest_rate,json=desiredInterestRate,proto3" json:"desired_interest_rate,omitempty"`
-	// min_interest_rate is the lowest interest rate the admin is allowed to set.
+	// min_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the lowest interest rate the admin is allowed to set.
 	// If unset (empty string), there is no lower limit.
 	MinInterestRate string `protobuf:"bytes,7,opt,name=min_interest_rate,json=minInterestRate,proto3" json:"min_interest_rate,omitempty"`
-	// max_interest_rate is the highest interest rate the admin is allowed to set.
+	// max_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the highest interest rate the admin is allowed to set.
 	// If unset (empty string), there is no upper limit.
 	MaxInterestRate string `protobuf:"bytes,8,opt,name=max_interest_rate,json=maxInterestRate,proto3" json:"max_interest_rate,omitempty"`
 	// swap_in_enabled indicates whether users are allowed to deposit into the vault.

--- a/module.go
+++ b/module.go
@@ -215,7 +215,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateMinInterestRate",
 					Use:       "update-min-interest-rate [admin] [vault_address] [min_rate]",
 					Alias:     []string{"umir"},
-					Short:     "Sets the vault's minimum APY interest rate (e.g., \"0.9\" for 90% and \"0.9001353\" for 90.01353%)) or clears it when not provided.",
+					Short:     "Sets the vault's minimum APY interest rate (e.g., \"0.9\" for 90% and \"0.9001353\" for 90.01353%) or clears it when not provided.",
 					Example:   fmt.Sprintf("%s update-min-interest-rate %s %s 0.01", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -227,7 +227,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateMaxInterestRate",
 					Use:       "update-max-interest-rate [admin] [vault_address] [max_rate]",
 					Alias:     []string{"umaxir"},
-					Short:     "Sets the vault's maximum APY interest rate (e.g., \"0.9\" for 90% and \"0.9001353\" for 90.01353%)) or clears it when not provided.",
+					Short:     "Sets the vault's maximum APY interest rate (e.g., \"0.9\" for 90% and \"0.9001353\" for 90.01353%) or clears it when not provided.",
 					Example:   fmt.Sprintf("%s update-max-interest-rate %s %s 0.1", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},

--- a/module.go
+++ b/module.go
@@ -203,7 +203,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateInterestRate",
 					Use:       "update-interest-rate [admin] [vault_address] [new_rate]",
 					Alias:     []string{"uir"},
-					Short:     "Updates the current APY interest rate (e.g., \"0.9\" for 90% and \"0.038\" for  3.8%) for the vault.",
+					Short:     "Updates the current APY interest rate (e.g., \"0.9\" for 90% and \"0.9001353\" for 90.01353%) for the vault.",
 					Example:   fmt.Sprintf("%s update-interest-rate %s %s 0.05", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -215,7 +215,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateMinInterestRate",
 					Use:       "update-min-interest-rate [admin] [vault_address] [min_rate]",
 					Alias:     []string{"umir"},
-					Short:     "Sets the vault's minimum APY interest rate (e.g., \"0.9\" for 90% and \"0.038\" for  3.8%)) or clears it when not provided.",
+					Short:     "Sets the vault's minimum APY interest rate (e.g., \"0.9\" for 90% and \"0.9001353\" for 90.01353%)) or clears it when not provided.",
 					Example:   fmt.Sprintf("%s update-min-interest-rate %s %s 0.01", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -227,7 +227,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateMaxInterestRate",
 					Use:       "update-max-interest-rate [admin] [vault_address] [max_rate]",
 					Alias:     []string{"umaxir"},
-					Short:     "Sets the vault's maximum APY interest rate (e.g., \"0.9\" for 90% and \"0.038\" for  3.8%)) or clears it when not provided.",
+					Short:     "Sets the vault's maximum APY interest rate (e.g., \"0.9\" for 90% and \"0.9001353\" for 90.01353%)) or clears it when not provided.",
 					Example:   fmt.Sprintf("%s update-max-interest-rate %s %s 0.1", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},

--- a/module.go
+++ b/module.go
@@ -203,7 +203,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateInterestRate",
 					Use:       "update-interest-rate [admin] [vault_address] [new_rate]",
 					Alias:     []string{"uir"},
-					Short:     "Updates the current interest rate (e.g., \"0.9\" for 90%) for the vault.",
+					Short:     "Updates the current APY interest rate (e.g., \"0.9\" for 90%) for the vault.",
 					Example:   fmt.Sprintf("%s update-interest-rate %s %s 0.05", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -215,7 +215,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateMinInterestRate",
 					Use:       "update-min-interest-rate [admin] [vault_address] [min_rate]",
 					Alias:     []string{"umir"},
-					Short:     "Sets the vault's maximum interest rate (e.g., \"0.9\" for 90%) or clears it when not provided.",
+					Short:     "Sets the vault's minimum APY interest rate (e.g., \"0.9\" for 90%) or clears it when not provided.",
 					Example:   fmt.Sprintf("%s update-min-interest-rate %s %s 0.01", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -227,7 +227,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateMaxInterestRate",
 					Use:       "update-max-interest-rate [admin] [vault_address] [max_rate]",
 					Alias:     []string{"umaxir"},
-					Short:     "Sets the vault's maximum interest rate (e.g., \"0.9\" for 90%) or clears it when not provided.",
+					Short:     "Sets the vault's maximum APY interest rate (e.g., \"0.9\" for 90%) or clears it when not provided.",
 					Example:   fmt.Sprintf("%s update-max-interest-rate %s %s 0.1", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},

--- a/module.go
+++ b/module.go
@@ -203,7 +203,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateInterestRate",
 					Use:       "update-interest-rate [admin] [vault_address] [new_rate]",
 					Alias:     []string{"uir"},
-					Short:     "Update the current interest rate for a vault",
+					Short:     "Updates the current interest rate (e.g., \"0.9\" for 90%) for the vault.",
 					Example:   fmt.Sprintf("%s update-interest-rate %s %s 0.05", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -215,7 +215,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateMinInterestRate",
 					Use:       "update-min-interest-rate [admin] [vault_address] [min_rate]",
 					Alias:     []string{"umir"},
-					Short:     "Set or clear the minimum allowable interest rate for a vault. For example, an interest rate of 90% must be entered as '0.9'.",
+					Short:     "Sets the vault's maximum interest rate (e.g., \"0.9\" for 90%) or clears it when not provided.",
 					Example:   fmt.Sprintf("%s update-min-interest-rate %s %s 0.01", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -227,7 +227,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateMaxInterestRate",
 					Use:       "update-max-interest-rate [admin] [vault_address] [max_rate]",
 					Alias:     []string{"umaxir"},
-					Short:     "Set or clear the maximum allowable interest rate for a vault",
+					Short:     "Sets the vault's maximum interest rate (e.g., \"0.9\" for 90%) or clears it when not provided.",
 					Example:   fmt.Sprintf("%s update-max-interest-rate %s %s 0.1", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},

--- a/module.go
+++ b/module.go
@@ -203,7 +203,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateInterestRate",
 					Use:       "update-interest-rate [admin] [vault_address] [new_rate]",
 					Alias:     []string{"uir"},
-					Short:     "Updates the current APY interest rate (e.g., \"0.9\" for 90% and \"0.9001353\" for 90.01353%) for the vault.",
+					Short:     "Updates the current annual interest rate (e.g., \"0.9\" for 90% and \"0.9001353\" for 90.01353%) for the vault.",
 					Example:   fmt.Sprintf("%s update-interest-rate %s %s 0.05", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -215,7 +215,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateMinInterestRate",
 					Use:       "update-min-interest-rate [admin] [vault_address] [min_rate]",
 					Alias:     []string{"umir"},
-					Short:     "Sets the vault's minimum APY interest rate (e.g., \"0.9\" for 90% and \"0.9001353\" for 90.01353%) or clears it when not provided.",
+					Short:     "Sets the vault's minimum annual interest rate (e.g., \"0.9\" for 90% and \"0.9001353\" for 90.01353%) or clears it when not provided.",
 					Example:   fmt.Sprintf("%s update-min-interest-rate %s %s 0.01", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -227,7 +227,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateMaxInterestRate",
 					Use:       "update-max-interest-rate [admin] [vault_address] [max_rate]",
 					Alias:     []string{"umaxir"},
-					Short:     "Sets the vault's maximum APY interest rate (e.g., \"0.9\" for 90% and \"0.9001353\" for 90.01353%) or clears it when not provided.",
+					Short:     "Sets the vault's maximum annual interest rate (e.g., \"0.9\" for 90% and \"0.9001353\" for 90.01353%) or clears it when not provided.",
 					Example:   fmt.Sprintf("%s update-max-interest-rate %s %s 0.1", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},

--- a/module.go
+++ b/module.go
@@ -203,7 +203,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateInterestRate",
 					Use:       "update-interest-rate [admin] [vault_address] [new_rate]",
 					Alias:     []string{"uir"},
-					Short:     "Updates the current APY interest rate (e.g., \"0.9\" for 90%) for the vault.",
+					Short:     "Updates the current APY interest rate (e.g., \"0.9\" for 90% and \"0.038\" for  3.8%) for the vault.",
 					Example:   fmt.Sprintf("%s update-interest-rate %s %s 0.05", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -215,7 +215,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateMinInterestRate",
 					Use:       "update-min-interest-rate [admin] [vault_address] [min_rate]",
 					Alias:     []string{"umir"},
-					Short:     "Sets the vault's minimum APY interest rate (e.g., \"0.9\" for 90%) or clears it when not provided.",
+					Short:     "Sets the vault's minimum APY interest rate (e.g., \"0.9\" for 90% and \"0.038\" for  3.8%)) or clears it when not provided.",
 					Example:   fmt.Sprintf("%s update-min-interest-rate %s %s 0.01", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
@@ -227,7 +227,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateMaxInterestRate",
 					Use:       "update-max-interest-rate [admin] [vault_address] [max_rate]",
 					Alias:     []string{"umaxir"},
-					Short:     "Sets the vault's maximum APY interest rate (e.g., \"0.9\" for 90%) or clears it when not provided.",
+					Short:     "Sets the vault's maximum APY interest rate (e.g., \"0.9\" for 90% and \"0.038\" for  3.8%)) or clears it when not provided.",
 					Example:   fmt.Sprintf("%s update-max-interest-rate %s %s 0.1", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},

--- a/module.go
+++ b/module.go
@@ -24,6 +24,7 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/version"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
@@ -153,6 +154,11 @@ func (m AppModule) RegisterServices(cfg module.Configurator) {
 
 // AutoCLIOptions defines CLI commands for tx and query.
 func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
+	txStart := fmt.Sprintf("%s tx %s", version.AppName, types.ModuleName)
+	queryStart := fmt.Sprintf("%s query %s", version.AppName, types.ModuleName)
+	exampleAdminAddr := "pb1g4s2q6c0a8y9c0s6e1f4h7j9k2l4m6n8p0q2r"
+	exampleVaultAddr := "pb1z3x5c7v9b2n4m6f8h0j1k3l5p7r9s0t2w4y6"
+	exampleOwnerAddr := "pb1a2b3c4d5e6f7g8h9j0k1l2m3n4p5q6r7s8t"
 	return &autocliv1.ModuleOptions{
 		Tx: &autocliv1.ServiceCommandDescriptor{
 			Service: vaultv1.Msg_ServiceDesc.ServiceName,
@@ -162,6 +168,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "create [admin] [underlying_asset] [share_denom]",
 					Alias:     []string{"c", "new"},
 					Short:     "Create a new vault",
+					Example:   fmt.Sprintf("%s create %s nhash svnhash", txStart, exampleAdminAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
 						{ProtoField: "underlying_asset"},
@@ -173,6 +180,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "swap-in [owner] [vault_address] [assets]",
 					Alias:     []string{"si"},
 					Short:     "Deposit underlying assets into a vault to mint shares",
+					Example:   fmt.Sprintf("%s swap-in %s %s 1000nhash", txStart, exampleOwnerAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "owner"},
 						{ProtoField: "vault_address"},
@@ -184,6 +192,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "swap-out [owner] [vault_address] [assets]",
 					Alias:     []string{"so"},
 					Short:     "Withdraw underlying assets from a vault by burning shares",
+					Example:   fmt.Sprintf("%s swap-out %s %s 100svnhash", txStart, exampleOwnerAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "owner"},
 						{ProtoField: "vault_address"},
@@ -195,6 +204,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "update-interest-rate [admin] [vault_address] [new_rate]",
 					Alias:     []string{"uir"},
 					Short:     "Update the current interest rate for a vault",
+					Example:   fmt.Sprintf("%s update-interest-rate %s %s 0.05", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
 						{ProtoField: "vault_address"},
@@ -206,6 +216,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "update-min-interest-rate [admin] [vault_address] [min_rate]",
 					Alias:     []string{"umir"},
 					Short:     "Set or clear the minimum allowable interest rate for a vault. For example, an interest rate of 90% must be entered as '0.9'.",
+					Example:   fmt.Sprintf("%s update-min-interest-rate %s %s 0.01", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
 						{ProtoField: "vault_address"},
@@ -217,6 +228,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "update-max-interest-rate [admin] [vault_address] [max_rate]",
 					Alias:     []string{"umaxir"},
 					Short:     "Set or clear the maximum allowable interest rate for a vault",
+					Example:   fmt.Sprintf("%s update-max-interest-rate %s %s 0.1", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
 						{ProtoField: "vault_address"},
@@ -228,6 +240,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "deposit-interest-funds [admin] [vault_address] [amount]",
 					Alias:     []string{"dif"},
 					Short:     "Deposit funds into a vault for paying interest",
+					Example:   fmt.Sprintf("%s deposit-interest-funds %s %s 5000nhash", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
 						{ProtoField: "vault_address"},
@@ -239,6 +252,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "withdraw-interest-funds [admin] [vault_address] [amount]",
 					Alias:     []string{"wif"},
 					Short:     "Withdraw unused interest funds from a vault",
+					Example:   fmt.Sprintf("%s withdraw-interest-funds %s %s 1000nhash", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
 						{ProtoField: "vault_address"},
@@ -250,6 +264,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "deposit-principal-funds [admin] [vault_address] [amount]",
 					Alias:     []string{"dpf"},
 					Short:     "Deposit principal funds into the vault’s marker",
+					Example:   fmt.Sprintf("%s deposit-principal-funds %s %s 100000nhash", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
 						{ProtoField: "vault_address"},
@@ -261,6 +276,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "withdraw-principal-funds [admin] [vault_address] [amount]",
 					Alias:     []string{"wpf"},
 					Short:     "Withdraw principal funds from the vault’s marker",
+					Example:   fmt.Sprintf("%s withdraw-principal-funds %s %s 10000nhash", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
 						{ProtoField: "vault_address"},
@@ -272,6 +288,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "toggle-swap-in [admin] [vault_address] [enabled]",
 					Alias:     []string{"tsi"},
 					Short:     "Enable or disable swap-in operations for a vault",
+					Example:   fmt.Sprintf("%s toggle-swap-in %s %s false", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
 						{ProtoField: "vault_address"},
@@ -283,6 +300,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "toggle-swap-out [admin] [vault_address] [enabled]",
 					Alias:     []string{"tso"},
 					Short:     "Enable or disable swap-out operations for a vault",
+					Example:   fmt.Sprintf("%s toggle-swap-out %s %s false", txStart, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
 						{ProtoField: "vault_address"},
@@ -300,12 +318,14 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "list",
 					Alias:     []string{"l", "ls"},
 					Short:     "Query all vaults",
+					Example:   fmt.Sprintf("%s list", queryStart),
 				},
 				{
 					RpcMethod: "Vault",
 					Use:       "get [vault_address]",
 					Alias:     []string{"g"},
 					Short:     "Query a specific vault's configuration and state",
+					Example:   fmt.Sprintf("%s get %s", queryStart, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "vault_address"},
 					},
@@ -315,6 +335,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "estimate-swap-in [vault_address] [assets]",
 					Alias:     []string{"esi"},
 					Short:     "Estimate the number of shares received for a given deposit",
+					Example:   fmt.Sprintf("%s estimate-swap-in %s 1000nhash", queryStart, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "vault_address"},
 						{ProtoField: "assets"},
@@ -325,6 +346,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "estimate-swap-out [vault_address] [assets]",
 					Alias:     []string{"eso"},
 					Short:     "Estimate the amount of underlying assets received for a given withdrawal",
+					Example:   fmt.Sprintf("%s estimate-swap-out %s 100svnhash", queryStart, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "vault_address"},
 						{ProtoField: "assets"},

--- a/module.go
+++ b/module.go
@@ -141,8 +141,8 @@ func (m AppModule) BeginBlock(ctx context.Context) error {
 }
 
 // EndBlock returns the end blocker for the vault module.
-func (a AppModule) EndBlock(ctx context.Context) error {
-	return a.keeper.EndBlocker(ctx)
+func (m AppModule) EndBlock(ctx context.Context) error {
+	return m.keeper.EndBlocker(ctx)
 }
 
 // RegisterServices registers gRPC query and message services.
@@ -205,7 +205,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateMinInterestRate",
 					Use:       "update-min-interest-rate [admin] [vault_address] [min_rate]",
 					Alias:     []string{"umir"},
-					Short:     "Set or clear the minimum allowable interest rate for a vault",
+					Short:     "Set or clear the minimum allowable interest rate for a vault. For example, an interest rate of 90% must be entered as '0.9'.",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
 						{ProtoField: "vault_address"},

--- a/proto/vault/v1/events.proto
+++ b/proto/vault/v1/events.proto
@@ -81,7 +81,7 @@ message EventVaultReconcile {
   cosmos.base.v1beta1.Coin principal_before = 2 [(gogoproto.nullable) = false];
   // principal_after is the principal amount after applying interest.
   cosmos.base.v1beta1.Coin principal_after = 3 [(gogoproto.nullable) = false];
-  // rate is a decimal string (e.g., "0.9" for 90%) representing interest rate (APY) for the period.
+  // rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing interest rate (APY) for the period.
   string rate = 4;
   // time is the payout duration in seconds.
   int64 time = 5;
@@ -93,9 +93,9 @@ message EventVaultReconcile {
 message EventVaultInterestChange {
   // vault_address is the bech32 address of the vault.
   string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // current_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate (APY) the vault is using.
+  // current_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the actual interest rate (APY) the vault is using.
   string current_rate = 2;
-  // desired_rate is a decimal string (e.g., "0.9" for 90%) representing the the interest rate (APY) the admin wants to use.
+  // desired_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the the interest rate (APY) the admin wants to use.
   string desired_rate = 3;
 }
 
@@ -165,7 +165,7 @@ message EventMinInterestRateUpdated {
   string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // admin is the address of the account that updated the limit.
   string admin = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90%).
+  // min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
   // An empty string "" represents no minimum.
   string min_rate = 3;
 }
@@ -176,7 +176,7 @@ message EventMaxInterestRateUpdated {
   string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // admin is the address of the account that updated the limit.
   string admin = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90%).
+  // max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
   // An empty string "" represents no maximum.
   string max_rate = 3;
 }

--- a/proto/vault/v1/events.proto
+++ b/proto/vault/v1/events.proto
@@ -81,7 +81,7 @@ message EventVaultReconcile {
   cosmos.base.v1beta1.Coin principal_before = 2 [(gogoproto.nullable) = false];
   // principal_after is the principal amount after applying interest.
   cosmos.base.v1beta1.Coin principal_after = 3 [(gogoproto.nullable) = false];
-  // rate is the interest rate for the period.
+  // rate is a decimal string (e.g., "0.9" for 90%) representing interest rate for the period.
   string rate = 4;
   // time is the payout duration in seconds.
   int64 time = 5;
@@ -93,9 +93,9 @@ message EventVaultReconcile {
 message EventVaultInterestChange {
   // vault_address is the bech32 address of the vault.
   string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // current_rate is the interest rate actual rate the vault is using.
+  // current_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate the vault is using.
   string current_rate = 2;
-  // desired_rate is the interest rate the admin wants to use.
+  // desired_rate is a decimal string (e.g., "0.9" for 90%) representing the the interest rate the admin wants to use.
   string desired_rate = 3;
 }
 
@@ -165,7 +165,8 @@ message EventMinInterestRateUpdated {
   string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // admin is the address of the account that updated the limit.
   string admin = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // min_rate is the newly set minimum interest rate (as string, can be "").
+  // min_rate is the newly set minimum interest rate as a decimal string (e.g., "0.9" for 90%).
+  // An empty string "" represents no minimum.
   string min_rate = 3;
 }
 
@@ -175,6 +176,7 @@ message EventMaxInterestRateUpdated {
   string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // admin is the address of the account that updated the limit.
   string admin = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // max_rate is the newly set maximum interest rate (as string, can be "").
+  // max_rate is the newly set maximum interest rate as a decimal string (e.g., "0.9" for 90%).
+  // An empty string "" represents no maximum.
   string max_rate = 3;
 }

--- a/proto/vault/v1/events.proto
+++ b/proto/vault/v1/events.proto
@@ -81,7 +81,7 @@ message EventVaultReconcile {
   cosmos.base.v1beta1.Coin principal_before = 2 [(gogoproto.nullable) = false];
   // principal_after is the principal amount after applying interest.
   cosmos.base.v1beta1.Coin principal_after = 3 [(gogoproto.nullable) = false];
-  // rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing interest rate (APY) for the period.
+  // rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing annual interest rate for the period.
   string rate = 4;
   // time is the payout duration in seconds.
   int64 time = 5;
@@ -93,9 +93,9 @@ message EventVaultReconcile {
 message EventVaultInterestChange {
   // vault_address is the bech32 address of the vault.
   string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // current_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual interest rate (APY) the vault is using.
+  // current_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual annual interest rate the vault is using.
   string current_rate = 2;
-  // desired_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the the interest rate (APY) the admin wants to use.
+  // desired_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the the annual interest rate the admin wants to use.
   string desired_rate = 3;
 }
 
@@ -165,7 +165,7 @@ message EventMinInterestRateUpdated {
   string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // admin is the address of the account that updated the limit.
   string admin = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
+  // min_rate is the newly set minimum annual interest rate as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
   // An empty string "" represents no minimum.
   string min_rate = 3;
 }
@@ -176,7 +176,7 @@ message EventMaxInterestRateUpdated {
   string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // admin is the address of the account that updated the limit.
   string admin = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
+  // max_rate is the newly set maximum annual interest rate as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
   // An empty string "" represents no maximum.
   string max_rate = 3;
 }

--- a/proto/vault/v1/events.proto
+++ b/proto/vault/v1/events.proto
@@ -81,7 +81,7 @@ message EventVaultReconcile {
   cosmos.base.v1beta1.Coin principal_before = 2 [(gogoproto.nullable) = false];
   // principal_after is the principal amount after applying interest.
   cosmos.base.v1beta1.Coin principal_after = 3 [(gogoproto.nullable) = false];
-  // rate is a decimal string (e.g., "0.9" for 90%) representing interest rate for the period.
+  // rate is a decimal string (e.g., "0.9" for 90%) representing interest rate (APY) for the period.
   string rate = 4;
   // time is the payout duration in seconds.
   int64 time = 5;
@@ -93,9 +93,9 @@ message EventVaultReconcile {
 message EventVaultInterestChange {
   // vault_address is the bech32 address of the vault.
   string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // current_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate the vault is using.
+  // current_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate (APY) the vault is using.
   string current_rate = 2;
-  // desired_rate is a decimal string (e.g., "0.9" for 90%) representing the the interest rate the admin wants to use.
+  // desired_rate is a decimal string (e.g., "0.9" for 90%) representing the the interest rate (APY) the admin wants to use.
   string desired_rate = 3;
 }
 
@@ -165,7 +165,7 @@ message EventMinInterestRateUpdated {
   string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // admin is the address of the account that updated the limit.
   string admin = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // min_rate is the newly set minimum interest rate as a decimal string (e.g., "0.9" for 90%).
+  // min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90%).
   // An empty string "" represents no minimum.
   string min_rate = 3;
 }
@@ -176,7 +176,7 @@ message EventMaxInterestRateUpdated {
   string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // admin is the address of the account that updated the limit.
   string admin = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // max_rate is the newly set maximum interest rate as a decimal string (e.g., "0.9" for 90%).
+  // max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90%).
   // An empty string "" represents no maximum.
   string max_rate = 3;
 }

--- a/proto/vault/v1/events.proto
+++ b/proto/vault/v1/events.proto
@@ -81,7 +81,7 @@ message EventVaultReconcile {
   cosmos.base.v1beta1.Coin principal_before = 2 [(gogoproto.nullable) = false];
   // principal_after is the principal amount after applying interest.
   cosmos.base.v1beta1.Coin principal_after = 3 [(gogoproto.nullable) = false];
-  // rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing interest rate (APY) for the period.
+  // rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing interest rate (APY) for the period.
   string rate = 4;
   // time is the payout duration in seconds.
   int64 time = 5;
@@ -93,9 +93,9 @@ message EventVaultReconcile {
 message EventVaultInterestChange {
   // vault_address is the bech32 address of the vault.
   string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // current_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the actual interest rate (APY) the vault is using.
+  // current_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual interest rate (APY) the vault is using.
   string current_rate = 2;
-  // desired_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the the interest rate (APY) the admin wants to use.
+  // desired_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the the interest rate (APY) the admin wants to use.
   string desired_rate = 3;
 }
 
@@ -165,7 +165,7 @@ message EventMinInterestRateUpdated {
   string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // admin is the address of the account that updated the limit.
   string admin = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
+  // min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
   // An empty string "" represents no minimum.
   string min_rate = 3;
 }
@@ -176,7 +176,7 @@ message EventMaxInterestRateUpdated {
   string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // admin is the address of the account that updated the limit.
   string admin = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
+  // max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
   // An empty string "" represents no maximum.
   string max_rate = 3;
 }

--- a/proto/vault/v1/tx.proto
+++ b/proto/vault/v1/tx.proto
@@ -21,13 +21,13 @@ service Msg {
   // SwapOut exchanges vault shares for underlying assets by withdrawing from a vault.
   rpc SwapOut(MsgSwapOutRequest) returns (MsgSwapOutResponse);
 
-  // UpdateMinInterestRate sets the minimum allowed interest rate (APY) for a vault.
+  // UpdateMinInterestRate sets the minimum allowed annual interest rate for a vault.
   rpc UpdateMinInterestRate(MsgUpdateMinInterestRateRequest) returns (MsgUpdateMinInterestRateResponse);
 
-  // UpdateMaxInterestRate sets the maximum allowed interest rate (APY) for a vault.
+  // UpdateMaxInterestRate sets the maximum allowed annual interest rate for a vault.
   rpc UpdateMaxInterestRate(MsgUpdateMaxInterestRateRequest) returns (MsgUpdateMaxInterestRateResponse);
 
-  // UpdateInterestRate allows the interest admin to update the current interest rate (APY) within limits.
+  // UpdateInterestRate allows the interest admin to update the current annual interest rate within limits.
   rpc UpdateInterestRate(MsgUpdateInterestRateRequest) returns (MsgUpdateInterestRateResponse);
 
   // DepositInterestFunds allows depositing funds into the vault for paying interest.
@@ -123,14 +123,14 @@ message MsgUpdateMaxInterestRateRequest {
   string admin = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // The bech32 address of the vault whose maximum interest rate is being updated.
   string vault_address = 2;
-  // max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
+  // max_rate is the maximum allowable annual interest rate for the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
   // An empty string "" represents no maximum.
   string max_rate = 3;
 }
 
 message MsgUpdateMaxInterestRateResponse {}
 
-// MsgUpdateInterestRateRequest is the request message for updating the interest rate (APY) of a vault.
+// MsgUpdateInterestRateRequest is the request message for updating the annual interest rate of a vault.
 message MsgUpdateInterestRateRequest {
   option (cosmos.msg.v1.signer) = "admin";
 
@@ -138,7 +138,7 @@ message MsgUpdateInterestRateRequest {
   string admin = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // vault_address is the bech32 address of the vault.
   string vault_address = 2;
-  // new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
+  // new_rate is the new annual interest rate for the the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
   string new_rate = 3;
 }
 

--- a/proto/vault/v1/tx.proto
+++ b/proto/vault/v1/tx.proto
@@ -110,8 +110,8 @@ message MsgUpdateMinInterestRateRequest {
   string admin = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // The bech32 address of the vault whose minimum interest rate is being updated.
   string vault_address = 2;
-  // The minimum allowable interest rate for the vault.
-  // Provide an empty string ("") to disable the minimum interest rate limit.
+  // min_rate is the minimum allowable interest rate for the vault as a decimal string (e.g., "0.9" for 90%).
+  // An empty string "" represents no minimum.
   string min_rate = 3;
 }
 
@@ -123,8 +123,8 @@ message MsgUpdateMaxInterestRateRequest {
   string admin = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // The bech32 address of the vault whose maximum interest rate is being updated.
   string vault_address = 2;
-  // The maximum allowable interest rate for the vault.
-  // Provide an empty string ("") to disable the maximum interest rate limit.
+  // max_rate is the maximum allowable interest rate for the vault as a decimal string (e.g., "0.9" for 90%).
+  // An empty string "" represents no maximum.
   string max_rate = 3;
 }
 
@@ -138,7 +138,7 @@ message MsgUpdateInterestRateRequest {
   string admin = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // vault_address is the bech32 address of the vault.
   string vault_address = 2;
-  // new_rate is the new interest rate for the vault, expressed as an APY string (e.g., "-5.00" for -5%).
+  // new_rate is the new interest rate for the the vault as a decimal string (e.g., "0.9" for 90%).
   string new_rate = 3;
 }
 

--- a/proto/vault/v1/tx.proto
+++ b/proto/vault/v1/tx.proto
@@ -110,7 +110,7 @@ message MsgUpdateMinInterestRateRequest {
   string admin = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // The bech32 address of the vault whose minimum interest rate is being updated.
   string vault_address = 2;
-  // min_rate is the minimum allowable interest rate(APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
+  // min_rate is the minimum allowable interest rate(APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
   // An empty string "" represents no minimum.
   string min_rate = 3;
 }
@@ -123,7 +123,7 @@ message MsgUpdateMaxInterestRateRequest {
   string admin = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // The bech32 address of the vault whose maximum interest rate is being updated.
   string vault_address = 2;
-  // max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
+  // max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
   // An empty string "" represents no maximum.
   string max_rate = 3;
 }
@@ -138,7 +138,7 @@ message MsgUpdateInterestRateRequest {
   string admin = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // vault_address is the bech32 address of the vault.
   string vault_address = 2;
-  // new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
+  // new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
   string new_rate = 3;
 }
 

--- a/proto/vault/v1/tx.proto
+++ b/proto/vault/v1/tx.proto
@@ -21,13 +21,13 @@ service Msg {
   // SwapOut exchanges vault shares for underlying assets by withdrawing from a vault.
   rpc SwapOut(MsgSwapOutRequest) returns (MsgSwapOutResponse);
 
-  // UpdateMinInterestRate sets the minimum allowed interest rate for a vault.
+  // UpdateMinInterestRate sets the minimum allowed interest rate (APY) for a vault.
   rpc UpdateMinInterestRate(MsgUpdateMinInterestRateRequest) returns (MsgUpdateMinInterestRateResponse);
 
-  // UpdateMaxInterestRate sets the maximum allowed interest rate for a vault.
+  // UpdateMaxInterestRate sets the maximum allowed interest rate (APY) for a vault.
   rpc UpdateMaxInterestRate(MsgUpdateMaxInterestRateRequest) returns (MsgUpdateMaxInterestRateResponse);
 
-  // UpdateInterestRate allows the interest admin to update the current interest rate within limits.
+  // UpdateInterestRate allows the interest admin to update the current interest rate (APY) within limits.
   rpc UpdateInterestRate(MsgUpdateInterestRateRequest) returns (MsgUpdateInterestRateResponse);
 
   // DepositInterestFunds allows depositing funds into the vault for paying interest.
@@ -110,7 +110,7 @@ message MsgUpdateMinInterestRateRequest {
   string admin = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // The bech32 address of the vault whose minimum interest rate is being updated.
   string vault_address = 2;
-  // min_rate is the minimum allowable interest rate for the vault as a decimal string (e.g., "0.9" for 90%).
+  // min_rate is the minimum allowable interest rate(APY) for the vault as a decimal string (e.g., "0.9" for 90%).
   // An empty string "" represents no minimum.
   string min_rate = 3;
 }
@@ -123,14 +123,14 @@ message MsgUpdateMaxInterestRateRequest {
   string admin = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // The bech32 address of the vault whose maximum interest rate is being updated.
   string vault_address = 2;
-  // max_rate is the maximum allowable interest rate for the vault as a decimal string (e.g., "0.9" for 90%).
+  // max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90%).
   // An empty string "" represents no maximum.
   string max_rate = 3;
 }
 
 message MsgUpdateMaxInterestRateResponse {}
 
-// MsgUpdateInterestRateRequest is the request message for updating the interest rate of a vault.
+// MsgUpdateInterestRateRequest is the request message for updating the interest rate (APY) of a vault.
 message MsgUpdateInterestRateRequest {
   option (cosmos.msg.v1.signer) = "admin";
 
@@ -138,7 +138,7 @@ message MsgUpdateInterestRateRequest {
   string admin = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // vault_address is the bech32 address of the vault.
   string vault_address = 2;
-  // new_rate is the new interest rate for the the vault as a decimal string (e.g., "0.9" for 90%).
+  // new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90%).
   string new_rate = 3;
 }
 

--- a/proto/vault/v1/tx.proto
+++ b/proto/vault/v1/tx.proto
@@ -110,7 +110,7 @@ message MsgUpdateMinInterestRateRequest {
   string admin = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // The bech32 address of the vault whose minimum interest rate is being updated.
   string vault_address = 2;
-  // min_rate is the minimum allowable interest rate(APY) for the vault as a decimal string (e.g., "0.9" for 90%).
+  // min_rate is the minimum allowable interest rate(APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
   // An empty string "" represents no minimum.
   string min_rate = 3;
 }
@@ -123,7 +123,7 @@ message MsgUpdateMaxInterestRateRequest {
   string admin = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // The bech32 address of the vault whose maximum interest rate is being updated.
   string vault_address = 2;
-  // max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90%).
+  // max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
   // An empty string "" represents no maximum.
   string max_rate = 3;
 }
@@ -138,7 +138,7 @@ message MsgUpdateInterestRateRequest {
   string admin = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // vault_address is the bech32 address of the vault.
   string vault_address = 2;
-  // new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90%).
+  // new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
   string new_rate = 3;
 }
 

--- a/proto/vault/v1/vault.proto
+++ b/proto/vault/v1/vault.proto
@@ -18,15 +18,15 @@ message VaultAccount {
   repeated string underlying_assets = 3;
   // admin is the address that has administrative privileges over the vault.
   string admin = 4 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // current_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate (APY) currently being applied.
+  // current_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the actual interest rate (APY) currently being applied.
   // This may be adjusted programmatically (e.g., due to lack of funds).
   string current_interest_rate = 5 [(cosmos_proto.scalar) = "cosmos.DecString"];
-  // desired_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the target interest rate (APY) that the vault intends to apply.
+  // desired_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the target interest rate (APY) that the vault intends to apply.
   string desired_interest_rate = 6 [(cosmos_proto.scalar) = "cosmos.DecString"];
-  // min_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the lowest interest rate (APY) the admin is allowed to set.
+  // min_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the lowest interest rate (APY) the admin is allowed to set.
   // If unset (empty string), there is no lower limit.
   string min_interest_rate = 7 [(cosmos_proto.scalar) = "cosmos.DecString"];
-  // max_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the highest interest rate (APY) the admin is allowed to set.
+  // max_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the highest interest rate (APY) the admin is allowed to set.
   // If unset (empty string), there is no upper limit.
   string max_interest_rate = 8 [(cosmos_proto.scalar) = "cosmos.DecString"];
   // swap_in_enabled indicates whether users are allowed to deposit into the vault.

--- a/proto/vault/v1/vault.proto
+++ b/proto/vault/v1/vault.proto
@@ -18,15 +18,15 @@ message VaultAccount {
   repeated string underlying_assets = 3;
   // admin is the address that has administrative privileges over the vault.
   string admin = 4 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // current_interest_rate is the actual interest rate currently being applied.
+  // current_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate currently being applied.
   // This may be adjusted programmatically (e.g., due to lack of funds).
   string current_interest_rate = 5 [(cosmos_proto.scalar) = "cosmos.DecString"];
-  // desired_interest_rate is the target interest rate that the vault intends to apply.
+  // desired_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the target interest rate that the vault intends to apply.
   string desired_interest_rate = 6 [(cosmos_proto.scalar) = "cosmos.DecString"];
-  // min_interest_rate is the lowest interest rate the admin is allowed to set.
+  // min_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the lowest interest rate the admin is allowed to set.
   // If unset (empty string), there is no lower limit.
   string min_interest_rate = 7 [(cosmos_proto.scalar) = "cosmos.DecString"];
-  // max_interest_rate is the highest interest rate the admin is allowed to set.
+  // max_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the highest interest rate the admin is allowed to set.
   // If unset (empty string), there is no upper limit.
   string max_interest_rate = 8 [(cosmos_proto.scalar) = "cosmos.DecString"];
   // swap_in_enabled indicates whether users are allowed to deposit into the vault.

--- a/proto/vault/v1/vault.proto
+++ b/proto/vault/v1/vault.proto
@@ -18,15 +18,15 @@ message VaultAccount {
   repeated string underlying_assets = 3;
   // admin is the address that has administrative privileges over the vault.
   string admin = 4 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // current_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual interest rate (APY) currently being applied.
+  // current_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual annual interest rate currently being applied.
   // This may be adjusted programmatically (e.g., due to lack of funds).
   string current_interest_rate = 5 [(cosmos_proto.scalar) = "cosmos.DecString"];
-  // desired_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the target interest rate (APY) that the vault intends to apply.
+  // desired_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the target annual interest rate that the vault intends to apply.
   string desired_interest_rate = 6 [(cosmos_proto.scalar) = "cosmos.DecString"];
-  // min_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the lowest interest rate (APY) the admin is allowed to set.
+  // min_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the lowest annual interest rate the admin is allowed to set.
   // If unset (empty string), there is no lower limit.
   string min_interest_rate = 7 [(cosmos_proto.scalar) = "cosmos.DecString"];
-  // max_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the highest interest rate (APY) the admin is allowed to set.
+  // max_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the highest annual interest rate the admin is allowed to set.
   // If unset (empty string), there is no upper limit.
   string max_interest_rate = 8 [(cosmos_proto.scalar) = "cosmos.DecString"];
   // swap_in_enabled indicates whether users are allowed to deposit into the vault.

--- a/proto/vault/v1/vault.proto
+++ b/proto/vault/v1/vault.proto
@@ -18,15 +18,15 @@ message VaultAccount {
   repeated string underlying_assets = 3;
   // admin is the address that has administrative privileges over the vault.
   string admin = 4 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // current_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the actual interest rate (APY) currently being applied.
+  // current_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual interest rate (APY) currently being applied.
   // This may be adjusted programmatically (e.g., due to lack of funds).
   string current_interest_rate = 5 [(cosmos_proto.scalar) = "cosmos.DecString"];
-  // desired_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the target interest rate (APY) that the vault intends to apply.
+  // desired_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the target interest rate (APY) that the vault intends to apply.
   string desired_interest_rate = 6 [(cosmos_proto.scalar) = "cosmos.DecString"];
-  // min_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the lowest interest rate (APY) the admin is allowed to set.
+  // min_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the lowest interest rate (APY) the admin is allowed to set.
   // If unset (empty string), there is no lower limit.
   string min_interest_rate = 7 [(cosmos_proto.scalar) = "cosmos.DecString"];
-  // max_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the highest interest rate (APY) the admin is allowed to set.
+  // max_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the highest interest rate (APY) the admin is allowed to set.
   // If unset (empty string), there is no upper limit.
   string max_interest_rate = 8 [(cosmos_proto.scalar) = "cosmos.DecString"];
   // swap_in_enabled indicates whether users are allowed to deposit into the vault.

--- a/proto/vault/v1/vault.proto
+++ b/proto/vault/v1/vault.proto
@@ -18,15 +18,15 @@ message VaultAccount {
   repeated string underlying_assets = 3;
   // admin is the address that has administrative privileges over the vault.
   string admin = 4 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // current_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate currently being applied.
+  // current_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate (APY) currently being applied.
   // This may be adjusted programmatically (e.g., due to lack of funds).
   string current_interest_rate = 5 [(cosmos_proto.scalar) = "cosmos.DecString"];
-  // desired_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the target interest rate that the vault intends to apply.
+  // desired_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the target interest rate (APY) that the vault intends to apply.
   string desired_interest_rate = 6 [(cosmos_proto.scalar) = "cosmos.DecString"];
-  // min_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the lowest interest rate the admin is allowed to set.
+  // min_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the lowest interest rate (APY) the admin is allowed to set.
   // If unset (empty string), there is no lower limit.
   string min_interest_rate = 7 [(cosmos_proto.scalar) = "cosmos.DecString"];
-  // max_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the highest interest rate the admin is allowed to set.
+  // max_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the highest interest rate (APY) the admin is allowed to set.
   // If unset (empty string), there is no upper limit.
   string max_interest_rate = 8 [(cosmos_proto.scalar) = "cosmos.DecString"];
   // swap_in_enabled indicates whether users are allowed to deposit into the vault.

--- a/types/events.pb.go
+++ b/types/events.pb.go
@@ -425,7 +425,7 @@ type EventVaultReconcile struct {
 	PrincipalBefore types.Coin `protobuf:"bytes,2,opt,name=principal_before,json=principalBefore,proto3" json:"principal_before"`
 	// principal_after is the principal amount after applying interest.
 	PrincipalAfter types.Coin `protobuf:"bytes,3,opt,name=principal_after,json=principalAfter,proto3" json:"principal_after"`
-	// rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing interest rate (APY) for the period.
+	// rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing annual interest rate for the period.
 	Rate string `protobuf:"bytes,4,opt,name=rate,proto3" json:"rate,omitempty"`
 	// time is the payout duration in seconds.
 	Time int64 `protobuf:"varint,5,opt,name=time,proto3" json:"time,omitempty"`
@@ -512,9 +512,9 @@ func (m *EventVaultReconcile) GetInterestEarned() types.Coin {
 type EventVaultInterestChange struct {
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// current_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual interest rate (APY) the vault is using.
+	// current_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual annual interest rate the vault is using.
 	CurrentRate string `protobuf:"bytes,2,opt,name=current_rate,json=currentRate,proto3" json:"current_rate,omitempty"`
-	// desired_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the the interest rate (APY) the admin wants to use.
+	// desired_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the the annual interest rate the admin wants to use.
 	DesiredRate string `protobuf:"bytes,3,opt,name=desired_rate,json=desiredRate,proto3" json:"desired_rate,omitempty"`
 }
 
@@ -962,7 +962,7 @@ type EventMinInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
+	// min_rate is the newly set minimum annual interest rate as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
@@ -1027,7 +1027,7 @@ type EventMaxInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
+	// max_rate is the newly set maximum annual interest rate as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }

--- a/types/events.pb.go
+++ b/types/events.pb.go
@@ -425,7 +425,7 @@ type EventVaultReconcile struct {
 	PrincipalBefore types.Coin `protobuf:"bytes,2,opt,name=principal_before,json=principalBefore,proto3" json:"principal_before"`
 	// principal_after is the principal amount after applying interest.
 	PrincipalAfter types.Coin `protobuf:"bytes,3,opt,name=principal_after,json=principalAfter,proto3" json:"principal_after"`
-	// rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing interest rate (APY) for the period.
+	// rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing interest rate (APY) for the period.
 	Rate string `protobuf:"bytes,4,opt,name=rate,proto3" json:"rate,omitempty"`
 	// time is the payout duration in seconds.
 	Time int64 `protobuf:"varint,5,opt,name=time,proto3" json:"time,omitempty"`
@@ -512,9 +512,9 @@ func (m *EventVaultReconcile) GetInterestEarned() types.Coin {
 type EventVaultInterestChange struct {
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// current_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the actual interest rate (APY) the vault is using.
+	// current_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual interest rate (APY) the vault is using.
 	CurrentRate string `protobuf:"bytes,2,opt,name=current_rate,json=currentRate,proto3" json:"current_rate,omitempty"`
-	// desired_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the the interest rate (APY) the admin wants to use.
+	// desired_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the the interest rate (APY) the admin wants to use.
 	DesiredRate string `protobuf:"bytes,3,opt,name=desired_rate,json=desiredRate,proto3" json:"desired_rate,omitempty"`
 }
 
@@ -962,7 +962,7 @@ type EventMinInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
+	// min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
@@ -1027,7 +1027,7 @@ type EventMaxInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
+	// max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }

--- a/types/events.pb.go
+++ b/types/events.pb.go
@@ -425,7 +425,7 @@ type EventVaultReconcile struct {
 	PrincipalBefore types.Coin `protobuf:"bytes,2,opt,name=principal_before,json=principalBefore,proto3" json:"principal_before"`
 	// principal_after is the principal amount after applying interest.
 	PrincipalAfter types.Coin `protobuf:"bytes,3,opt,name=principal_after,json=principalAfter,proto3" json:"principal_after"`
-	// rate is a decimal string (e.g., "0.9" for 90%) representing interest rate (APY) for the period.
+	// rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing interest rate (APY) for the period.
 	Rate string `protobuf:"bytes,4,opt,name=rate,proto3" json:"rate,omitempty"`
 	// time is the payout duration in seconds.
 	Time int64 `protobuf:"varint,5,opt,name=time,proto3" json:"time,omitempty"`
@@ -512,9 +512,9 @@ func (m *EventVaultReconcile) GetInterestEarned() types.Coin {
 type EventVaultInterestChange struct {
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// current_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate (APY) the vault is using.
+	// current_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the actual interest rate (APY) the vault is using.
 	CurrentRate string `protobuf:"bytes,2,opt,name=current_rate,json=currentRate,proto3" json:"current_rate,omitempty"`
-	// desired_rate is a decimal string (e.g., "0.9" for 90%) representing the the interest rate (APY) the admin wants to use.
+	// desired_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the the interest rate (APY) the admin wants to use.
 	DesiredRate string `protobuf:"bytes,3,opt,name=desired_rate,json=desiredRate,proto3" json:"desired_rate,omitempty"`
 }
 
@@ -962,7 +962,7 @@ type EventMinInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90%).
+	// min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
 	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
@@ -1027,7 +1027,7 @@ type EventMaxInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90%).
+	// max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }

--- a/types/events.pb.go
+++ b/types/events.pb.go
@@ -425,7 +425,7 @@ type EventVaultReconcile struct {
 	PrincipalBefore types.Coin `protobuf:"bytes,2,opt,name=principal_before,json=principalBefore,proto3" json:"principal_before"`
 	// principal_after is the principal amount after applying interest.
 	PrincipalAfter types.Coin `protobuf:"bytes,3,opt,name=principal_after,json=principalAfter,proto3" json:"principal_after"`
-	// rate is the interest rate for the period.
+	// rate is a decimal string (e.g., "0.9" for 90%) representing interest rate for the period.
 	Rate string `protobuf:"bytes,4,opt,name=rate,proto3" json:"rate,omitempty"`
 	// time is the payout duration in seconds.
 	Time int64 `protobuf:"varint,5,opt,name=time,proto3" json:"time,omitempty"`
@@ -512,9 +512,9 @@ func (m *EventVaultReconcile) GetInterestEarned() types.Coin {
 type EventVaultInterestChange struct {
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// current_rate is the interest rate actual rate the vault is using.
+	// current_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate the vault is using.
 	CurrentRate string `protobuf:"bytes,2,opt,name=current_rate,json=currentRate,proto3" json:"current_rate,omitempty"`
-	// desired_rate is the interest rate the admin wants to use.
+	// desired_rate is a decimal string (e.g., "0.9" for 90%) representing the the interest rate the admin wants to use.
 	DesiredRate string `protobuf:"bytes,3,opt,name=desired_rate,json=desiredRate,proto3" json:"desired_rate,omitempty"`
 }
 
@@ -962,7 +962,8 @@ type EventMinInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// min_rate is the newly set minimum interest rate (as string, can be "").
+	// min_rate is the newly set minimum interest rate as a decimal string (e.g., "0.9" for 90%).
+	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
 
@@ -1026,7 +1027,8 @@ type EventMaxInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// max_rate is the newly set maximum interest rate (as string, can be "").
+	// max_rate is the newly set maximum interest rate as a decimal string (e.g., "0.9" for 90%).
+	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }
 

--- a/types/events.pb.go
+++ b/types/events.pb.go
@@ -425,7 +425,7 @@ type EventVaultReconcile struct {
 	PrincipalBefore types.Coin `protobuf:"bytes,2,opt,name=principal_before,json=principalBefore,proto3" json:"principal_before"`
 	// principal_after is the principal amount after applying interest.
 	PrincipalAfter types.Coin `protobuf:"bytes,3,opt,name=principal_after,json=principalAfter,proto3" json:"principal_after"`
-	// rate is a decimal string (e.g., "0.9" for 90%) representing interest rate for the period.
+	// rate is a decimal string (e.g., "0.9" for 90%) representing interest rate (APY) for the period.
 	Rate string `protobuf:"bytes,4,opt,name=rate,proto3" json:"rate,omitempty"`
 	// time is the payout duration in seconds.
 	Time int64 `protobuf:"varint,5,opt,name=time,proto3" json:"time,omitempty"`
@@ -512,9 +512,9 @@ func (m *EventVaultReconcile) GetInterestEarned() types.Coin {
 type EventVaultInterestChange struct {
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// current_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate the vault is using.
+	// current_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate (APY) the vault is using.
 	CurrentRate string `protobuf:"bytes,2,opt,name=current_rate,json=currentRate,proto3" json:"current_rate,omitempty"`
-	// desired_rate is a decimal string (e.g., "0.9" for 90%) representing the the interest rate the admin wants to use.
+	// desired_rate is a decimal string (e.g., "0.9" for 90%) representing the the interest rate (APY) the admin wants to use.
 	DesiredRate string `protobuf:"bytes,3,opt,name=desired_rate,json=desiredRate,proto3" json:"desired_rate,omitempty"`
 }
 
@@ -962,7 +962,7 @@ type EventMinInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// min_rate is the newly set minimum interest rate as a decimal string (e.g., "0.9" for 90%).
+	// min_rate is the newly set minimum interest rate (APY) as a decimal string (e.g., "0.9" for 90%).
 	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
@@ -1027,7 +1027,7 @@ type EventMaxInterestRateUpdated struct {
 	VaultAddress string `protobuf:"bytes,1,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
 	// admin is the address of the account that updated the limit.
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`
-	// max_rate is the newly set maximum interest rate as a decimal string (e.g., "0.9" for 90%).
+	// max_rate is the newly set maximum interest rate (APY) as a decimal string (e.g., "0.9" for 90%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }

--- a/types/tx.pb.go
+++ b/types/tx.pb.go
@@ -366,7 +366,7 @@ type MsgUpdateMinInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose minimum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// min_rate is the minimum allowable interest rate for the vault as a decimal string (e.g., "0.9" for 90%).
+	// min_rate is the minimum allowable interest rate(APY) for the vault as a decimal string (e.g., "0.9" for 90%).
 	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
@@ -466,7 +466,7 @@ type MsgUpdateMaxInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose maximum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// max_rate is the maximum allowable interest rate for the vault as a decimal string (e.g., "0.9" for 90%).
+	// max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }
@@ -561,13 +561,13 @@ func (m *MsgUpdateMaxInterestRateResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgUpdateMaxInterestRateResponse proto.InternalMessageInfo
 
-// MsgUpdateInterestRateRequest is the request message for updating the interest rate of a vault.
+// MsgUpdateInterestRateRequest is the request message for updating the interest rate (APY) of a vault.
 type MsgUpdateInterestRateRequest struct {
 	// admin is the address of the vault administrator.
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// new_rate is the new interest rate for the the vault as a decimal string (e.g., "0.9" for 90%).
+	// new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90%).
 	NewRate string `protobuf:"bytes,3,opt,name=new_rate,json=newRate,proto3" json:"new_rate,omitempty"`
 }
 
@@ -1378,11 +1378,11 @@ type MsgClient interface {
 	SwapIn(ctx context.Context, in *MsgSwapInRequest, opts ...grpc.CallOption) (*MsgSwapInResponse, error)
 	// SwapOut exchanges vault shares for underlying assets by withdrawing from a vault.
 	SwapOut(ctx context.Context, in *MsgSwapOutRequest, opts ...grpc.CallOption) (*MsgSwapOutResponse, error)
-	// UpdateMinInterestRate sets the minimum allowed interest rate for a vault.
+	// UpdateMinInterestRate sets the minimum allowed interest rate (APY) for a vault.
 	UpdateMinInterestRate(ctx context.Context, in *MsgUpdateMinInterestRateRequest, opts ...grpc.CallOption) (*MsgUpdateMinInterestRateResponse, error)
-	// UpdateMaxInterestRate sets the maximum allowed interest rate for a vault.
+	// UpdateMaxInterestRate sets the maximum allowed interest rate (APY) for a vault.
 	UpdateMaxInterestRate(ctx context.Context, in *MsgUpdateMaxInterestRateRequest, opts ...grpc.CallOption) (*MsgUpdateMaxInterestRateResponse, error)
-	// UpdateInterestRate allows the interest admin to update the current interest rate within limits.
+	// UpdateInterestRate allows the interest admin to update the current interest rate (APY) within limits.
 	UpdateInterestRate(ctx context.Context, in *MsgUpdateInterestRateRequest, opts ...grpc.CallOption) (*MsgUpdateInterestRateResponse, error)
 	// DepositInterestFunds allows depositing funds into the vault for paying interest.
 	DepositInterestFunds(ctx context.Context, in *MsgDepositInterestFundsRequest, opts ...grpc.CallOption) (*MsgDepositInterestFundsResponse, error)
@@ -1522,11 +1522,11 @@ type MsgServer interface {
 	SwapIn(context.Context, *MsgSwapInRequest) (*MsgSwapInResponse, error)
 	// SwapOut exchanges vault shares for underlying assets by withdrawing from a vault.
 	SwapOut(context.Context, *MsgSwapOutRequest) (*MsgSwapOutResponse, error)
-	// UpdateMinInterestRate sets the minimum allowed interest rate for a vault.
+	// UpdateMinInterestRate sets the minimum allowed interest rate (APY) for a vault.
 	UpdateMinInterestRate(context.Context, *MsgUpdateMinInterestRateRequest) (*MsgUpdateMinInterestRateResponse, error)
-	// UpdateMaxInterestRate sets the maximum allowed interest rate for a vault.
+	// UpdateMaxInterestRate sets the maximum allowed interest rate (APY) for a vault.
 	UpdateMaxInterestRate(context.Context, *MsgUpdateMaxInterestRateRequest) (*MsgUpdateMaxInterestRateResponse, error)
-	// UpdateInterestRate allows the interest admin to update the current interest rate within limits.
+	// UpdateInterestRate allows the interest admin to update the current interest rate (APY) within limits.
 	UpdateInterestRate(context.Context, *MsgUpdateInterestRateRequest) (*MsgUpdateInterestRateResponse, error)
 	// DepositInterestFunds allows depositing funds into the vault for paying interest.
 	DepositInterestFunds(context.Context, *MsgDepositInterestFundsRequest) (*MsgDepositInterestFundsResponse, error)

--- a/types/tx.pb.go
+++ b/types/tx.pb.go
@@ -366,7 +366,7 @@ type MsgUpdateMinInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose minimum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// min_rate is the minimum allowable interest rate(APY) for the vault as a decimal string (e.g., "0.9" for 90%).
+	// min_rate is the minimum allowable interest rate(APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
 	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
@@ -466,7 +466,7 @@ type MsgUpdateMaxInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose maximum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90%).
+	// max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }
@@ -567,7 +567,7 @@ type MsgUpdateInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90%).
+	// new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
 	NewRate string `protobuf:"bytes,3,opt,name=new_rate,json=newRate,proto3" json:"new_rate,omitempty"`
 }
 

--- a/types/tx.pb.go
+++ b/types/tx.pb.go
@@ -366,7 +366,7 @@ type MsgUpdateMinInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose minimum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// min_rate is the minimum allowable interest rate(APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
+	// min_rate is the minimum allowable interest rate(APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
@@ -466,7 +466,7 @@ type MsgUpdateMaxInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose maximum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
+	// max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }
@@ -567,7 +567,7 @@ type MsgUpdateInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%).
+	// new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	NewRate string `protobuf:"bytes,3,opt,name=new_rate,json=newRate,proto3" json:"new_rate,omitempty"`
 }
 

--- a/types/tx.pb.go
+++ b/types/tx.pb.go
@@ -366,8 +366,8 @@ type MsgUpdateMinInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose minimum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// The minimum allowable interest rate for the vault.
-	// Provide an empty string ("") to disable the minimum interest rate limit.
+	// min_rate is the minimum allowable interest rate for the vault as a decimal string (e.g., "0.9" for 90%).
+	// An empty string "" represents no minimum.
 	MinRate string `protobuf:"bytes,3,opt,name=min_rate,json=minRate,proto3" json:"min_rate,omitempty"`
 }
 
@@ -466,8 +466,8 @@ type MsgUpdateMaxInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose maximum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// The maximum allowable interest rate for the vault.
-	// Provide an empty string ("") to disable the maximum interest rate limit.
+	// max_rate is the maximum allowable interest rate for the vault as a decimal string (e.g., "0.9" for 90%).
+	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }
 
@@ -567,7 +567,7 @@ type MsgUpdateInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// new_rate is the new interest rate for the vault, expressed as an APY string (e.g., "-5.00" for -5%).
+	// new_rate is the new interest rate for the the vault as a decimal string (e.g., "0.9" for 90%).
 	NewRate string `protobuf:"bytes,3,opt,name=new_rate,json=newRate,proto3" json:"new_rate,omitempty"`
 }
 

--- a/types/tx.pb.go
+++ b/types/tx.pb.go
@@ -466,7 +466,7 @@ type MsgUpdateMaxInterestRateRequest struct {
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// The bech32 address of the vault whose maximum interest rate is being updated.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// max_rate is the maximum allowable interest rate (APY) for the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
+	// max_rate is the maximum allowable annual interest rate for the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	// An empty string "" represents no maximum.
 	MaxRate string `protobuf:"bytes,3,opt,name=max_rate,json=maxRate,proto3" json:"max_rate,omitempty"`
 }
@@ -561,13 +561,13 @@ func (m *MsgUpdateMaxInterestRateResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgUpdateMaxInterestRateResponse proto.InternalMessageInfo
 
-// MsgUpdateInterestRateRequest is the request message for updating the interest rate (APY) of a vault.
+// MsgUpdateInterestRateRequest is the request message for updating the annual interest rate of a vault.
 type MsgUpdateInterestRateRequest struct {
 	// admin is the address of the vault administrator.
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
 	// vault_address is the bech32 address of the vault.
 	VaultAddress string `protobuf:"bytes,2,opt,name=vault_address,json=vaultAddress,proto3" json:"vault_address,omitempty"`
-	// new_rate is the new interest rate (APY) for the the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
+	// new_rate is the new annual interest rate for the the vault as a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%).
 	NewRate string `protobuf:"bytes,3,opt,name=new_rate,json=newRate,proto3" json:"new_rate,omitempty"`
 }
 
@@ -1378,11 +1378,11 @@ type MsgClient interface {
 	SwapIn(ctx context.Context, in *MsgSwapInRequest, opts ...grpc.CallOption) (*MsgSwapInResponse, error)
 	// SwapOut exchanges vault shares for underlying assets by withdrawing from a vault.
 	SwapOut(ctx context.Context, in *MsgSwapOutRequest, opts ...grpc.CallOption) (*MsgSwapOutResponse, error)
-	// UpdateMinInterestRate sets the minimum allowed interest rate (APY) for a vault.
+	// UpdateMinInterestRate sets the minimum allowed annual interest rate for a vault.
 	UpdateMinInterestRate(ctx context.Context, in *MsgUpdateMinInterestRateRequest, opts ...grpc.CallOption) (*MsgUpdateMinInterestRateResponse, error)
-	// UpdateMaxInterestRate sets the maximum allowed interest rate (APY) for a vault.
+	// UpdateMaxInterestRate sets the maximum allowed annual interest rate for a vault.
 	UpdateMaxInterestRate(ctx context.Context, in *MsgUpdateMaxInterestRateRequest, opts ...grpc.CallOption) (*MsgUpdateMaxInterestRateResponse, error)
-	// UpdateInterestRate allows the interest admin to update the current interest rate (APY) within limits.
+	// UpdateInterestRate allows the interest admin to update the current annual interest rate within limits.
 	UpdateInterestRate(ctx context.Context, in *MsgUpdateInterestRateRequest, opts ...grpc.CallOption) (*MsgUpdateInterestRateResponse, error)
 	// DepositInterestFunds allows depositing funds into the vault for paying interest.
 	DepositInterestFunds(ctx context.Context, in *MsgDepositInterestFundsRequest, opts ...grpc.CallOption) (*MsgDepositInterestFundsResponse, error)
@@ -1522,11 +1522,11 @@ type MsgServer interface {
 	SwapIn(context.Context, *MsgSwapInRequest) (*MsgSwapInResponse, error)
 	// SwapOut exchanges vault shares for underlying assets by withdrawing from a vault.
 	SwapOut(context.Context, *MsgSwapOutRequest) (*MsgSwapOutResponse, error)
-	// UpdateMinInterestRate sets the minimum allowed interest rate (APY) for a vault.
+	// UpdateMinInterestRate sets the minimum allowed annual interest rate for a vault.
 	UpdateMinInterestRate(context.Context, *MsgUpdateMinInterestRateRequest) (*MsgUpdateMinInterestRateResponse, error)
-	// UpdateMaxInterestRate sets the maximum allowed interest rate (APY) for a vault.
+	// UpdateMaxInterestRate sets the maximum allowed annual interest rate for a vault.
 	UpdateMaxInterestRate(context.Context, *MsgUpdateMaxInterestRateRequest) (*MsgUpdateMaxInterestRateResponse, error)
-	// UpdateInterestRate allows the interest admin to update the current interest rate (APY) within limits.
+	// UpdateInterestRate allows the interest admin to update the current annual interest rate within limits.
 	UpdateInterestRate(context.Context, *MsgUpdateInterestRateRequest) (*MsgUpdateInterestRateResponse, error)
 	// DepositInterestFunds allows depositing funds into the vault for paying interest.
 	DepositInterestFunds(context.Context, *MsgDepositInterestFundsRequest) (*MsgDepositInterestFundsResponse, error)

--- a/types/vault.pb.go
+++ b/types/vault.pb.go
@@ -36,15 +36,15 @@ type VaultAccount struct {
 	UnderlyingAssets []string `protobuf:"bytes,3,rep,name=underlying_assets,json=underlyingAssets,proto3" json:"underlying_assets,omitempty"`
 	// admin is the address that has administrative privileges over the vault.
 	Admin string `protobuf:"bytes,4,opt,name=admin,proto3" json:"admin,omitempty"`
-	// current_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the actual interest rate (APY) currently being applied.
+	// current_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual interest rate (APY) currently being applied.
 	// This may be adjusted programmatically (e.g., due to lack of funds).
 	CurrentInterestRate string `protobuf:"bytes,5,opt,name=current_interest_rate,json=currentInterestRate,proto3" json:"current_interest_rate,omitempty"`
-	// desired_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the target interest rate (APY) that the vault intends to apply.
+	// desired_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the target interest rate (APY) that the vault intends to apply.
 	DesiredInterestRate string `protobuf:"bytes,6,opt,name=desired_interest_rate,json=desiredInterestRate,proto3" json:"desired_interest_rate,omitempty"`
-	// min_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the lowest interest rate (APY) the admin is allowed to set.
+	// min_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the lowest interest rate (APY) the admin is allowed to set.
 	// If unset (empty string), there is no lower limit.
 	MinInterestRate string `protobuf:"bytes,7,opt,name=min_interest_rate,json=minInterestRate,proto3" json:"min_interest_rate,omitempty"`
-	// max_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the highest interest rate (APY) the admin is allowed to set.
+	// max_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the highest interest rate (APY) the admin is allowed to set.
 	// If unset (empty string), there is no upper limit.
 	MaxInterestRate string `protobuf:"bytes,8,opt,name=max_interest_rate,json=maxInterestRate,proto3" json:"max_interest_rate,omitempty"`
 	// swap_in_enabled indicates whether users are allowed to deposit into the vault.

--- a/types/vault.pb.go
+++ b/types/vault.pb.go
@@ -36,15 +36,15 @@ type VaultAccount struct {
 	UnderlyingAssets []string `protobuf:"bytes,3,rep,name=underlying_assets,json=underlyingAssets,proto3" json:"underlying_assets,omitempty"`
 	// admin is the address that has administrative privileges over the vault.
 	Admin string `protobuf:"bytes,4,opt,name=admin,proto3" json:"admin,omitempty"`
-	// current_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate currently being applied.
+	// current_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate (APY) currently being applied.
 	// This may be adjusted programmatically (e.g., due to lack of funds).
 	CurrentInterestRate string `protobuf:"bytes,5,opt,name=current_interest_rate,json=currentInterestRate,proto3" json:"current_interest_rate,omitempty"`
-	// desired_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the target interest rate that the vault intends to apply.
+	// desired_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the target interest rate (APY) that the vault intends to apply.
 	DesiredInterestRate string `protobuf:"bytes,6,opt,name=desired_interest_rate,json=desiredInterestRate,proto3" json:"desired_interest_rate,omitempty"`
-	// min_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the lowest interest rate the admin is allowed to set.
+	// min_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the lowest interest rate (APY) the admin is allowed to set.
 	// If unset (empty string), there is no lower limit.
 	MinInterestRate string `protobuf:"bytes,7,opt,name=min_interest_rate,json=minInterestRate,proto3" json:"min_interest_rate,omitempty"`
-	// max_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the highest interest rate the admin is allowed to set.
+	// max_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the highest interest rate (APY) the admin is allowed to set.
 	// If unset (empty string), there is no upper limit.
 	MaxInterestRate string `protobuf:"bytes,8,opt,name=max_interest_rate,json=maxInterestRate,proto3" json:"max_interest_rate,omitempty"`
 	// swap_in_enabled indicates whether users are allowed to deposit into the vault.

--- a/types/vault.pb.go
+++ b/types/vault.pb.go
@@ -36,15 +36,15 @@ type VaultAccount struct {
 	UnderlyingAssets []string `protobuf:"bytes,3,rep,name=underlying_assets,json=underlyingAssets,proto3" json:"underlying_assets,omitempty"`
 	// admin is the address that has administrative privileges over the vault.
 	Admin string `protobuf:"bytes,4,opt,name=admin,proto3" json:"admin,omitempty"`
-	// current_interest_rate is the actual interest rate currently being applied.
+	// current_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate currently being applied.
 	// This may be adjusted programmatically (e.g., due to lack of funds).
 	CurrentInterestRate string `protobuf:"bytes,5,opt,name=current_interest_rate,json=currentInterestRate,proto3" json:"current_interest_rate,omitempty"`
-	// desired_interest_rate is the target interest rate that the vault intends to apply.
+	// desired_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the target interest rate that the vault intends to apply.
 	DesiredInterestRate string `protobuf:"bytes,6,opt,name=desired_interest_rate,json=desiredInterestRate,proto3" json:"desired_interest_rate,omitempty"`
-	// min_interest_rate is the lowest interest rate the admin is allowed to set.
+	// min_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the lowest interest rate the admin is allowed to set.
 	// If unset (empty string), there is no lower limit.
 	MinInterestRate string `protobuf:"bytes,7,opt,name=min_interest_rate,json=minInterestRate,proto3" json:"min_interest_rate,omitempty"`
-	// max_interest_rate is the highest interest rate the admin is allowed to set.
+	// max_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the highest interest rate the admin is allowed to set.
 	// If unset (empty string), there is no upper limit.
 	MaxInterestRate string `protobuf:"bytes,8,opt,name=max_interest_rate,json=maxInterestRate,proto3" json:"max_interest_rate,omitempty"`
 	// swap_in_enabled indicates whether users are allowed to deposit into the vault.

--- a/types/vault.pb.go
+++ b/types/vault.pb.go
@@ -36,15 +36,15 @@ type VaultAccount struct {
 	UnderlyingAssets []string `protobuf:"bytes,3,rep,name=underlying_assets,json=underlyingAssets,proto3" json:"underlying_assets,omitempty"`
 	// admin is the address that has administrative privileges over the vault.
 	Admin string `protobuf:"bytes,4,opt,name=admin,proto3" json:"admin,omitempty"`
-	// current_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the actual interest rate (APY) currently being applied.
+	// current_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the actual interest rate (APY) currently being applied.
 	// This may be adjusted programmatically (e.g., due to lack of funds).
 	CurrentInterestRate string `protobuf:"bytes,5,opt,name=current_interest_rate,json=currentInterestRate,proto3" json:"current_interest_rate,omitempty"`
-	// desired_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the target interest rate (APY) that the vault intends to apply.
+	// desired_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the target interest rate (APY) that the vault intends to apply.
 	DesiredInterestRate string `protobuf:"bytes,6,opt,name=desired_interest_rate,json=desiredInterestRate,proto3" json:"desired_interest_rate,omitempty"`
-	// min_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the lowest interest rate (APY) the admin is allowed to set.
+	// min_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the lowest interest rate (APY) the admin is allowed to set.
 	// If unset (empty string), there is no lower limit.
 	MinInterestRate string `protobuf:"bytes,7,opt,name=min_interest_rate,json=minInterestRate,proto3" json:"min_interest_rate,omitempty"`
-	// max_interest_rate is a decimal string (e.g., "0.9" for 90%) representing the highest interest rate (APY) the admin is allowed to set.
+	// max_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.038" for  3.8%) representing the highest interest rate (APY) the admin is allowed to set.
 	// If unset (empty string), there is no upper limit.
 	MaxInterestRate string `protobuf:"bytes,8,opt,name=max_interest_rate,json=maxInterestRate,proto3" json:"max_interest_rate,omitempty"`
 	// swap_in_enabled indicates whether users are allowed to deposit into the vault.

--- a/types/vault.pb.go
+++ b/types/vault.pb.go
@@ -36,15 +36,15 @@ type VaultAccount struct {
 	UnderlyingAssets []string `protobuf:"bytes,3,rep,name=underlying_assets,json=underlyingAssets,proto3" json:"underlying_assets,omitempty"`
 	// admin is the address that has administrative privileges over the vault.
 	Admin string `protobuf:"bytes,4,opt,name=admin,proto3" json:"admin,omitempty"`
-	// current_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual interest rate (APY) currently being applied.
+	// current_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the actual annual interest rate currently being applied.
 	// This may be adjusted programmatically (e.g., due to lack of funds).
 	CurrentInterestRate string `protobuf:"bytes,5,opt,name=current_interest_rate,json=currentInterestRate,proto3" json:"current_interest_rate,omitempty"`
-	// desired_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the target interest rate (APY) that the vault intends to apply.
+	// desired_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the target annual interest rate that the vault intends to apply.
 	DesiredInterestRate string `protobuf:"bytes,6,opt,name=desired_interest_rate,json=desiredInterestRate,proto3" json:"desired_interest_rate,omitempty"`
-	// min_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the lowest interest rate (APY) the admin is allowed to set.
+	// min_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the lowest annual interest rate the admin is allowed to set.
 	// If unset (empty string), there is no lower limit.
 	MinInterestRate string `protobuf:"bytes,7,opt,name=min_interest_rate,json=minInterestRate,proto3" json:"min_interest_rate,omitempty"`
-	// max_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the highest interest rate (APY) the admin is allowed to set.
+	// max_interest_rate is a decimal string (e.g., "0.9" for 90% and "0.9001353" for 90.01353%) representing the highest annual interest rate the admin is allowed to set.
 	// If unset (empty string), there is no upper limit.
 	MaxInterestRate string `protobuf:"bytes,8,opt,name=max_interest_rate,json=maxInterestRate,proto3" json:"max_interest_rate,omitempty"`
 	// swap_in_enabled indicates whether users are allowed to deposit into the vault.


### PR DESCRIPTION
### This PR improves the usability of our CLI by:

Adding an Example section to all commands.

Clarifying that interest rates must be in decimal format (e.g., "0.90" for 90%) in both command descriptions and proto comments.

Issue: #23 