### PR TITLE
 Phase 2 - Integrate Valuation Engine and Multi-Asset Swaps

### DIFF
--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -36,7 +36,7 @@ func (k msgServer) CreateVault(goCtx context.Context, msg *types.MsgCreateVaultR
 	return &types.MsgCreateVaultResponse{}, nil
 }
 
-// SwapIn handles depositing underlying assets into a vault and mints vault shares to the recipient.
+// SwapIn handles depositing assets accepted by the vault and mints vault shares to the recipient.
 func (k msgServer) SwapIn(goCtx context.Context, msg *types.MsgSwapInRequest) (*types.MsgSwapInResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
@@ -51,7 +51,7 @@ func (k msgServer) SwapIn(goCtx context.Context, msg *types.MsgSwapInRequest) (*
 	return &types.MsgSwapInResponse{}, nil
 }
 
-// SwapOut handles redeeming vault shares for underlying assets and transfers the assets to the recipient.
+// SwapOut handles redeeming vault shares for assets accepted by the vault and transfers them to the recipient.
 func (k msgServer) SwapOut(goCtx context.Context, msg *types.MsgSwapOutRequest) (*types.MsgSwapOutResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
@@ -323,10 +323,11 @@ func (k msgServer) DepositPrincipalFunds(goCtx context.Context, msg *types.MsgDe
 
 	depositFromAddress := sdk.MustAccAddressFromBech32(msg.Admin)
 	markerAddress := markertypes.MustGetMarkerAddress(vault.ShareDenom)
-	// TODO: support payment asset here
-	if vault.UnderlyingAsset != msg.Amount.Denom {
-		return nil, fmt.Errorf("denom not supported for vault must be of type \"%s\" : got \"%s\"", vault.UnderlyingAsset, msg.Amount.Denom)
+
+	if err := vault.ValidateAcceptedCoin(msg.Amount); err != nil {
+		return nil, err
 	}
+
 	if err := k.BankKeeper.SendCoins(markertypes.WithBypass(ctx),
 		depositFromAddress,
 		markerAddress,
@@ -361,10 +362,12 @@ func (k msgServer) WithdrawPrincipalFunds(goCtx context.Context, msg *types.MsgW
 
 	withdrawAddress := sdk.MustAccAddressFromBech32(msg.Admin)
 	markerAddress := markertypes.MustGetMarkerAddress(vault.ShareDenom)
-	if vault.UnderlyingAsset != msg.Amount.Denom {
-		return nil, fmt.Errorf("denom not supported for vault must be of type \"%s\" : got \"%s\"", vault.UnderlyingAsset, msg.Amount.Denom)
+
+	if err := vault.ValidateAcceptedCoin(msg.Amount); err != nil {
+		return nil, err
 	}
-	if err := k.BankKeeper.SendCoins(markertypes.WithBypass(ctx),
+
+	if err := k.BankKeeper.SendCoins(markertypes.WithTransferAgents(ctx, vaultAddr),
 		markerAddress,
 		withdrawAddress,
 		sdk.NewCoins(msg.Amount),

--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -58,7 +58,7 @@ func (k msgServer) SwapOut(goCtx context.Context, msg *types.MsgSwapOutRequest) 
 	vaultAddr := sdk.MustAccAddressFromBech32(msg.VaultAddress)
 	ownerAddr := sdk.MustAccAddressFromBech32(msg.Owner)
 
-	_, err := k.Keeper.SwapOut(ctx, vaultAddr, ownerAddr, msg.Assets)
+	_, err := k.Keeper.SwapOut(ctx, vaultAddr, ownerAddr, msg.Assets, msg.RedeemDenom)
 	if err != nil {
 		return nil, err
 	}

--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -322,7 +322,7 @@ func (k msgServer) DepositPrincipalFunds(goCtx context.Context, msg *types.MsgDe
 	}
 
 	depositFromAddress := sdk.MustAccAddressFromBech32(msg.Admin)
-	markerAddress := markertypes.MustGetMarkerAddress(vault.ShareDenom)
+	principalAddress := vault.PrincipalMarkerAddress()
 
 	if err := vault.ValidateAcceptedCoin(msg.Amount); err != nil {
 		return nil, err
@@ -330,7 +330,7 @@ func (k msgServer) DepositPrincipalFunds(goCtx context.Context, msg *types.MsgDe
 
 	if err := k.BankKeeper.SendCoins(markertypes.WithBypass(ctx),
 		depositFromAddress,
-		markerAddress,
+		principalAddress,
 		sdk.NewCoins(msg.Amount),
 	); err != nil {
 		return nil, fmt.Errorf("failed to deposit principal funds: %w", err)
@@ -361,14 +361,14 @@ func (k msgServer) WithdrawPrincipalFunds(goCtx context.Context, msg *types.MsgW
 	}
 
 	withdrawAddress := sdk.MustAccAddressFromBech32(msg.Admin)
-	markerAddress := markertypes.MustGetMarkerAddress(vault.ShareDenom)
+	principalAddress := vault.PrincipalMarkerAddress()
 
 	if err := vault.ValidateAcceptedCoin(msg.Amount); err != nil {
 		return nil, err
 	}
 
 	if err := k.BankKeeper.SendCoins(markertypes.WithTransferAgents(ctx, vaultAddr),
-		markerAddress,
+		principalAddress,
 		withdrawAddress,
 		sdk.NewCoins(msg.Amount),
 	); err != nil {

--- a/keeper/msg_server_security_test.go
+++ b/keeper/msg_server_security_test.go
@@ -75,7 +75,7 @@ func (s *TestSuite) TestMsgServer_SmallFirstSwapIn_HugeDonation_SwapOut() {
 
 	s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
 	sharesToBurn := sdk.NewCoin(shareDenom, respIn.Amount)
-	respOut, err := s.k.SwapOut(s.ctx, vaultAddr, owner, sharesToBurn)
+	respOut, err := s.k.SwapOut(s.ctx, vaultAddr, owner, sharesToBurn, "")
 	s.Require().NoError(err, "swap-out of all tiny depositor shares should succeed")
 
 	s.Require().True(

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -1584,7 +1584,7 @@ func (s *TestSuite) TestMsgServer_DepositInterestFunds_Failures() {
 				VaultAddress: vaultAddr.String(),
 				Amount:       sdk.NewInt64Coin(unsupportedDenom, 9_999_999),
 			},
-			expectedErrSubstrs: []string{"denom not supported for vault must be of type \"under\" : got \"unsupportedDenom\""},
+			expectedErrSubstrs: []string{"denom not supported for vault", "under", unsupportedDenom},
 		},
 		{
 			name:  "insufficient admin balance",
@@ -1747,7 +1747,7 @@ func (s *TestSuite) TestMsgServer_WithdrawInterestFunds_Failures() {
 				VaultAddress: vaultAddr.String(),
 				Amount:       sdk.NewInt64Coin(unsupportedDenom, 9_999_999),
 			},
-			expectedErrSubstrs: []string{"denom not supported for vault must be of type \"under\" : got \"unsupportedDenom\""},
+			expectedErrSubstrs: []string{"denom not supported for vault", "under", unsupportedDenom},
 		},
 	}
 
@@ -1886,7 +1886,7 @@ func (s *TestSuite) TestMsgServer_DepositPrincipalFunds_Failures() {
 				VaultAddress: vaultAddr.String(),
 				Amount:       sdk.NewInt64Coin("wrongdenom", 500),
 			},
-			expectedErrSubstrs: []string{"denom not supported for vault must be of type \"under\" : got \"wrongdenom\""},
+			expectedErrSubstrs: []string{"denom not supported for vault", "under", "wrongdenom"},
 		},
 		{
 			name:  "insufficient admin balance",
@@ -2036,7 +2036,7 @@ func (s *TestSuite) TestMsgServer_WithdrawPrincipalFunds_Failures() {
 				VaultAddress: vaultAddr.String(),
 				Amount:       sdk.NewInt64Coin("wrongdenom", 500),
 			},
-			expectedErrSubstrs: []string{"enom not supported for vault must be of type \"under\" : got \"wrongdenom\""},
+			expectedErrSubstrs: []string{"denom not supported for vault", "under", "wrongdenom"},
 		},
 		{
 			name:  "insufficient marker balance",

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -496,20 +497,20 @@ func (s *TestSuite) TestMsgServer_SwapOut_Failures() {
 		}
 	}
 
-	// randomAddr := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+	randomAddr := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
 	mintedShares := initialAssets.Amount.Mul(utils.ShareScalar)
 	overdrawShares := mintedShares.Add(math.NewInt(1)) // force insufficient funds
 
 	tests := []msgServerTestCase[types.MsgSwapOutRequest, any]{
-		// {
-		// 	name: "vault does not exist returns not found error",
-		// 	msg: types.MsgSwapOutRequest{
-		// 		Owner:        owner.String(),
-		// 		VaultAddress: randomAddr,
-		// 		Assets:       sdk.NewInt64Coin(shareDenom, 50),
-		// 	},
-		// 	expectedErrSubstrs: []string{"vault with address", "not found"},
-		// },
+		{
+			name: "vault does not exist returns not found error",
+			msg: types.MsgSwapOutRequest{
+				Owner:        owner.String(),
+				VaultAddress: randomAddr,
+				Assets:       sdk.NewInt64Coin(shareDenom, 50),
+			},
+			expectedErrSubstrs: []string{"vault with address", "not found"},
+		},
 		{
 			name:  "wrong denom rejected",
 			setup: setup(true),

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
-	"github.com/cometbft/cometbft/crypto/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -318,7 +317,7 @@ func (s *TestSuite) TestMsgServer_SwapIn_Failures() {
 				VaultAddress: vaultAddr.String(),
 				Assets:       sdk.NewInt64Coin("othercoin", 100),
 			},
-			expectedErrSubstrs: []string{"denom not supported for vault must be of type \"underlying\" : got \"othercoin\""},
+			expectedErrSubstrs: []string{"denom not supported for vault; must be \"underlying\": got \"othercoin\""},
 		},
 		{
 			name: "insufficient owner funds is rejected",
@@ -497,20 +496,20 @@ func (s *TestSuite) TestMsgServer_SwapOut_Failures() {
 		}
 	}
 
-	randomAddr := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+	// randomAddr := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
 	mintedShares := initialAssets.Amount.Mul(utils.ShareScalar)
 	overdrawShares := mintedShares.Add(math.NewInt(1)) // force insufficient funds
 
 	tests := []msgServerTestCase[types.MsgSwapOutRequest, any]{
-		{
-			name: "vault does not exist returns not found error",
-			msg: types.MsgSwapOutRequest{
-				Owner:        owner.String(),
-				VaultAddress: randomAddr,
-				Assets:       sdk.NewInt64Coin(shareDenom, 50),
-			},
-			expectedErrSubstrs: []string{"vault with address", "not found"},
-		},
+		// {
+		// 	name: "vault does not exist returns not found error",
+		// 	msg: types.MsgSwapOutRequest{
+		// 		Owner:        owner.String(),
+		// 		VaultAddress: randomAddr,
+		// 		Assets:       sdk.NewInt64Coin(shareDenom, 50),
+		// 	},
+		// 	expectedErrSubstrs: []string{"vault with address", "not found"},
+		// },
 		{
 			name:  "wrong denom rejected",
 			setup: setup(true),

--- a/keeper/query_server.go
+++ b/keeper/query_server.go
@@ -11,8 +11,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-
-	markertypes "github.com/provenance-io/provenance/x/marker/types"
 )
 
 var _ types.QueryServer = &queryServer{}
@@ -116,9 +114,9 @@ func (k queryServer) EstimateSwapIn(goCtx context.Context, req *types.QueryEstim
 		return nil, status.Errorf(codes.InvalidArgument, "denom not supported for vault must be of type \"%s\" : got \"%s\"", vault.UnderlyingAsset, req.Assets.Denom)
 	}
 
-	markerAddr := markertypes.MustGetMarkerAddress(vault.ShareDenom)
+	principalAddress := vault.PrincipalMarkerAddress()
 	totalShares := k.BankKeeper.GetSupply(ctx, vault.ShareDenom).Amount
-	totalAssets := k.BankKeeper.GetBalance(ctx, markerAddr, vault.UnderlyingAsset)
+	totalAssets := k.BankKeeper.GetBalance(ctx, principalAddress, vault.UnderlyingAsset)
 
 	estimatedTotalAssets, err := k.CalculateVaultTotalAssets(ctx, vault, totalAssets)
 	if err != nil {
@@ -162,7 +160,7 @@ func (k queryServer) EstimateSwapOut(goCtx context.Context, req *types.QueryEsti
 		return nil, status.Errorf(codes.InvalidArgument, "asset denom %s does not match vault share denom %s", req.Assets.Denom, vault.ShareDenom)
 	}
 
-	markerAddr := markertypes.MustGetMarkerAddress(vault.ShareDenom)
+	markerAddr := vault.PrincipalMarkerAddress()
 	totalShares := k.BankKeeper.GetSupply(ctx, vault.ShareDenom).Amount
 	totalAssets := k.BankKeeper.GetBalance(ctx, markerAddr, vault.UnderlyingAsset)
 

--- a/keeper/query_server.go
+++ b/keeper/query_server.go
@@ -160,9 +160,9 @@ func (k queryServer) EstimateSwapOut(goCtx context.Context, req *types.QueryEsti
 		return nil, status.Errorf(codes.InvalidArgument, "asset denom %s does not match vault share denom %s", req.Assets.Denom, vault.ShareDenom)
 	}
 
-	markerAddr := vault.PrincipalMarkerAddress()
+	principalAddress := vault.PrincipalMarkerAddress()
 	totalShares := k.BankKeeper.GetSupply(ctx, vault.ShareDenom).Amount
-	totalAssets := k.BankKeeper.GetBalance(ctx, markerAddr, vault.UnderlyingAsset)
+	totalAssets := k.BankKeeper.GetBalance(ctx, principalAddress, vault.UnderlyingAsset)
 
 	estimatedTotalAssets, err := k.CalculateVaultTotalAssets(ctx, vault, totalAssets)
 	if err != nil {

--- a/keeper/query_server_test.go
+++ b/keeper/query_server_test.go
@@ -68,7 +68,7 @@ func (s *TestSuite) TestQueryServer_Vault() {
 			Setup: setupVaults,
 			Req:   &types.QueryVaultRequest{Id: addr1.String()},
 			ExpectedResp: &types.QueryVaultResponse{
-				Vault: *types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr1), admin, shareDenom1, "stake1"),
+				Vault: *types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr1), admin, shareDenom1, "stake1", "usdc"),
 				Principal: types.AccountBalance{
 					Address: markerAddr1.String(),
 					Coins:   sdk.NewCoins(sdk.NewInt64Coin("stake1", 1000)),
@@ -84,7 +84,7 @@ func (s *TestSuite) TestQueryServer_Vault() {
 			Setup: setupVaults,
 			Req:   &types.QueryVaultRequest{Id: shareDenom2},
 			ExpectedResp: &types.QueryVaultResponse{
-				Vault: *types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr2), admin, shareDenom2, "stake2"),
+				Vault: *types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr2), admin, shareDenom2, "stake2", "usdc"),
 				Principal: types.AccountBalance{
 					Address: markerAddr2.String(),
 					Coins:   sdk.NewCoins(sdk.NewInt64Coin("stake2", 2000)),
@@ -185,13 +185,18 @@ func (s *TestSuite) TestQueryServer_Vaults() {
 			Name: "happy path - single vault",
 			Setup: func() {
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("stake2", 1), s.adminAddr)
-				_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom1, UnderlyingAsset: "stake2"})
+				_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom1,
+					UnderlyingAsset: "stake2",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
 			},
 			Req: &types.QueryVaultsRequest{},
 			ExpectedResp: &types.QueryVaultsResponse{
 				Vaults: []types.VaultAccount{
-					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr1), admin, shareDenom1, "stake2"),
+					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr1), admin, shareDenom1, "stake2", "usdc"),
 				},
 				Pagination: &query.PageResponse{Total: 1},
 			},
@@ -202,19 +207,34 @@ func (s *TestSuite) TestQueryServer_Vaults() {
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("stake2", 1), s.adminAddr)
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("nhash", 1), s.adminAddr)
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("usdf", 1), s.adminAddr)
-				_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom1, UnderlyingAsset: "stake2"})
+				_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom1,
+					UnderlyingAsset: "stake2",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
-				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom2, UnderlyingAsset: "nhash"})
+				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom2,
+					UnderlyingAsset: "nhash",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
-				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom3, UnderlyingAsset: "usdf"})
+				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom3,
+					UnderlyingAsset: "usdf",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
 			},
 			Req: &types.QueryVaultsRequest{},
 			ExpectedResp: &types.QueryVaultsResponse{
 				Vaults: []types.VaultAccount{
-					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr1), admin, shareDenom1, "stake2"),
-					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr2), admin, shareDenom2, "nhash"),
-					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr3), admin, shareDenom3, "usdf"),
+					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr1), admin, shareDenom1, "stake2", "usdc"),
+					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr2), admin, shareDenom2, "nhash", "usdc"),
+					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr3), admin, shareDenom3, "usdf", "usdc"),
 				},
 				Pagination: &query.PageResponse{Total: 3},
 			},
@@ -225,11 +245,26 @@ func (s *TestSuite) TestQueryServer_Vaults() {
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("stake2", 1), s.adminAddr)
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("nhash", 1), s.adminAddr)
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("usdf", 1), s.adminAddr)
-				_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom1, UnderlyingAsset: "stake2"})
+				_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom1,
+					UnderlyingAsset: "stake2",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
-				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom2, UnderlyingAsset: "nhash"})
+				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom2,
+					UnderlyingAsset: "nhash",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
-				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom3, UnderlyingAsset: "usdf"})
+				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom3,
+					UnderlyingAsset: "usdf",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
 			},
 			Req: &types.QueryVaultsRequest{
@@ -237,8 +272,8 @@ func (s *TestSuite) TestQueryServer_Vaults() {
 			},
 			ExpectedResp: &types.QueryVaultsResponse{
 				Vaults: []types.VaultAccount{
-					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr3), admin, shareDenom3, "usdf"),
-					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr1), admin, shareDenom1, "stake2"),
+					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr3), admin, shareDenom3, "usdf", "usdc"),
+					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr1), admin, shareDenom1, "stake2", "usdc"),
 				},
 				Pagination: &query.PageResponse{
 					NextKey: []byte("not nil"),
@@ -251,11 +286,26 @@ func (s *TestSuite) TestQueryServer_Vaults() {
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("stake2", 1), s.adminAddr)
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("nhash", 1), s.adminAddr)
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("usdf", 1), s.adminAddr)
-				_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom1, UnderlyingAsset: "stake2"})
+				_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom1,
+					UnderlyingAsset: "stake2",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
-				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom2, UnderlyingAsset: "nhash"})
+				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom2,
+					UnderlyingAsset: "nhash",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
-				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom3, UnderlyingAsset: "usdf"})
+				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom3,
+					UnderlyingAsset: "usdf",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
 			},
 			Req: &types.QueryVaultsRequest{
@@ -263,8 +313,8 @@ func (s *TestSuite) TestQueryServer_Vaults() {
 			},
 			ExpectedResp: &types.QueryVaultsResponse{
 				Vaults: []types.VaultAccount{
-					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr1), admin, shareDenom1, "stake2"),
-					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr2), admin, shareDenom2, "nhash"),
+					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr1), admin, shareDenom1, "stake2", "usdc"),
+					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr2), admin, shareDenom2, "nhash", "usdc"),
 				},
 				Pagination: &query.PageResponse{Total: 3},
 			},
@@ -275,11 +325,26 @@ func (s *TestSuite) TestQueryServer_Vaults() {
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("stake2", 1), s.adminAddr)
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("nhash", 1), s.adminAddr)
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("usdf", 1), s.adminAddr)
-				_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom1, UnderlyingAsset: "stake2"})
+				_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom1,
+					UnderlyingAsset: "stake2",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
-				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom2, UnderlyingAsset: "nhash"})
+				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom2,
+					UnderlyingAsset: "nhash",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
-				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom3, UnderlyingAsset: "usdf"})
+				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom3,
+					UnderlyingAsset: "usdf",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
 			},
 			Req: &types.QueryVaultsRequest{
@@ -287,7 +352,7 @@ func (s *TestSuite) TestQueryServer_Vaults() {
 			},
 			ExpectedResp: &types.QueryVaultsResponse{
 				Vaults: []types.VaultAccount{
-					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr2), admin, shareDenom2, "nhash"),
+					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr2), admin, shareDenom2, "nhash", "usdc"),
 				},
 				Pagination: &query.PageResponse{},
 			},
@@ -298,11 +363,26 @@ func (s *TestSuite) TestQueryServer_Vaults() {
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("stake2", 1), s.adminAddr)
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("nhash", 1), s.adminAddr)
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("usdf", 1), s.adminAddr)
-				_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom1, UnderlyingAsset: "stake2"})
+				_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom1,
+					UnderlyingAsset: "stake2",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
-				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom2, UnderlyingAsset: "nhash"})
+				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom2,
+					UnderlyingAsset: "nhash",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
-				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom3, UnderlyingAsset: "usdf"})
+				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom3,
+					UnderlyingAsset: "usdf",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
 			},
 			Req: &types.QueryVaultsRequest{
@@ -310,9 +390,9 @@ func (s *TestSuite) TestQueryServer_Vaults() {
 			},
 			ExpectedResp: &types.QueryVaultsResponse{
 				Vaults: []types.VaultAccount{
-					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr1), admin, shareDenom1, "stake2"),
-					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr2), admin, shareDenom2, "nhash"),
-					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr3), admin, shareDenom3, "usdf"),
+					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr1), admin, shareDenom1, "stake2", "usdc"),
+					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr2), admin, shareDenom2, "nhash", "usdc"),
+					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr3), admin, shareDenom3, "usdf", "usdc"),
 				},
 				Pagination: &query.PageResponse{Total: 3},
 			},
@@ -323,11 +403,26 @@ func (s *TestSuite) TestQueryServer_Vaults() {
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("stake2", 1), s.adminAddr)
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("nhash", 1), s.adminAddr)
 				s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin("usdf", 1), s.adminAddr)
-				_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom1, UnderlyingAsset: "stake2"})
+				_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom1,
+					UnderlyingAsset: "stake2",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
-				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom2, UnderlyingAsset: "nhash"})
+				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom2,
+					UnderlyingAsset: "nhash",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
-				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{Admin: admin, ShareDenom: shareDenom3, UnderlyingAsset: "usdf"})
+				_, err = s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+					Admin:           admin,
+					ShareDenom:      shareDenom3,
+					UnderlyingAsset: "usdf",
+					PaymentDenom:    "usdc",
+				})
 				s.Require().NoError(err)
 			},
 			Req: &types.QueryVaultsRequest{
@@ -335,8 +430,8 @@ func (s *TestSuite) TestQueryServer_Vaults() {
 			},
 			ExpectedResp: &types.QueryVaultsResponse{
 				Vaults: []types.VaultAccount{
-					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr2), admin, shareDenom2, "nhash"),
-					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr1), admin, shareDenom1, "stake2"),
+					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr2), admin, shareDenom2, "nhash", "usdc"),
+					*types.NewVaultAccount(authtypes.NewBaseAccountWithAddress(addr1), admin, shareDenom1, "stake2", "usdc"),
 				},
 				Pagination: &query.PageResponse{
 					NextKey: []byte("not nil"),

--- a/keeper/reconcile.go
+++ b/keeper/reconcile.go
@@ -59,10 +59,10 @@ func (k *Keeper) PerformVaultInterestTransfer(ctx sdk.Context, vault *types.Vaul
 	}
 
 	periodDuration := currentBlockTime - vault.PeriodStart
-	markerAddress := markertypes.MustGetMarkerAddress(vault.ShareDenom)
+	principalAddress := vault.PrincipalMarkerAddress()
 
 	reserves := k.BankKeeper.GetBalance(ctx, vault.GetAddress(), vault.UnderlyingAsset)
-	principal := k.BankKeeper.GetBalance(ctx, markerAddress, vault.UnderlyingAsset)
+	principal := k.BankKeeper.GetBalance(ctx, principalAddress, vault.UnderlyingAsset)
 
 	interestEarned, err := interest.CalculateInterestEarned(principal, vault.CurrentInterestRate, periodDuration)
 	if err != nil {
@@ -76,7 +76,7 @@ func (k *Keeper) PerformVaultInterestTransfer(ctx sdk.Context, vault *types.Vaul
 
 		if err := k.BankKeeper.SendCoins(markertypes.WithBypass(ctx),
 			vault.GetAddress(),
-			markerAddress,
+			principalAddress,
 			sdk.NewCoins(sdk.NewCoin(vault.UnderlyingAsset, interestEarned)),
 		); err != nil {
 			return fmt.Errorf("failed to pay interest: %w", err)
@@ -88,7 +88,7 @@ func (k *Keeper) PerformVaultInterestTransfer(ctx sdk.Context, vault *types.Vaul
 		}
 
 		if err := k.BankKeeper.SendCoins(markertypes.WithBypass(ctx),
-			markerAddress,
+			principalAddress,
 			vault.GetAddress(),
 			sdk.NewCoins(sdk.NewCoin(vault.UnderlyingAsset, owed)),
 		); err != nil {
@@ -96,7 +96,7 @@ func (k *Keeper) PerformVaultInterestTransfer(ctx sdk.Context, vault *types.Vaul
 		}
 	}
 
-	principalAfter := k.BankKeeper.GetBalance(ctx, markerAddress, vault.UnderlyingAsset)
+	principalAfter := k.BankKeeper.GetBalance(ctx, principalAddress, vault.UnderlyingAsset)
 
 	k.emitEvent(ctx, types.NewEventVaultReconcile(
 		vault.GetAddress().String(),
@@ -123,10 +123,10 @@ func (k *Keeper) CanPayoutDuration(ctx sdk.Context, vault *types.VaultAccount, d
 
 	denom := vault.UnderlyingAsset
 	vaultAddr := vault.GetAddress()
-	markerAddr := markertypes.MustGetMarkerAddress(vault.ShareDenom)
+	principalAddress := vault.PrincipalMarkerAddress()
 
 	reserves := k.BankKeeper.GetBalance(ctx, vaultAddr, denom)
-	principal := k.BankKeeper.GetBalance(ctx, markerAddr, denom)
+	principal := k.BankKeeper.GetBalance(ctx, principalAddress, denom)
 
 	interestEarned, err := interest.CalculateInterestEarned(principal, vault.CurrentInterestRate, duration)
 	if err != nil {

--- a/keeper/reconcile.go
+++ b/keeper/reconcile.go
@@ -23,9 +23,9 @@ const (
 
 // ReconcileVaultInterest updates interest accounting for a vault if a new interest period has started.
 //
-// If this is the first time the vault accrues interest, it initializes PeriodStart and persists the
-// vault account. If the current block time is after PeriodStart, it applies the interest transfer
-// and enqueues the next period start. If the current time has not advanced past PeriodStart, it is a no-op.
+// If this is the first time the vault accrues interest, it triggers the start of a new period.
+// If the current block time is after PeriodStart, it applies the interest transfer.
+// If the current time has not advanced past PeriodStart, it is a no-op.
 //
 // This should be called before any transaction that changes vault principal/reserves or depends on the
 // current interest state.
@@ -263,9 +263,9 @@ func (k *Keeper) tryGetVault(ctx sdk.Context, addr sdk.AccAddress) (*types.Vault
 	return vault, true
 }
 
-// handleReconciledVaults processes vaults whose start times are due (time <= now).
+// handleReconciledVaults processes vaults from the payout verification queue.
 //
-// It collects due entries using WalkDueStarts, removes them from the start queue, partitions the
+// It collects due entries using WalkPayoutVerifications, removes them from the verification queue, partitions the
 // corresponding vaults into payable vs depleted for the forecast window, updates payable vaults'
 // timeouts, and disables interest for depleted vaults.
 func (k *Keeper) handleReconciledVaults(ctx context.Context) error {
@@ -335,10 +335,11 @@ func (k *Keeper) handleDepletedVaults(ctx context.Context, failedPayouts []*type
 	}
 }
 
-// resetVaultInterestPeriods updates PeriodStart and PeriodTimeout for the provided vaults and
-// persists them, then enqueues the corresponding timeout entries.
+// resetVaultInterestPeriods starts a new accrual period for the provided vaults after a successful
+// interest reconciliation by calling SafeEnqueueTimeout for each.
 //
-// This is called after a successful interest reconciliation to start a new accrual period.
+// This updates PeriodStart and PeriodTimeout, persists the vault, and enqueues the corresponding timeout entry.
+
 func (k *Keeper) resetVaultInterestPeriods(ctx context.Context, vaults []*types.VaultAccount) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 

--- a/keeper/suite_test.go
+++ b/keeper/suite_test.go
@@ -199,7 +199,6 @@ func (s *TestSuite) setupBaseVault(underlyingDenom, shareDenom string, paymentDe
 func (s *TestSuite) setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom string, price, volume int64) *types.VaultAccount {
 	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 2_000_000), s.adminAddr)
 	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentDenom, sdk.NewCoins(sdk.NewInt64Coin(paymentDenom, 100_000)))
-	// Pass the paymentDenom here so the vault is created with it.
 	vault := s.setupBaseVault(underlyingDenom, shareDenom, paymentDenom)
 
 	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)

--- a/keeper/suite_test.go
+++ b/keeper/suite_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/provlabs/vault/keeper"
 	"github.com/provlabs/vault/simapp"
+	"github.com/provlabs/vault/types"
 )
 
 type TestSuite struct {
@@ -165,4 +166,37 @@ func createSendCoinEvents(fromAddress, toAddress string, amount string) []sdk.Ev
 	))
 
 	return events
+}
+
+// setupBaseVault creates and activates markers for the underlying and share denoms,
+// withdraws some underlying coins to the admin, and creates the vault.
+// It returns the newly created vault account.
+func (s *TestSuite) setupBaseVault(underlyingDenom, shareDenom string) *types.VaultAccount {
+	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
+	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, underlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 100_000)))
+
+	vaultCfg := vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom}
+	vault, err := s.k.CreateVault(s.ctx, vaultCfg)
+	s.Require().NoError(err, "vault creation should succeed")
+	return vault
+}
+
+// setupSinglePaymentDenomVault is a comprehensive helper that creates a vault with
+// an underlying asset, a share denom, and a single payment denom. It creates all markers,
+// withdraws funds to the admin, creates the vault, and sets a custom NAV
+// for the payment denom to the underlying denom.
+func (s *TestSuite) setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom string, price, volume int64) *types.VaultAccount {
+	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 2_000_000), s.adminAddr)
+	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentDenom, sdk.NewCoins(sdk.NewInt64Coin(paymentDenom, 100_000)))
+	vault := s.setupBaseVault(underlyingDenom, shareDenom)
+
+	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
+	paymentMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentMarkerAddr)
+	s.Require().NoError(err, "should fetch payment marker for NAV setup")
+	s.Require().NoError(s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{
+		Price:  sdk.NewInt64Coin(underlyingDenom, price),
+		Volume: uint64(volume),
+	}, "test"), "should set NAV %s->%s=%d/%d", paymentDenom, underlyingDenom, price, volume)
+
+	return vault
 }

--- a/keeper/valuation_engine.go
+++ b/keeper/valuation_engine.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/provlabs/vault/types"
 	"github.com/provlabs/vault/utils"
+
+	markertypes "github.com/provenance-io/provenance/x/marker/types"
 )
 
 // UnitPriceFraction returns a price ratio (priceNumerator, priceDenominator) that expresses
@@ -87,7 +89,7 @@ func (k Keeper) FromUnderlyingAssetAmount(ctx sdk.Context, vault types.VaultAcco
 // It sums all balances at the vault address (excluding share_denom) after converting each
 // balance into underlying units via ToUnderlyingAssetAmount. Result is floored integer units.
 func (k Keeper) GetTVVInUnderlyingAsset(ctx sdk.Context, vault types.VaultAccount) (math.Int, error) {
-	balances := k.BankKeeper.GetAllBalances(ctx, vault.GetAddress())
+	balances := k.BankKeeper.GetAllBalances(ctx, markertypes.MustGetMarkerAddress(vault.ShareDenom))
 	total := math.ZeroInt()
 	for _, balance := range balances {
 		if balance.Denom == vault.ShareDenom {

--- a/keeper/valuation_engine.go
+++ b/keeper/valuation_engine.go
@@ -8,17 +8,15 @@ import (
 
 	"github.com/provlabs/vault/types"
 	"github.com/provlabs/vault/utils"
-
-	markertypes "github.com/provenance-io/provenance/x/marker/types"
 )
 
-// UnitPriceFraction returns a price ratio (priceNumerator, priceDenominator) that expresses
-// how many units of underlyingAsset are worth one unit of srcDenom, derived from the NAV.
+// UnitPriceFraction returns the unit price of srcDenom expressed in vault.UnderlyingAsset
+// as an integer fraction (priceNumerator, priceDenominator), derived from the NAV.
 //
 // Semantics:
-//   - NAV.Price is the total value (in underlyingAsset) for NAV.Volume units of srcDenom.
-//   - Therefore, unit price = NAV.Price.Amount / NAV.Volume (underlying per 1 src).
-//   - This function returns that unit price as an integer fraction (num, den).
+//   - NAV.Price is the total value (in underlyingAsset units) for NAV.Volume units of srcDenom.
+//   - Therefore, 1 srcDenom = (NAV.Price.Amount / NAV.Volume) underlying units.
+//   - This function returns (NAV.Price.Amount, NAV.Volume) so callers can apply floor arithmetic.
 //
 // Special cases and errors:
 //   - If srcDenom == underlyingAsset, returns (1, 1).
@@ -43,12 +41,16 @@ func (k Keeper) UnitPriceFraction(ctx sdk.Context, srcDenom, underlyingAsset str
 	return priceAmt, volAmt, nil
 }
 
-// ToUnderlyingAssetAmount converts an input coin into its value expressed in vault.UnderlyingAsset,
-// using integer floor arithmetic:
+// ToUnderlyingAssetAmount converts an input coin into its value expressed in
+// vault.UnderlyingAsset using integer floor arithmetic.
+//
+// Formula:
 //
 //	value_in_underlying = in.Amount * priceNumerator / priceDenominator
 //
-// where (priceNumerator, priceDenominator) come from UnitPriceFraction(in.Denom → underlying).
+// where (priceNumerator, priceDenominator) are from UnitPriceFraction(in.Denom → underlying).
+// This performs a pure conversion based on NAV (or identity if denom==underlying). It does
+// not enforce whether the denom is accepted by the vault; such policy checks are handled elsewhere.
 func (k Keeper) ToUnderlyingAssetAmount(ctx sdk.Context, vault types.VaultAccount, in sdk.Coin) (math.Int, error) {
 	priceAmount, volume, err := k.UnitPriceFraction(ctx, in.Denom, vault.UnderlyingAsset)
 	if err != nil {
@@ -57,15 +59,16 @@ func (k Keeper) ToUnderlyingAssetAmount(ctx sdk.Context, vault types.VaultAccoun
 	return in.Amount.Mul(priceAmount).Quo(volume), nil
 }
 
-// FromUnderlyingAssetAmount converts an amount expressed in vault.UnderlyingAsset
-// into a payout coin in outDenom, using integer floor arithmetic.
+// FromUnderlyingAssetAmount converts an amount in vault.UnderlyingAsset into a payout coin
+// in outDenom using integer floor arithmetic.
 //
 // Rules:
-//   - If outDenom == underlyingAsset, returns that amount as a coin directly.
+//   - If outDenom == underlyingAsset, returns that amount directly.
 //   - Otherwise uses the reciprocal of UnitPriceFraction(outDenom → underlying):
 //     out = underlyingAmount * denominator / numerator
 //
-// This performs only conversion; callers should enforce policy/liquidity as needed.
+// This is a pure denomination conversion (with floor). Liquidity/policy enforcement, if any,
+// must be handled by callers.
 func (k Keeper) FromUnderlyingAssetAmount(ctx sdk.Context, vault types.VaultAccount, underlyingAmount math.Int, outDenom string) (sdk.Coin, error) {
 	if !underlyingAmount.IsPositive() {
 		return sdk.NewCoin(outDenom, math.ZeroInt()), nil
@@ -85,11 +88,20 @@ func (k Keeper) FromUnderlyingAssetAmount(ctx sdk.Context, vault types.VaultAcco
 	return sdk.NewCoin(outDenom, out), nil
 }
 
-// GetTVVInUnderlyingAsset returns the Total Vault Value (TVV) expressed in vault.UnderlyingAsset.
-// It sums all balances at the vault address (excluding share_denom) after converting each
-// balance into underlying units via ToUnderlyingAssetAmount. Result is floored integer units.
+// GetTVVInUnderlyingAsset returns the Total Vault Value (TVV) expressed in
+// vault.UnderlyingAsset using floor arithmetic.
+//
+// Source of truth:
+//   - TVV sums the balances held at the vault’s *principal* account, i.e. the marker
+//     address for vault.PrincipalMarkerAddress().
+//   - The vault account’s own balances are treated as *reserves* and are not included here.
+//
+// Computation:
+//   - Iterate all non-share-denom balances at the marker (principal) account.
+//   - Convert each balance to underlying units via ToUnderlyingAssetAmount.
+//   - Sum the converted amounts (floor at each multiplication/division step).
 func (k Keeper) GetTVVInUnderlyingAsset(ctx sdk.Context, vault types.VaultAccount) (math.Int, error) {
-	balances := k.BankKeeper.GetAllBalances(ctx, markertypes.MustGetMarkerAddress(vault.ShareDenom))
+	balances := k.BankKeeper.GetAllBalances(ctx, vault.PrincipalMarkerAddress())
 	total := math.ZeroInt()
 	for _, balance := range balances {
 		if balance.Denom == vault.ShareDenom {
@@ -104,9 +116,13 @@ func (k Keeper) GetTVVInUnderlyingAsset(ctx sdk.Context, vault types.VaultAccoun
 	return total, nil
 }
 
-// GetNAVPerShareInUnderlyingAsset returns the floor NAV-per-share in units of vault.UnderlyingAsset.
-// Computation: NAV_per_share = TVV(underlying) / totalShareSupply. If total shares == 0,
-// returns 0. All values are integer and use floor division.
+// GetNAVPerShareInUnderlyingAsset returns the floor NAV-per-share in units of
+// vault.UnderlyingAsset.
+//
+// Computation:
+//   - TVV(underlying) is obtained from GetTVVInUnderlyingAsset (principal/marker balances only).
+//   - totalShareSupply is fetched from BankKeeper.GetSupply(vault.ShareDenom) (the live supply).
+//   - If total shares == 0, returns 0. Otherwise returns TVV / totalShareSupply (floor).
 func (k Keeper) GetNAVPerShareInUnderlyingAsset(ctx sdk.Context, vault types.VaultAccount) (math.Int, error) {
 	tvv, err := k.GetTVVInUnderlyingAsset(ctx, vault)
 	if err != nil {
@@ -119,12 +135,18 @@ func (k Keeper) GetNAVPerShareInUnderlyingAsset(ctx sdk.Context, vault types.Vau
 	return tvv.Quo(totalShares), nil
 }
 
-// ConvertDepositToSharesInUnderlyingAsset converts a deposit coin into vault shares.
+// ConvertDepositToSharesInUnderlyingAsset converts a deposit coin into vault shares
+// using the current TVV and total share supply (both pro-rata, floor arithmetic).
+//
 // Steps:
 //  1. Convert the deposit into underlying-asset value via ToUnderlyingAssetAmount.
-//  2. Compute shares using CalculateSharesFromAssets(value_in_underlying, TVV, totalShares).
+//  2. Compute the share amount using
+//     CalculateSharesFromAssets(value_in_underlying, TVV, totalShares)
+//     where TVV is from principal (marker) balances.
 //
-// The returned coin is the minted shares in vault.ShareDenom.
+// Returns a coin in vault.ShareDenom representing the minted shares. This function
+// performs calculation only; callers mint/burn/transfer as needed. Very small deposits
+// may floor to zero shares.
 func (k Keeper) ConvertDepositToSharesInUnderlyingAsset(ctx sdk.Context, vault types.VaultAccount, in sdk.Coin) (sdk.Coin, error) {
 	valInAsset, err := k.ToUnderlyingAssetAmount(ctx, vault, in)
 	if err != nil {
@@ -138,12 +160,18 @@ func (k Keeper) ConvertDepositToSharesInUnderlyingAsset(ctx sdk.Context, vault t
 	return utils.CalculateSharesFromAssets(valInAsset, tvv, totalShares, vault.ShareDenom)
 }
 
-// ConvertSharesToRedeemCoin converts a share amount into a payout coin in redeemDenom.
-// Steps:
-//  1. Convert shares → underlying amount via CalculateAssetsFromShares(shares, totalShares, TVV).
-//  2. Convert underlying → redeemDenom via FromUnderlyingAssetAmount (identity fast-path if same denom).
+// ConvertSharesToRedeemCoin converts a share amount into a payout coin in redeemDenom
+// using the current TVV and total share supply (both pro-rata, floor arithmetic).
 //
-// All arithmetic is integer with floor. If shares <= 0, returns a zero-amount coin.
+// Steps:
+//  1. Convert shares → underlying via
+//     CalculateAssetsFromShares(shares, totalShares, TVV)
+//     where TVV is from principal (marker) balances.
+//  2. Convert the resulting underlying amount to redeemDenom via FromUnderlyingAssetAmount
+//     (identity fast-path if redeemDenom == vault.UnderlyingAsset).
+//
+// Returns a coin in redeemDenom. This function performs calculation only; callers
+// must enforce liquidity/policy. If shares <= 0, returns a zero-amount coin.
 func (k Keeper) ConvertSharesToRedeemCoin(ctx sdk.Context, vault types.VaultAccount, shares math.Int, redeemDenom string) (sdk.Coin, error) {
 	if !shares.IsPositive() {
 		return sdk.NewCoin(redeemDenom, math.ZeroInt()), nil

--- a/keeper/valuation_engine_test.go
+++ b/keeper/valuation_engine_test.go
@@ -103,6 +103,19 @@ func (s *TestSuite) TestToUnderlyingAssetAmount() {
 	s.Require().Contains(err.Error(), "nav not found", "error should mention missing NAV")
 }
 
+func (s *TestSuite) TestToUnderlyingAssetAmount_IdentityFastPath() {
+	underlyingDenom := "ylds"
+	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 1_000_000), s.adminAddr)
+
+	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
+	vaultAccount := types.VaultAccount{ShareDenom: "vshare", UnderlyingAsset: underlyingDenom}
+
+	inputAmount := int64(123456789)
+	outAmount, err := testKeeper.ToUnderlyingAssetAmount(s.ctx, vaultAccount, sdk.NewInt64Coin(underlyingDenom, inputAmount))
+	s.Require().NoError(err, "identity conversion to underlying should not error for denom %s", underlyingDenom)
+	s.Require().Equal(math.NewInt(inputAmount), outAmount, "identity conversion should preserve the input amount for denom %s", underlyingDenom)
+}
+
 func (s *TestSuite) TestFromUnderlyingAssetAmount() {
 	underlyingDenom := "ylds"
 	paymentDenom := "usdc"
@@ -173,6 +186,31 @@ func (s *TestSuite) TestFromUnderlyingAssetAmount() {
 		}, "test"),
 		"should restore valid NAV",
 	)
+}
+
+func (s *TestSuite) TestFromUnderlyingAssetAmount_NegativeUnderlyingYieldsZero() {
+	underlyingDenom := "ylds"
+	paymentDenom := "usdc"
+
+	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
+	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 2_000_000), s.adminAddr)
+
+	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
+	paymentMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentMarkerAddr)
+	s.Require().NoError(err, "fetching payment marker account should succeed")
+
+	s.Require().NoError(
+		s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{Price: sdk.NewInt64Coin(underlyingDenom, 1), Volume: 2}, "set NAV 1/2"),
+		"setting NAV for %s should succeed", paymentDenom,
+	)
+
+	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
+	vaultAccount := types.VaultAccount{ShareDenom: "vshare", UnderlyingAsset: underlyingDenom}
+
+	outCoin, err := testKeeper.FromUnderlyingAssetAmount(s.ctx, vaultAccount, math.NewInt(-5), paymentDenom)
+	s.Require().NoError(err, "converting negative underlying amount should not error and should yield a zero coin")
+	s.Require().Equal(paymentDenom, outCoin.Denom, "output denom should match requested payout denom")
+	s.Require().True(outCoin.IsZero(), "output coin should be zero when underlying amount is non-positive")
 }
 
 func (s *TestSuite) TestGetTVVInUnderlyingAsset_ExcludesSharesAndSumsInAsset() {
@@ -266,6 +304,92 @@ func (s *TestSuite) TestGetTVVInUnderlyingAsset_ErrorPropagation() {
 
 	s.Require().Error(err, "get TVV should fail when an asset is missing a NAV")
 	s.Require().Contains(err.Error(), "nav not found for euro/ylds", "error should propagate from the missing NAV")
+}
+
+func (s *TestSuite) TestGetTVVInUnderlyingAsset_MultiDenomFlooring() {
+	underlyingDenom := "ylds"
+	paymentADenom := "usdc"
+	paymentBDenom := "eurc"
+	shareDenom := "vshare"
+
+	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
+	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentADenom, 2_000_000), s.adminAddr)
+	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentBDenom, 2_000_000), s.adminAddr)
+
+	paymentAMarkerAddr := markertypes.MustGetMarkerAddress(paymentADenom)
+	paymentAMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentAMarkerAddr)
+	s.Require().NoError(err, "fetching payment A marker account should succeed")
+
+	paymentBMarkerAddr := markertypes.MustGetMarkerAddress(paymentBDenom)
+	paymentBMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentBMarkerAddr)
+	s.Require().NoError(err, "fetching payment B marker account should succeed")
+
+	s.Require().NoError(
+		s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentAMarkerAccount, markertypes.NetAssetValue{Price: sdk.NewInt64Coin(underlyingDenom, 1), Volume: 3}, "set NAV A 1/3"),
+		"setting NAV for %s should succeed", paymentADenom,
+	)
+	s.Require().NoError(
+		s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentBMarkerAccount, markertypes.NetAssetValue{Price: sdk.NewInt64Coin(underlyingDenom, 2), Volume: 3}, "set NAV B 2/3"),
+		"setting NAV for %s should succeed", paymentBDenom,
+	)
+
+	vaultAccount, err := s.k.CreateVault(s.ctx, vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom})
+	s.Require().NoError(err, "vault creation should succeed for multi-denom TVV test")
+
+	withdrawForFunding := sdk.NewCoins(
+		sdk.NewInt64Coin(underlyingDenom, 1),
+		sdk.NewInt64Coin(paymentADenom, 4),
+		sdk.NewInt64Coin(paymentBDenom, 5),
+	)
+	s.Require().NoError(
+		s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, underlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 1))),
+		"withdrawing underlying to admin should succeed for TVV funding",
+	)
+	s.Require().NoError(
+		s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentADenom, sdk.NewCoins(sdk.NewInt64Coin(paymentADenom, 4))),
+		"withdrawing payment A to admin should succeed for TVV funding",
+	)
+	s.Require().NoError(
+		s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentBDenom, sdk.NewCoins(sdk.NewInt64Coin(paymentBDenom, 5))),
+		"withdrawing payment B to admin should succeed for TVV funding",
+	)
+	s.Require().NoError(
+		s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vaultAccount.PrincipalMarkerAddress(), withdrawForFunding),
+		"sending mixed funding to principal should succeed",
+	)
+
+	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
+	tvv, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vaultAccount)
+	s.Require().NoError(err, "computing TVV with multiple NAV mappings should not error")
+	s.Require().Equal(
+		math.NewInt(5),
+		tvv,
+		"TVV should equal 1 underlying + floor(4*1/3)=1 + floor(5*2/3)=3 => total 5",
+	)
+}
+
+func (s *TestSuite) TestGetTVVInUnderlyingAsset_ExcludesReserves() {
+	underlyingDenom := "ylds"
+	shareDenom := "vshare"
+
+	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
+
+	vaultAccount, err := s.k.CreateVault(s.ctx, vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom})
+	s.Require().NoError(err, "vault creation should succeed for reserves exclusion test")
+
+	s.Require().NoError(
+		s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, underlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 999))),
+		"withdrawing underlying to admin should succeed to fund reserves",
+	)
+	s.Require().NoError(
+		s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vaultAccount.GetAddress(), sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 999))),
+		"sending funds to the vault account (reserves) should succeed",
+	)
+
+	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
+	tvv, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vaultAccount)
+	s.Require().NoError(err, "computing TVV should not error when only reserves are funded")
+	s.Require().True(tvv.IsZero(), "TVV should be zero because reserves are excluded and principal is unfunded")
 }
 
 func (s *TestSuite) TestGetNAVPerShareInUnderlyingAsset_FloorsToZeroForTinyPerShare() {
@@ -484,19 +608,6 @@ func (s *TestSuite) TestConvertSharesToRedeemCoin_ZeroAndDustRedemption() {
 	s.Require().True(dustCoin.IsZero(), "dust redemption should floor to a zero coin")
 }
 
-func (s *TestSuite) TestToUnderlyingAssetAmount_IdentityFastPath() {
-	underlyingDenom := "ylds"
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 1_000_000), s.adminAddr)
-
-	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	vaultAccount := types.VaultAccount{ShareDenom: "vshare", UnderlyingAsset: underlyingDenom}
-
-	inputAmount := int64(123456789)
-	outAmount, err := testKeeper.ToUnderlyingAssetAmount(s.ctx, vaultAccount, sdk.NewInt64Coin(underlyingDenom, inputAmount))
-	s.Require().NoError(err, "identity conversion to underlying should not error for denom %s", underlyingDenom)
-	s.Require().Equal(math.NewInt(inputAmount), outAmount, "identity conversion should preserve the input amount for denom %s", underlyingDenom)
-}
-
 func (s *TestSuite) TestConvertSharesToRedeemCoin_TVVZero_SupplyNonzero() {
 	underlyingDenom := "ylds"
 	shareDenom := "vshare"
@@ -517,115 +628,4 @@ func (s *TestSuite) TestConvertSharesToRedeemCoin_TVVZero_SupplyNonzero() {
 	s.Require().NoError(err, "redeeming with TVV=0 and shares>0 should not error")
 	s.Require().Equal(underlyingDenom, redeemCoin.Denom, "redeem denom should be the underlying asset")
 	s.Require().True(redeemCoin.Amount.IsZero(), "redeemed amount should be zero when TVV is zero")
-}
-
-func (s *TestSuite) TestGetTVVInUnderlyingAsset_MultiDenomFlooring() {
-	underlyingDenom := "ylds"
-	paymentADenom := "usdc"
-	paymentBDenom := "eurc"
-	shareDenom := "vshare"
-
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentADenom, 2_000_000), s.adminAddr)
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentBDenom, 2_000_000), s.adminAddr)
-
-	paymentAMarkerAddr := markertypes.MustGetMarkerAddress(paymentADenom)
-	paymentAMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentAMarkerAddr)
-	s.Require().NoError(err, "fetching payment A marker account should succeed")
-
-	paymentBMarkerAddr := markertypes.MustGetMarkerAddress(paymentBDenom)
-	paymentBMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentBMarkerAddr)
-	s.Require().NoError(err, "fetching payment B marker account should succeed")
-
-	s.Require().NoError(
-		s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentAMarkerAccount, markertypes.NetAssetValue{Price: sdk.NewInt64Coin(underlyingDenom, 1), Volume: 3}, "set NAV A 1/3"),
-		"setting NAV for %s should succeed", paymentADenom,
-	)
-	s.Require().NoError(
-		s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentBMarkerAccount, markertypes.NetAssetValue{Price: sdk.NewInt64Coin(underlyingDenom, 2), Volume: 3}, "set NAV B 2/3"),
-		"setting NAV for %s should succeed", paymentBDenom,
-	)
-
-	vaultAccount, err := s.k.CreateVault(s.ctx, vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom})
-	s.Require().NoError(err, "vault creation should succeed for multi-denom TVV test")
-
-	withdrawForFunding := sdk.NewCoins(
-		sdk.NewInt64Coin(underlyingDenom, 1),
-		sdk.NewInt64Coin(paymentADenom, 4),
-		sdk.NewInt64Coin(paymentBDenom, 5),
-	)
-	s.Require().NoError(
-		s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, underlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 1))),
-		"withdrawing underlying to admin should succeed for TVV funding",
-	)
-	s.Require().NoError(
-		s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentADenom, sdk.NewCoins(sdk.NewInt64Coin(paymentADenom, 4))),
-		"withdrawing payment A to admin should succeed for TVV funding",
-	)
-	s.Require().NoError(
-		s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentBDenom, sdk.NewCoins(sdk.NewInt64Coin(paymentBDenom, 5))),
-		"withdrawing payment B to admin should succeed for TVV funding",
-	)
-	s.Require().NoError(
-		s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vaultAccount.PrincipalMarkerAddress(), withdrawForFunding),
-		"sending mixed funding to principal should succeed",
-	)
-
-	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	tvv, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vaultAccount)
-	s.Require().NoError(err, "computing TVV with multiple NAV mappings should not error")
-	s.Require().Equal(
-		math.NewInt(5),
-		tvv,
-		"TVV should equal 1 underlying + floor(4*1/3)=1 + floor(5*2/3)=3 => total 5",
-	)
-}
-
-func (s *TestSuite) TestGetTVVInUnderlyingAsset_ExcludesReserves() {
-	underlyingDenom := "ylds"
-	shareDenom := "vshare"
-
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-
-	vaultAccount, err := s.k.CreateVault(s.ctx, vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom})
-	s.Require().NoError(err, "vault creation should succeed for reserves exclusion test")
-
-	s.Require().NoError(
-		s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, underlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 999))),
-		"withdrawing underlying to admin should succeed to fund reserves",
-	)
-	s.Require().NoError(
-		s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vaultAccount.GetAddress(), sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 999))),
-		"sending funds to the vault account (reserves) should succeed",
-	)
-
-	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	tvv, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vaultAccount)
-	s.Require().NoError(err, "computing TVV should not error when only reserves are funded")
-	s.Require().True(tvv.IsZero(), "TVV should be zero because reserves are excluded and principal is unfunded")
-}
-
-func (s *TestSuite) TestFromUnderlyingAssetAmount_NegativeUnderlyingYieldsZero() {
-	underlyingDenom := "ylds"
-	paymentDenom := "usdc"
-
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 2_000_000), s.adminAddr)
-
-	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
-	paymentMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentMarkerAddr)
-	s.Require().NoError(err, "fetching payment marker account should succeed")
-
-	s.Require().NoError(
-		s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{Price: sdk.NewInt64Coin(underlyingDenom, 1), Volume: 2}, "set NAV 1/2"),
-		"setting NAV for %s should succeed", paymentDenom,
-	)
-
-	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	vaultAccount := types.VaultAccount{ShareDenom: "vshare", UnderlyingAsset: underlyingDenom}
-
-	outCoin, err := testKeeper.FromUnderlyingAssetAmount(s.ctx, vaultAccount, math.NewInt(-5), paymentDenom)
-	s.Require().NoError(err, "converting negative underlying amount should not error and should yield a zero coin")
-	s.Require().Equal(paymentDenom, outCoin.Denom, "output denom should match requested payout denom")
-	s.Require().True(outCoin.IsZero(), "output coin should be zero when underlying amount is non-positive")
 }

--- a/keeper/valuation_engine_test.go
+++ b/keeper/valuation_engine_test.go
@@ -14,19 +14,8 @@ import (
 func (s *TestSuite) TestUnitPriceFraction_Table() {
 	underlyingDenom := "ylds"
 	paymentDenom := "usdc"
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 2_000_000), s.adminAddr)
-
-	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
-	paymentMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentMarkerAddr)
-	s.Require().NoError(err, "should fetch payment marker account for NAV setup")
-	navRecord := markertypes.NetAssetValue{
-		Price:  sdk.NewInt64Coin(underlyingDenom, 1),
-		Volume: 2,
-	}
-	s.Require().NoError(s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, navRecord, "test"), "should set NAV usdc->ylds=1/2")
-
-	vaultAccount := &types.VaultAccount{ShareDenom: "vshare", UnderlyingAsset: underlyingDenom}
+	shareDenom := "vshare"
+	s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
 
 	cases := []struct {
 		name                  string
@@ -54,11 +43,6 @@ func (s *TestSuite) TestUnitPriceFraction_Table() {
 			s.Require().Equal(math.NewInt(scenario.expectedNumerator), numerator, "numerator should match expected")
 			s.Require().Equal(math.NewInt(scenario.expectedDenominator), denominator, "denominator should match expected")
 			s.Require().True(denominator.IsPositive(), "denominator should be > 0")
-
-			if scenario.fromDenom == vaultAccount.UnderlyingAsset {
-				s.Require().Equal(math.NewInt(1), numerator, "identity numerator should be 1")
-				s.Require().Equal(math.NewInt(1), denominator, "identity denominator should be 1")
-			}
 		})
 	}
 }
@@ -66,52 +50,36 @@ func (s *TestSuite) TestUnitPriceFraction_Table() {
 func (s *TestSuite) TestToUnderlyingAssetAmount() {
 	underlyingDenom := "ylds"
 	paymentDenom := "usdc"
-	share := "vshare"
-
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 2_000_000), s.adminAddr)
-
-	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
-	paymentMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentMarkerAddr)
-	s.Require().NoError(err, "should fetch payment marker for NAV setup")
-
-	s.Require().NoError(
-		s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{
-			Price:  sdk.NewInt64Coin(underlyingDenom, 1),
-			Volume: 2,
-		}, "test"),
-		"should set NAV usdc->ylds=1/2",
-	)
+	shareDenom := "vshare"
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
 
 	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	v := types.VaultAccount{ShareDenom: share, UnderlyingAsset: underlyingDenom}
 
-	val, err := testKeeper.ToUnderlyingAssetAmount(s.ctx, v, sdk.NewInt64Coin(paymentDenom, 4))
+	val, err := testKeeper.ToUnderlyingAssetAmount(s.ctx, *vault, sdk.NewInt64Coin(paymentDenom, 4))
 	s.Require().NoError(err, "to-underlying should succeed for valid NAV")
 	s.Require().Equal(math.NewInt(2), val, "4 usdc at 1/2 should be 2 ylds")
 
-	valFloor, err := testKeeper.ToUnderlyingAssetAmount(s.ctx, v, sdk.NewInt64Coin(paymentDenom, 5))
+	valFloor, err := testKeeper.ToUnderlyingAssetAmount(s.ctx, *vault, sdk.NewInt64Coin(paymentDenom, 5))
 	s.Require().NoError(err, "to-underlying with floor should succeed")
 	s.Require().Equal(math.NewInt(2), valFloor, "5 usdc at 1/2 should floor to 2 ylds (not 2.5)")
 
-	valZero, err := testKeeper.ToUnderlyingAssetAmount(s.ctx, v, sdk.NewInt64Coin(paymentDenom, 0))
+	valZero, err := testKeeper.ToUnderlyingAssetAmount(s.ctx, *vault, sdk.NewInt64Coin(paymentDenom, 0))
 	s.Require().NoError(err, "to-underlying with zero amount should succeed")
 	s.Require().Equal(math.ZeroInt(), valZero, "0 usdc should convert to 0 ylds")
 
-	_, err = testKeeper.ToUnderlyingAssetAmount(s.ctx, v, sdk.NewInt64Coin("unknown", 5))
+	_, err = testKeeper.ToUnderlyingAssetAmount(s.ctx, *vault, sdk.NewInt64Coin("unknown", 5))
 	s.Require().Error(err, "should error when NAV missing for input denom")
 	s.Require().Contains(err.Error(), "nav not found", "error should mention missing NAV")
 }
 
 func (s *TestSuite) TestToUnderlyingAssetAmount_IdentityFastPath() {
 	underlyingDenom := "ylds"
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 1_000_000), s.adminAddr)
+	shareDenom := "vshare"
+	vault := s.setupBaseVault(underlyingDenom, shareDenom)
 
 	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	vaultAccount := types.VaultAccount{ShareDenom: "vshare", UnderlyingAsset: underlyingDenom}
-
 	inputAmount := int64(123456789)
-	outAmount, err := testKeeper.ToUnderlyingAssetAmount(s.ctx, vaultAccount, sdk.NewInt64Coin(underlyingDenom, inputAmount))
+	outAmount, err := testKeeper.ToUnderlyingAssetAmount(s.ctx, *vault, sdk.NewInt64Coin(underlyingDenom, inputAmount))
 	s.Require().NoError(err, "identity conversion to underlying should not error for denom %s", underlyingDenom)
 	s.Require().Equal(math.NewInt(inputAmount), outAmount, "identity conversion should preserve the input amount for denom %s", underlyingDenom)
 }
@@ -119,52 +87,40 @@ func (s *TestSuite) TestToUnderlyingAssetAmount_IdentityFastPath() {
 func (s *TestSuite) TestFromUnderlyingAssetAmount() {
 	underlyingDenom := "ylds"
 	paymentDenom := "usdc"
-
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 2_000_000), s.adminAddr)
-
-	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
-	paymentMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentMarkerAddr)
-	s.Require().NoError(err, "should fetch payment marker account for NAV setup")
-
-	s.Require().NoError(
-		s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{
-			Price:  sdk.NewInt64Coin(underlyingDenom, 1),
-			Volume: 2,
-		}, "test"),
-		"should set NAV usdc->ylds=1/2",
-	)
+	shareDenom := "vshare"
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
 
 	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	v := types.VaultAccount{ShareDenom: "vshare", UnderlyingAsset: underlyingDenom}
 
-	out1, err := testKeeper.FromUnderlyingAssetAmount(s.ctx, v, math.NewInt(3), underlyingDenom)
+	out1, err := testKeeper.FromUnderlyingAssetAmount(s.ctx, *vault, math.NewInt(3), underlyingDenom)
 	s.Require().NoError(err, "from-underlying identity should succeed")
 	s.Require().Equal(underlyingDenom, out1.Denom, "identity denom should be underlying")
 	s.Require().Equal(math.NewInt(3), out1.Amount, "identity amount should match input")
 
-	out2, err := testKeeper.FromUnderlyingAssetAmount(s.ctx, v, math.NewInt(3), paymentDenom)
+	out2, err := testKeeper.FromUnderlyingAssetAmount(s.ctx, *vault, math.NewInt(3), paymentDenom)
 	s.Require().NoError(err, "from-underlying to payment should succeed")
 	s.Require().Equal(paymentDenom, out2.Denom, "output denom should be payment")
 	s.Require().Equal(math.NewInt(6), out2.Amount, "3 underlying at 1/2 asset per 1 payment yields 6 payment")
 
+	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
+	paymentMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentMarkerAddr)
+	s.Require().NoError(err, "should fetch payment marker account for NAV setup")
 	s.Require().NoError(
 		s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{
 			Price:  sdk.NewInt64Coin(underlyingDenom, 3),
 			Volume: 2,
-		}, "test"),
-		"should set NAV usdc->ylds=3/2",
-	)
-	outFloor, err := testKeeper.FromUnderlyingAssetAmount(s.ctx, v, math.NewInt(4), paymentDenom)
+		}, "test"), "should set NAV usdc->ylds=3/2")
+
+	outFloor, err := testKeeper.FromUnderlyingAssetAmount(s.ctx, *vault, math.NewInt(4), paymentDenom)
 	s.Require().NoError(err, "from-underlying with floor should succeed")
 	s.Require().Equal(paymentDenom, outFloor.Denom, "output denom should be payment")
 	s.Require().Equal(math.NewInt(2), outFloor.Amount, "4 underlying at 3/2 asset per 1 payment yields 2 payment (floored from 2.66)")
 
-	outZero, err := testKeeper.FromUnderlyingAssetAmount(s.ctx, v, math.ZeroInt(), paymentDenom)
+	outZero, err := testKeeper.FromUnderlyingAssetAmount(s.ctx, *vault, math.ZeroInt(), paymentDenom)
 	s.Require().NoError(err, "zero underlying should not error")
 	s.Require().Equal(math.ZeroInt(), outZero.Amount, "zero underlying should yield zero output")
 
-	_, err = testKeeper.FromUnderlyingAssetAmount(s.ctx, v, math.NewInt(5), "unknown")
+	_, err = testKeeper.FromUnderlyingAssetAmount(s.ctx, *vault, math.NewInt(5), "unknown")
 	s.Require().Error(err, "should error when NAV missing for output denom")
 	s.Require().Contains(err.Error(), "nav not found", "error should mention missing NAV")
 
@@ -172,40 +128,20 @@ func (s *TestSuite) TestFromUnderlyingAssetAmount() {
 		s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{
 			Price:  sdk.NewInt64Coin(underlyingDenom, 0),
 			Volume: 2,
-		}, "test"),
-		"should set zero-price NAV",
-	)
-	_, err = testKeeper.FromUnderlyingAssetAmount(s.ctx, v, math.NewInt(5), paymentDenom)
+		}, "test"), "should set zero-price NAV")
+	_, err = testKeeper.FromUnderlyingAssetAmount(s.ctx, *vault, math.NewInt(5), paymentDenom)
 	s.Require().Error(err, "should error when price is zero")
 	s.Require().Contains(err.Error(), "zero price", "error should indicate zero price")
-
-	s.Require().NoError(
-		s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{
-			Price:  sdk.NewInt64Coin(underlyingDenom, 1),
-			Volume: 2,
-		}, "test"),
-		"should restore valid NAV",
-	)
 }
 
 func (s *TestSuite) TestFromUnderlyingAssetAmount_NegativeUnderlyingYieldsZero() {
 	underlyingDenom := "ylds"
 	paymentDenom := "usdc"
-
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 2_000_000), s.adminAddr)
-
-	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
-	paymentMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentMarkerAddr)
-	s.Require().NoError(err, "fetching payment marker account should succeed")
-
-	s.Require().NoError(
-		s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{Price: sdk.NewInt64Coin(underlyingDenom, 1), Volume: 2}, "set NAV 1/2"),
-		"setting NAV for %s should succeed", paymentDenom,
-	)
+	shareDenom := "vshare"
+	s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
 
 	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	vaultAccount := types.VaultAccount{ShareDenom: "vshare", UnderlyingAsset: underlyingDenom}
+	vaultAccount := types.VaultAccount{ShareDenom: shareDenom, UnderlyingAsset: underlyingDenom}
 
 	outCoin, err := testKeeper.FromUnderlyingAssetAmount(s.ctx, vaultAccount, math.NewInt(-5), paymentDenom)
 	s.Require().NoError(err, "converting negative underlying amount should not error and should yield a zero coin")
@@ -217,24 +153,9 @@ func (s *TestSuite) TestGetTVVInUnderlyingAsset_ExcludesSharesAndSumsInAsset() {
 	underlyingDenom := "ylds"
 	paymentDenom := "usdc"
 	shareDenom := "vshare"
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, underlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 100_000)))
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 2_000_000), s.adminAddr)
-	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentDenom, sdk.NewCoins(sdk.NewInt64Coin(paymentDenom, 100_000)))
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
 
-	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
-	paymentMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentMarkerAddr)
-	s.Require().NoError(err, "should fetch payment marker for NAV setup")
-	s.Require().NoError(s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{
-		Price:  sdk.NewInt64Coin(underlyingDenom, 1),
-		Volume: 2,
-	}, "test"), "should set NAV usdc->ylds=1/2")
-
-	vaultCfg := vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom}
-	vault, err := s.k.CreateVault(s.ctx, vaultCfg)
-	s.Require().NoError(err, "vault creation should succeed")
-
-	principalAddress := markertypes.MustGetMarkerAddress(shareDenom)
+	principalAddress := vault.PrincipalMarkerAddress()
 	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, principalAddress, sdk.NewCoins(
 		sdk.NewInt64Coin(underlyingDenom, 1000),
 		sdk.NewInt64Coin(paymentDenom, 10),
@@ -249,20 +170,14 @@ func (s *TestSuite) TestGetTVVInUnderlyingAsset_ExcludesSharesAndSumsInAsset() {
 func (s *TestSuite) TestGetTVVInUnderlyingAsset_EmptyAndSharesOnly() {
 	underlyingDenom := "ylds"
 	shareDenom := "vshare"
+	vault := s.setupBaseVault(underlyingDenom, shareDenom)
 
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-
-	vaultCfg := vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom}
-	vault, err := s.k.CreateVault(s.ctx, vaultCfg)
-	s.Require().NoError(err, "vault creation should succeed")
 	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-
 	tvvEmpty, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vault)
 	s.Require().NoError(err, "get TVV of empty vault should succeed")
 	s.Require().Equal(math.ZeroInt(), tvvEmpty, "TVV of empty vault should be zero")
 
 	s.Require().NoError(s.k.MarkerKeeper.MintCoin(s.ctx, vault.GetAddress(), sdk.NewInt64Coin(shareDenom, 1000)), "should mint shares")
-
 	tvvSharesOnly, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vault)
 	s.Require().NoError(err, "get TVV of shares-only vault should succeed")
 	s.Require().Equal(math.ZeroInt(), tvvSharesOnly, "TVV of shares-only vault should be zero")
@@ -273,25 +188,10 @@ func (s *TestSuite) TestGetTVVInUnderlyingAsset_ErrorPropagation() {
 	paymentDenomWithNAV := "usdc"
 	paymentDenomWithoutNAV := "euro"
 	shareDenom := "vshare"
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenomWithNAV, 1, 2)
 
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenomWithNAV, 2_000_000), s.adminAddr)
 	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenomWithoutNAV, 2_000_000), s.adminAddr)
-
-	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentDenomWithNAV, sdk.NewCoins(sdk.NewInt64Coin(paymentDenomWithNAV, 100_000)))
 	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentDenomWithoutNAV, sdk.NewCoins(sdk.NewInt64Coin(paymentDenomWithoutNAV, 100_000)))
-
-	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenomWithNAV)
-	paymentMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentMarkerAddr)
-	s.Require().NoError(err, "should fetch payment marker for NAV setup")
-	s.Require().NoError(s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{
-		Price:  sdk.NewInt64Coin(underlyingDenom, 1),
-		Volume: 2,
-	}, "test"), "should set NAV usdc->ylds=1/2")
-
-	vaultCfg := vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom}
-	vault, err := s.k.CreateVault(s.ctx, vaultCfg)
-	s.Require().NoError(err, "vault creation should succeed")
 
 	principalAddress := vault.PrincipalMarkerAddress()
 	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, principalAddress, sdk.NewCoins(
@@ -300,8 +200,7 @@ func (s *TestSuite) TestGetTVVInUnderlyingAsset_ErrorPropagation() {
 	)), "should fund vault with both valid and invalid assets")
 
 	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	_, err = testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vault)
-
+	_, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vault)
 	s.Require().Error(err, "get TVV should fail when an asset is missing a NAV")
 	s.Require().Contains(err.Error(), "nav not found for euro/ylds", "error should propagate from the missing NAV")
 }
@@ -315,79 +214,49 @@ func (s *TestSuite) TestGetTVVInUnderlyingAsset_MultiDenomFlooring() {
 	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
 	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentADenom, 2_000_000), s.adminAddr)
 	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentBDenom, 2_000_000), s.adminAddr)
+	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, underlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 1)))
+	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentADenom, sdk.NewCoins(sdk.NewInt64Coin(paymentADenom, 4)))
+	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentBDenom, sdk.NewCoins(sdk.NewInt64Coin(paymentBDenom, 5)))
 
 	paymentAMarkerAddr := markertypes.MustGetMarkerAddress(paymentADenom)
 	paymentAMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentAMarkerAddr)
 	s.Require().NoError(err, "fetching payment A marker account should succeed")
-
 	paymentBMarkerAddr := markertypes.MustGetMarkerAddress(paymentBDenom)
 	paymentBMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentBMarkerAddr)
 	s.Require().NoError(err, "fetching payment B marker account should succeed")
 
 	s.Require().NoError(
 		s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentAMarkerAccount, markertypes.NetAssetValue{Price: sdk.NewInt64Coin(underlyingDenom, 1), Volume: 3}, "set NAV A 1/3"),
-		"setting NAV for %s should succeed", paymentADenom,
-	)
+		"setting NAV for %s should succeed", paymentADenom)
 	s.Require().NoError(
 		s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentBMarkerAccount, markertypes.NetAssetValue{Price: sdk.NewInt64Coin(underlyingDenom, 2), Volume: 3}, "set NAV B 2/3"),
-		"setting NAV for %s should succeed", paymentBDenom,
-	)
+		"setting NAV for %s should succeed", paymentBDenom)
 
 	vaultAccount, err := s.k.CreateVault(s.ctx, vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom})
 	s.Require().NoError(err, "vault creation should succeed for multi-denom TVV test")
 
-	withdrawForFunding := sdk.NewCoins(
+	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vaultAccount.PrincipalMarkerAddress(), sdk.NewCoins(
 		sdk.NewInt64Coin(underlyingDenom, 1),
 		sdk.NewInt64Coin(paymentADenom, 4),
 		sdk.NewInt64Coin(paymentBDenom, 5),
-	)
-	s.Require().NoError(
-		s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, underlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 1))),
-		"withdrawing underlying to admin should succeed for TVV funding",
-	)
-	s.Require().NoError(
-		s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentADenom, sdk.NewCoins(sdk.NewInt64Coin(paymentADenom, 4))),
-		"withdrawing payment A to admin should succeed for TVV funding",
-	)
-	s.Require().NoError(
-		s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentBDenom, sdk.NewCoins(sdk.NewInt64Coin(paymentBDenom, 5))),
-		"withdrawing payment B to admin should succeed for TVV funding",
-	)
-	s.Require().NoError(
-		s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vaultAccount.PrincipalMarkerAddress(), withdrawForFunding),
-		"sending mixed funding to principal should succeed",
-	)
+	)), "sending mixed funding to principal should succeed")
 
 	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
 	tvv, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vaultAccount)
 	s.Require().NoError(err, "computing TVV with multiple NAV mappings should not error")
-	s.Require().Equal(
-		math.NewInt(5),
-		tvv,
-		"TVV should equal 1 underlying + floor(4*1/3)=1 + floor(5*2/3)=3 => total 5",
-	)
+	s.Require().Equal(math.NewInt(5), tvv, "TVV should equal 1 underlying + floor(4*1/3)=1 + floor(5*2/3)=3 => total 5")
 }
 
 func (s *TestSuite) TestGetTVVInUnderlyingAsset_ExcludesReserves() {
 	underlyingDenom := "ylds"
 	shareDenom := "vshare"
+	vault := s.setupBaseVault(underlyingDenom, shareDenom)
 
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-
-	vaultAccount, err := s.k.CreateVault(s.ctx, vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom})
-	s.Require().NoError(err, "vault creation should succeed for reserves exclusion test")
-
-	s.Require().NoError(
-		s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, underlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 999))),
-		"withdrawing underlying to admin should succeed to fund reserves",
-	)
-	s.Require().NoError(
-		s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vaultAccount.GetAddress(), sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 999))),
-		"sending funds to the vault account (reserves) should succeed",
-	)
+	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vault.GetAddress(), sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 999))),
+		"sending funds to the vault account (reserves) should succeed")
 
 	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	tvv, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vaultAccount)
+	tvv, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vault)
 	s.Require().NoError(err, "computing TVV should not error when only reserves are funded")
 	s.Require().True(tvv.IsZero(), "TVV should be zero because reserves are excluded and principal is unfunded")
 }
@@ -396,25 +265,9 @@ func (s *TestSuite) TestGetNAVPerShareInUnderlyingAsset_FloorsToZeroForTinyPerSh
 	underlyingDenom := "ylds"
 	paymentDenom := "usdc"
 	shareDenom := "vshare"
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, underlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 100_000)))
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 2_000_000), s.adminAddr)
-	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentDenom, sdk.NewCoins(sdk.NewInt64Coin(paymentDenom, 100_000)))
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
 
-	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
-	paymentMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentMarkerAddr)
-	s.Require().NoError(err, "should fetch payment marker for NAV setup")
-	s.Require().NoError(s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{
-		Price:  sdk.NewInt64Coin(underlyingDenom, 1),
-		Volume: 2,
-	}, "test"), "should set NAV usdc->ylds=1/2")
-
-	vaultCfg := vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom}
-	vault, err := s.k.CreateVault(s.ctx, vaultCfg)
-	s.Require().NoError(err, "vault creation should succeed")
-
-	vaultMarkerAddress := markertypes.MustGetMarkerAddress(shareDenom)
-	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vaultMarkerAddress, sdk.NewCoins(
+	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vault.PrincipalMarkerAddress(), sdk.NewCoins(
 		sdk.NewInt64Coin(underlyingDenom, 1000),
 		sdk.NewInt64Coin(paymentDenom, 10),
 	)), "should fund vault marker for NAV calc")
@@ -432,18 +285,13 @@ func (s *TestSuite) TestGetNAVPerShareInUnderlyingAsset_FloorsToZeroForTinyPerSh
 func (s *TestSuite) TestGetNAVPerShareInUnderlyingAsset_ZeroSupplyAndNormalNAV() {
 	underlyingDenom := "ylds"
 	shareDenom := "vshare"
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, underlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 100_000)))
+	vault := s.setupBaseVault(underlyingDenom, shareDenom)
 
-	vaultCfg := vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom}
-	vault, err := s.k.CreateVault(s.ctx, vaultCfg)
-	s.Require().NoError(err, "vault creation should succeed")
-	principalAddress := vault.PrincipalMarkerAddress()
 	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-
-	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, principalAddress, sdk.NewCoins(
+	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vault.PrincipalMarkerAddress(), sdk.NewCoins(
 		sdk.NewInt64Coin(underlyingDenom, 1000),
 	)), "should fund vault for TVV")
+
 	navPerShareZeroSupply, err := testKeeper.GetNAVPerShareInUnderlyingAsset(s.ctx, *vault)
 	s.Require().NoError(err, "should not error with zero share supply")
 	s.Require().Equal(math.ZeroInt(), navPerShareZeroSupply, "NAV per share should be zero with zero share supply")
@@ -458,34 +306,16 @@ func (s *TestSuite) TestConvertDepositToSharesInUnderlyingAsset_UsesNAV() {
 	underlyingDenom := "ylds"
 	paymentDenom := "usdc"
 	shareDenom := "vshare"
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
 
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, underlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 100_000)))
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 2_000_000), s.adminAddr)
-	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentDenom, sdk.NewCoins(sdk.NewInt64Coin(paymentDenom, 100_000)))
-
-	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
-	paymentMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentMarkerAddr)
-	s.Require().NoError(err, "should fetch payment marker for NAV setup")
-	s.Require().NoError(s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{
-		Price:  sdk.NewInt64Coin(underlyingDenom, 1),
-		Volume: 2,
-	}, "test"), "should set NAV usdc->ylds=1/2")
-
-	vaultCfg := vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom}
-	vault, err := s.k.CreateVault(s.ctx, vaultCfg)
-	s.Require().NoError(err, "vault creation should succeed")
-
-	principalAddress := markertypes.MustGetMarkerAddress(shareDenom)
-	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, principalAddress, sdk.NewCoins(
+	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
+	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vault.PrincipalMarkerAddress(), sdk.NewCoins(
 		sdk.NewInt64Coin(underlyingDenom, 1000),
 		sdk.NewInt64Coin(paymentDenom, 10),
 	)), "should fund vault marker for TVV")
 
-	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
 	tvv, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vault)
 	s.Require().NoError(err, "should compute TVV")
-
 	initialShares := tvv.Mul(utils.ShareScalar)
 	s.Require().NoError(
 		s.k.MarkerKeeper.MintCoin(s.ctx, vault.GetAddress(), sdk.NewCoin(shareDenom, initialShares)),
@@ -502,27 +332,23 @@ func (s *TestSuite) TestConvertDepositToSharesInUnderlyingAsset_InitialAndDustDe
 	underlyingDenom := "ylds"
 	paymentDenom := "usdc"
 	shareDenom := "vshare"
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, underlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 100_000)))
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 2_000_000), s.adminAddr)
+	vault := s.setupBaseVault(underlyingDenom, shareDenom)
+
 	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
+	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 2_000_000), s.adminAddr)
 	paymentMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentMarkerAddr)
 	s.Require().NoError(err, "should fetch payment marker for NAV setup")
 	s.Require().NoError(s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{
 		Price:  sdk.NewInt64Coin(underlyingDenom, 1),
 		Volume: 2_000_000_000,
 	}, "test"), "should set NAV usdc->ylds=1/2e9 (for dust test)")
-	vaultCfg := vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom}
-	vault, err := s.k.CreateVault(s.ctx, vaultCfg)
-	s.Require().NoError(err, "vault creation should succeed")
-	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	principalAddress := vault.PrincipalMarkerAddress()
 
+	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
 	initialDepositShares, err := testKeeper.ConvertDepositToSharesInUnderlyingAsset(s.ctx, *vault, sdk.NewInt64Coin(underlyingDenom, 100))
 	s.Require().NoError(err, "initial deposit should succeed")
 	s.Require().Equal(utils.ShareScalar.Mul(math.NewInt(100)), initialDepositShares.Amount, "initial deposit should mint shares at parity with ShareScalar")
 
-	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, principalAddress, sdk.NewCoins(
+	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vault.PrincipalMarkerAddress(), sdk.NewCoins(
 		sdk.NewInt64Coin(underlyingDenom, 1000),
 	)), "should fund vault for TVV")
 	s.Require().NoError(s.k.MarkerKeeper.MintCoin(s.ctx, vault.GetAddress(), sdk.NewCoin(shareDenom, math.NewInt(1))), "should add a single share to circulation")
@@ -535,25 +361,9 @@ func (s *TestSuite) TestConvertSharesToRedeemCoin_AssetAndPaymentPaths() {
 	underlyingDenom := "ylds"
 	paymentDenom := "usdc"
 	shareDenom := "vshare"
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, underlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 100_000)))
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 2_000_000), s.adminAddr)
-	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, paymentDenom, sdk.NewCoins(sdk.NewInt64Coin(paymentDenom, 100_000)))
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
 
-	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
-	paymentMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentMarkerAddr)
-	s.Require().NoError(err, "should fetch payment marker for NAV setup")
-	s.Require().NoError(s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{
-		Price:  sdk.NewInt64Coin(underlyingDenom, 1),
-		Volume: 2,
-	}, "test"), "should set NAV usdc->ylds=1/2")
-
-	vaultCfg := vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom}
-	vault, err := s.k.CreateVault(s.ctx, vaultCfg)
-	s.Require().NoError(err, "vault creation should succeed")
-
-	vaultPrincipalAddress := markertypes.MustGetMarkerAddress(shareDenom)
-	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vaultPrincipalAddress, sdk.NewCoins(
+	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vault.PrincipalMarkerAddress(), sdk.NewCoins(
 		sdk.NewInt64Coin(underlyingDenom, 1000),
 		sdk.NewInt64Coin(paymentDenom, 10),
 	)), "should fund vault with base and payment coins")
@@ -581,12 +391,8 @@ func (s *TestSuite) TestConvertSharesToRedeemCoin_AssetAndPaymentPaths() {
 func (s *TestSuite) TestConvertSharesToRedeemCoin_ZeroAndDustRedemption() {
 	underlyingDenom := "ylds"
 	shareDenom := "vshare"
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-	s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, s.adminAddr, underlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 100_000)))
+	vault := s.setupBaseVault(underlyingDenom, shareDenom)
 
-	vaultCfg := vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom}
-	vault, err := s.k.CreateVault(s.ctx, vaultCfg)
-	s.Require().NoError(err, "vault creation should succeed")
 	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
 
 	zeroCoin, err := testKeeper.ConvertSharesToRedeemCoin(s.ctx, *vault, math.ZeroInt(), underlyingDenom)
@@ -611,20 +417,16 @@ func (s *TestSuite) TestConvertSharesToRedeemCoin_ZeroAndDustRedemption() {
 func (s *TestSuite) TestConvertSharesToRedeemCoin_TVVZero_SupplyNonzero() {
 	underlyingDenom := "ylds"
 	shareDenom := "vshare"
-
-	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 2_000_000), s.adminAddr)
-
-	vaultAccount, err := s.k.CreateVault(s.ctx, vaultAttrs{admin: s.adminAddr.String(), share: shareDenom, underlying: underlyingDenom})
-	s.Require().NoError(err, "vault creation should succeed for share %s and underlying %s", shareDenom, underlyingDenom)
+	vault := s.setupBaseVault(underlyingDenom, shareDenom)
 
 	initialShareSupply := sdk.NewCoin(shareDenom, utils.ShareScalar)
 	s.Require().NoError(
-		s.k.MarkerKeeper.MintCoin(s.ctx, vaultAccount.GetAddress(), initialShareSupply),
+		s.k.MarkerKeeper.MintCoin(s.ctx, vault.GetAddress(), initialShareSupply),
 		"minting initial shares while TVV is zero should succeed",
 	)
 
 	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	redeemCoin, err := testKeeper.ConvertSharesToRedeemCoin(s.ctx, *vaultAccount, utils.ShareScalar, underlyingDenom)
+	redeemCoin, err := testKeeper.ConvertSharesToRedeemCoin(s.ctx, *vault, utils.ShareScalar, underlyingDenom)
 	s.Require().NoError(err, "redeeming with TVV=0 and shares>0 should not error")
 	s.Require().Equal(underlyingDenom, redeemCoin.Denom, "redeem denom should be the underlying asset")
 	s.Require().True(redeemCoin.Amount.IsZero(), "redeemed amount should be zero when TVV is zero")

--- a/keeper/vault.go
+++ b/keeper/vault.go
@@ -183,7 +183,7 @@ func (k *Keeper) SwapIn(ctx sdk.Context, vaultAddr, recipient sdk.AccAddress, as
 		return nil, fmt.Errorf("failed to reconcile vault interest: %w", err)
 	}
 
-	markerAddr := markertypes.MustGetMarkerAddress(vault.ShareDenom)
+	markerAddr := vault.PrincipalMarkerAddress()
 
 	shares, err := k.ConvertDepositToSharesInUnderlyingAsset(ctx, *vault, asset)
 	if err != nil {

--- a/keeper/vault.go
+++ b/keeper/vault.go
@@ -183,7 +183,7 @@ func (k *Keeper) SwapIn(ctx sdk.Context, vaultAddr, recipient sdk.AccAddress, as
 		return nil, fmt.Errorf("failed to reconcile vault interest: %w", err)
 	}
 
-	markerAddr := vault.PrincipalMarkerAddress()
+	principalAddress := vault.PrincipalMarkerAddress()
 
 	shares, err := k.ConvertDepositToSharesInUnderlyingAsset(ctx, *vault, asset)
 	if err != nil {
@@ -202,7 +202,7 @@ func (k *Keeper) SwapIn(ctx sdk.Context, vaultAddr, recipient sdk.AccAddress, as
 		return nil, err
 	}
 
-	if err := k.BankKeeper.SendCoins(markertypes.WithBypass(ctx), recipient, markerAddr, sdk.NewCoins(asset)); err != nil {
+	if err := k.BankKeeper.SendCoins(markertypes.WithBypass(ctx), recipient, principalAddress, sdk.NewCoins(asset)); err != nil {
 		return nil, err
 	}
 
@@ -242,7 +242,7 @@ func (k *Keeper) SwapOut(ctx sdk.Context, vaultAddr, owner sdk.AccAddress, share
 		return nil, fmt.Errorf("failed to reconcile vault interest: %w", err)
 	}
 
-	markerAddr := markertypes.MustGetMarkerAddress(vault.ShareDenom)
+	principalAddress := vault.PrincipalMarkerAddress()
 
 	assets, err := k.ConvertSharesToRedeemCoin(ctx, *vault, shares.Amount, redeemDenom)
 	if err != nil {
@@ -253,7 +253,7 @@ func (k *Keeper) SwapOut(ctx sdk.Context, vaultAddr, owner sdk.AccAddress, share
 		return nil, err
 	}
 
-	if err := k.BankKeeper.SendCoins(ctx, owner, markerAddr, sdk.NewCoins(shares)); err != nil {
+	if err := k.BankKeeper.SendCoins(ctx, owner, principalAddress, sdk.NewCoins(shares)); err != nil {
 		return nil, fmt.Errorf("failed to send shares to marker: %w", err)
 	}
 
@@ -261,7 +261,7 @@ func (k *Keeper) SwapOut(ctx sdk.Context, vaultAddr, owner sdk.AccAddress, share
 		return nil, fmt.Errorf("failed to burn shares: %w", err)
 	}
 
-	if err := k.BankKeeper.SendCoins(markertypes.WithTransferAgents(ctx, vaultAddr), markerAddr, owner, sdk.NewCoins(assets)); err != nil {
+	if err := k.BankKeeper.SendCoins(markertypes.WithTransferAgents(ctx, vaultAddr), principalAddress, owner, sdk.NewCoins(assets)); err != nil {
 		return nil, fmt.Errorf("failed to send underlying asset: %w", err)
 	}
 

--- a/keeper/vault.go
+++ b/keeper/vault.go
@@ -253,6 +253,10 @@ func (k *Keeper) SwapOut(ctx sdk.Context, vaultAddr, owner sdk.AccAddress, share
 		return nil, err
 	}
 
+	if assets.Amount.IsZero() && shares.Amount.IsPositive() {
+		return nil, fmt.Errorf("redeem amount of %s is too small and results in zero assets", shares.String())
+	}
+
 	if err := k.BankKeeper.SendCoins(ctx, owner, principalAddress, sdk.NewCoins(shares)); err != nil {
 		return nil, fmt.Errorf("failed to send shares to marker: %w", err)
 	}

--- a/keeper/vault_test.go
+++ b/keeper/vault_test.go
@@ -1,12 +1,18 @@
 package keeper_test
 
 import (
+	"time"
+
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	"github.com/provlabs/vault/keeper"
 	"github.com/provlabs/vault/types"
 	"github.com/provlabs/vault/utils"
+
+	attrtypes "github.com/provenance-io/provenance/x/attribute/types"
+	markertypes "github.com/provenance-io/provenance/x/marker/types"
 )
 
 type vaultAttrs struct {
@@ -186,7 +192,7 @@ func (s *TestSuite) TestSwapOut_MultiAsset() {
 	s.Require().ErrorContains(err, "denom not supported for vault", "error should indicate the denom is not accepted")
 }
 
-func (s *TestSuite) TestSwapOut_Failures() {
+func (s *TestSuite) TestSwapOut_FailsWhenDisabled() {
 	underlyingDenom := "ylds"
 	shareDenom := "vshare"
 	vault := s.setupBaseVault(underlyingDenom, shareDenom)
@@ -194,24 +200,209 @@ func (s *TestSuite) TestSwapOut_Failures() {
 
 	vault.SwapOutEnabled = false
 	s.k.AuthKeeper.SetAccount(s.ctx, vault)
+
 	_, err := s.k.SwapOut(s.ctx, vault.GetAddress(), redeemerAddr, sdk.NewInt64Coin(shareDenom, 10), "")
 	s.Require().Error(err, "swap out should fail when disabled")
 	s.Require().ErrorContains(err, "swaps are not enabled", "error should mention swaps are disabled")
+}
+
+func (s *TestSuite) TestSwapOut_FailsWithInsufficientShares() {
+	underlyingDenom := "ylds"
+	shareDenom := "vshare"
+	vault := s.setupBaseVault(underlyingDenom, shareDenom)
+
+	initialTVV := int64(1000)
+	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vault.PrincipalMarkerAddress(), sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, initialTVV))), "should fund vault principal to give shares value")
+	initialShares := utils.ShareScalar.MulRaw(initialTVV)
+	s.Require().NoError(s.k.MarkerKeeper.MintCoin(s.ctx, vault.GetAddress(), sdk.NewCoin(shareDenom, initialShares)), "should mint initial share supply")
+
+	sharesForRedeemer := utils.ShareScalar.MulRaw(100)
+	redeemerAddr := s.CreateAndFundAccount(sdk.Coin{})
+	s.Require().NoError(s.k.MarkerKeeper.WithdrawCoins(s.ctx, vault.GetAddress(), redeemerAddr, shareDenom, sdk.NewCoins(sdk.NewCoin(shareDenom, sharesForRedeemer))), "should fund redeemer with shares")
 
 	vault.SwapOutEnabled = true
 	s.k.AuthKeeper.SetAccount(s.ctx, vault)
-	_, err = s.k.SwapOut(s.ctx, vault.GetAddress(), redeemerAddr, sdk.NewInt64Coin(shareDenom, 101), "")
+
+	sharesToRedeem := utils.ShareScalar.MulRaw(101)
+	_, err := s.k.SwapOut(s.ctx, vault.GetAddress(), redeemerAddr, sdk.NewCoin(shareDenom, sharesToRedeem), "")
 	s.Require().Error(err, "swap out should fail with insufficient shares")
 	s.Require().ErrorContains(err, "insufficient funds", "error should mention insufficient funds for shares")
+}
 
-	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vault.PrincipalMarkerAddress(), sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 10))), "should fund vault principal with a small amount of liquidity")
-	s.Require().NoError(s.k.MarkerKeeper.MintCoin(s.ctx, vault.GetAddress(), sdk.NewCoin(shareDenom, utils.ShareScalar.MulRaw(1000))), "should mint a large supply of shares")
+func (s *TestSuite) TestSwapOut_FailsWithInsufficientLiquidity() {
+	underlyingDenom := "ylds"
+	paymentDenom := "usdc"
+	shareDenom := "vshare"
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
 
-	// Corrected test logic: Expect NO error, but a ZERO payout.
-	redeemerBalanceBefore := s.simApp.BankKeeper.GetBalance(s.ctx, redeemerAddr, underlyingDenom)
-	_, err = s.k.SwapOut(s.ctx, vault.GetAddress(), redeemerAddr, sdk.NewInt64Coin(shareDenom, 50), "")
-	s.Require().NoError(err, "swap out should succeed even with low liquidity, yielding a zero payout")
-	s.assertBalance(redeemerAddr, underlyingDenom, redeemerBalanceBefore.Amount) //expect no change
+	initialLiquidity := sdk.NewCoins(
+		sdk.NewInt64Coin(underlyingDenom, 10),
+		sdk.NewInt64Coin(paymentDenom, 1000),
+	)
+	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vault.PrincipalMarkerAddress(), initialLiquidity), "should fund vault principal with mixed liquidity")
+
+	initialTVV, err := s.k.GetTVVInUnderlyingAsset(s.ctx, *vault)
+	s.Require().NoError(err, "should calculate initial tvv")
+	initialShares := utils.ShareScalar.Mul(initialTVV)
+	s.Require().NoError(s.k.MarkerKeeper.MintCoin(s.ctx, vault.GetAddress(), sdk.NewCoin(shareDenom, initialShares)), "should mint initial share supply")
+
+	sharesForRedeemer := utils.ShareScalar.MulRaw(100)
+	redeemerAddr := s.CreateAndFundAccount(sdk.Coin{})
+	s.Require().NoError(s.k.MarkerKeeper.WithdrawCoins(s.ctx, vault.GetAddress(), redeemerAddr, shareDenom, sdk.NewCoins(sdk.NewCoin(shareDenom, sharesForRedeemer))), "should fund redeemer with shares")
+
+	vault.SwapOutEnabled = true
+	s.k.AuthKeeper.SetAccount(s.ctx, vault)
+
+	sharesToRedeem := utils.ShareScalar.MulRaw(50)
+	_, err = s.k.SwapOut(s.ctx, vault.GetAddress(), redeemerAddr, sdk.NewCoin(shareDenom, sharesToRedeem), underlyingDenom)
+	s.Require().Error(err, "swap out should fail with insufficient vault liquidity for the requested denom")
+	s.Require().ErrorContains(err, "insufficient funds", "error should mention insufficient funds for underlying asset")
+}
+
+// TODO: https://github.com/ProvLabs/vault/issues/49
+// We will probably need to review the implementation of this if it isn't right.
+// This test confirms that a SwapOut from a marker account fails if the underlying restricted asset has no required attributes
+// and the vault lacks TRANSFER permission on it. This behavior is distinct from the case where the asset has required
+// attributes, in which the attribute check is correctly enforced. We need to confirm if this "fail-on-no-attributes" path is
+// the intended design. A proposed solution would be to add bypass but send it to the vault account, then from the vault
+// account, send it to the claimer without bypass in order to apply all the send restrictions correctly.
+func (s *TestSuite) TestSwapOut_FailsWithRestrictedUnderlyingAssetNoAttributes() {
+	shareDenom := "vshare"
+	restrictedUnderlyingDenom := "restrictedasset"
+
+	restrictedMarkerAddr := markertypes.MustGetMarkerAddress(restrictedUnderlyingDenom)
+	restrictedMarker := markertypes.NewMarkerAccount(
+		authtypes.NewBaseAccountWithAddress(restrictedMarkerAddr),
+		sdk.NewInt64Coin(restrictedUnderlyingDenom, 1_000_000),
+		s.adminAddr,
+		[]markertypes.AccessGrant{
+			{Address: s.adminAddr.String(), Permissions: markertypes.AccessList{markertypes.Access_Mint, markertypes.Access_Admin, markertypes.Access_Withdraw, markertypes.Access_Burn, markertypes.Access_Transfer}},
+		},
+		markertypes.StatusProposed,
+		markertypes.MarkerType_RestrictedCoin,
+		false, true, false, []string{},
+	)
+	s.Require().NoError(s.simApp.MarkerKeeper.AddFinalizeAndActivateMarker(s.ctx, restrictedMarker), "should successfully create the restricted underlying asset marker")
+
+	vaultCfg := vaultAttrs{
+		admin:      s.adminAddr.String(),
+		share:      shareDenom,
+		underlying: restrictedUnderlyingDenom,
+	}
+	vault, err := s.k.CreateVault(s.ctx, vaultCfg)
+	s.Require().NoError(err, "vault creation with restricted underlying should succeed")
+	vault.SwapOutEnabled = true
+	s.k.AuthKeeper.SetAccount(s.ctx, vault)
+
+	initialTVV := int64(500)
+	s.Require().NoError(s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, vault.PrincipalMarkerAddress(), restrictedUnderlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(restrictedUnderlyingDenom, initialTVV))))
+	initialShares := utils.ShareScalar.MulRaw(initialTVV)
+	s.Require().NoError(s.k.MarkerKeeper.MintCoin(s.ctx, vault.GetAddress(), sdk.NewCoin(shareDenom, initialShares)), "should mint initial share supply")
+
+	redeemerAddr := s.CreateAndFundAccount(sdk.Coin{})
+	sharesForRedeemer := utils.ShareScalar.MulRaw(100)
+	s.Require().NoError(s.k.MarkerKeeper.WithdrawCoins(s.ctx, vault.GetAddress(), redeemerAddr, shareDenom, sdk.NewCoins(sdk.NewCoin(shareDenom, sharesForRedeemer))), "should fund redeemer from the vault's existing shares")
+
+	sharesToRedeem := sdk.NewCoin(shareDenom, utils.ShareScalar.MulRaw(50))
+	_, err = s.k.SwapOut(s.ctx, vault.GetAddress(), redeemerAddr, sharesToRedeem, "")
+
+	s.Require().Error(err, "swap-out should fail because the sender lacks transfer permission for a restricted asset with no attributes")
+	s.Require().ErrorContains(err, "does not have transfer permissions", "error message should indicate missing transfer permission")
+}
+
+func (s *TestSuite) TestSwapOut_FailsWithRestrictedUnderlyingAssetRequiredAttributes() {
+	shareDenom := "vshare"
+	restrictedUnderlyingDenom := "restrictedasset"
+
+	restrictedMarkerAddr := markertypes.MustGetMarkerAddress(restrictedUnderlyingDenom)
+	restrictedMarker := markertypes.NewMarkerAccount(
+		authtypes.NewBaseAccountWithAddress(restrictedMarkerAddr),
+		sdk.NewInt64Coin(restrictedUnderlyingDenom, 1_000_000),
+		s.adminAddr,
+		[]markertypes.AccessGrant{
+			{Address: s.adminAddr.String(), Permissions: markertypes.AccessList{markertypes.Access_Mint, markertypes.Access_Admin, markertypes.Access_Withdraw, markertypes.Access_Burn, markertypes.Access_Transfer}},
+		},
+		markertypes.StatusProposed,
+		markertypes.MarkerType_RestrictedCoin,
+		false, true, false, []string{"you.dont.have.me"},
+	)
+	s.Require().NoError(s.simApp.MarkerKeeper.AddFinalizeAndActivateMarker(s.ctx, restrictedMarker), "should successfully create the restricted underlying asset marker")
+
+	vaultCfg := vaultAttrs{
+		admin:      s.adminAddr.String(),
+		share:      shareDenom,
+		underlying: restrictedUnderlyingDenom,
+	}
+	vault, err := s.k.CreateVault(s.ctx, vaultCfg)
+	s.Require().NoError(err, "vault creation with restricted underlying should succeed")
+	vault.SwapOutEnabled = true
+	s.k.AuthKeeper.SetAccount(s.ctx, vault)
+
+	initialTVV := int64(500)
+	s.Require().NoError(s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, vault.PrincipalMarkerAddress(), restrictedUnderlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(restrictedUnderlyingDenom, initialTVV))))
+	initialShares := utils.ShareScalar.MulRaw(initialTVV)
+	s.Require().NoError(s.k.MarkerKeeper.MintCoin(s.ctx, vault.GetAddress(), sdk.NewCoin(shareDenom, initialShares)), "should mint initial share supply")
+
+	sharesForRedeemer := utils.ShareScalar.MulRaw(100)
+	redeemerAddr := s.CreateAndFundAccount(sdk.NewCoin(shareDenom, sharesForRedeemer))
+
+	sharesToRedeem := sdk.NewCoin(shareDenom, utils.ShareScalar.MulRaw(50))
+	_, err = s.k.SwapOut(s.ctx, vault.GetAddress(), redeemerAddr, sharesToRedeem, "")
+
+	s.Require().Error(err, "swap-out should fail because the redeemer is missing a required attribute")
+	s.Require().ErrorContains(err, "required attribute: \"you.dont.have.me\"", "error should indicate a missing attribute failure")
+}
+
+func (s *TestSuite) TestSwapOut_SucceedsWithRestrictedUnderlyingAssetRequiredAttributes() {
+	shareDenom := "vshare"
+	restrictedUnderlyingDenom := "restrictedasset"
+	requiredAttribute := "iamrequired"
+
+	restrictedMarkerAddr := markertypes.MustGetMarkerAddress(restrictedUnderlyingDenom)
+	restrictedMarker := markertypes.NewMarkerAccount(
+		authtypes.NewBaseAccountWithAddress(restrictedMarkerAddr),
+		sdk.NewInt64Coin(restrictedUnderlyingDenom, 1_000_000),
+		s.adminAddr,
+		[]markertypes.AccessGrant{
+			{Address: s.adminAddr.String(), Permissions: markertypes.AccessList{markertypes.Access_Mint, markertypes.Access_Admin, markertypes.Access_Withdraw, markertypes.Access_Burn, markertypes.Access_Transfer}},
+		},
+		markertypes.StatusProposed,
+		markertypes.MarkerType_RestrictedCoin,
+		false, true, false, []string{requiredAttribute},
+	)
+	s.Require().NoError(s.simApp.MarkerKeeper.AddFinalizeAndActivateMarker(s.ctx, restrictedMarker), "should successfully create the restricted underlying asset marker")
+
+	vaultCfg := vaultAttrs{
+		admin:      s.adminAddr.String(),
+		share:      shareDenom,
+		underlying: restrictedUnderlyingDenom,
+	}
+	vault, err := s.k.CreateVault(s.ctx, vaultCfg)
+	s.Require().NoError(err, "vault creation with restricted underlying should succeed")
+	vault.SwapOutEnabled = true
+	s.k.AuthKeeper.SetAccount(s.ctx, vault)
+
+	initialTVV := int64(500)
+	s.Require().NoError(s.k.MarkerKeeper.WithdrawCoins(s.ctx, s.adminAddr, vault.PrincipalMarkerAddress(), restrictedUnderlyingDenom, sdk.NewCoins(sdk.NewInt64Coin(restrictedUnderlyingDenom, initialTVV))))
+	initialShares := utils.ShareScalar.MulRaw(initialTVV)
+	s.Require().NoError(s.k.MarkerKeeper.MintCoin(s.ctx, vault.GetAddress(), sdk.NewCoin(shareDenom, initialShares)), "should mint initial share supply")
+
+	redeemerAddr := s.CreateAndFundAccount(sdk.Coin{})
+	sharesForRedeemer := utils.ShareScalar.MulRaw(100)
+	s.Require().NoError(s.k.MarkerKeeper.WithdrawCoins(s.ctx, vault.GetAddress(), redeemerAddr, shareDenom, sdk.NewCoins(sdk.NewCoin(shareDenom, sharesForRedeemer))), "should fund redeemer from the vault's existing shares")
+
+	s.simApp.AccountKeeper.SetAccount(s.ctx, s.simApp.AccountKeeper.NewAccountWithAddress(s.ctx, s.adminAddr))
+
+	s.Require().NoError(s.simApp.NameKeeper.SetNameRecord(s.ctx, requiredAttribute, s.adminAddr, false), "should successfully bind the name to the admin's address")
+	expireTime := time.Now().Add(24 * time.Hour)
+	attribute := attrtypes.NewAttribute(requiredAttribute, redeemerAddr.String(), attrtypes.AttributeType_String, []byte("true"), &expireTime)
+	s.Require().NoError(s.simApp.AttributeKeeper.SetAttribute(s.ctx, attribute, s.adminAddr), "should successfully set the required attribute on the redeemer")
+
+	sharesToRedeem := sdk.NewCoin(shareDenom, utils.ShareScalar.MulRaw(50))
+	_, err = s.k.SwapOut(s.ctx, vault.GetAddress(), redeemerAddr, sharesToRedeem, "")
+
+	s.Require().NoError(err, "swap-out should succeed because the redeemer has the required attribute")
+	s.assertBalance(redeemerAddr, restrictedUnderlyingDenom, math.NewInt(50))
 }
 
 func (s *TestSuite) TestSetMinMaxInterestRate_NoOp_NoEvent() {

--- a/types/msgs.go
+++ b/types/msgs.go
@@ -37,6 +37,17 @@ func (m MsgCreateVaultRequest) ValidateBasic() error {
 		return fmt.Errorf("invalid underlying asset: %q: %w", m.UnderlyingAsset, err)
 	}
 
+	if len(m.PaymentDenom) > 0 {
+		if err := sdk.ValidateDenom(m.PaymentDenom); err != nil {
+			return fmt.Errorf("invalid payment denom: %q: %w", m.PaymentDenom, err)
+		}
+	}
+
+	if m.UnderlyingAsset == m.PaymentDenom {
+		return fmt.Errorf("payment (%q) denom cannot equal underlying asset denom (%q)", m.PaymentDenom, m.UnderlyingAsset)
+
+	}
+
 	return nil
 }
 

--- a/types/msgs.go
+++ b/types/msgs.go
@@ -22,7 +22,7 @@ var AllRequestMsgs = []sdk.Msg{
 	(*MsgWithdrawInterestFundsRequest)(nil),
 }
 
-// ValidateBasic returns a not implemented error for MsgCreateVaultRequest.
+// ValidateBasic performs stateless validation on MsgCreateVaultRequest.
 func (m MsgCreateVaultRequest) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(m.Admin)
 	if err != nil {
@@ -45,21 +45,20 @@ func (m MsgCreateVaultRequest) ValidateBasic() error {
 
 	if m.UnderlyingAsset == m.PaymentDenom {
 		return fmt.Errorf("payment (%q) denom cannot equal underlying asset denom (%q)", m.PaymentDenom, m.UnderlyingAsset)
-
 	}
 
 	return nil
 }
 
-// ValidateBasic returns a not implemented error for MsgSwapInRequest.
+// ValidateBasic performs stateless validation on MsgSwapInRequest.
 func (m MsgSwapInRequest) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(m.VaultAddress)
 	if err != nil {
-		return fmt.Errorf("invalid vault address %s : %w", m.VaultAddress, err)
+		return fmt.Errorf("invalid vault address: %q: %w", m.VaultAddress, err)
 	}
 	_, err = sdk.AccAddressFromBech32(m.Owner)
 	if err != nil {
-		return fmt.Errorf("invalid owner address %s : %w", m.VaultAddress, err)
+		return fmt.Errorf("invalid owner address: %q: %w", m.Owner, err)
 	}
 
 	err = m.Assets.Validate()
@@ -74,15 +73,15 @@ func (m MsgSwapInRequest) ValidateBasic() error {
 	return nil
 }
 
-// ValidateBasic performs stateless validation on MsgSwapOutRequest fields.
+// ValidateBasic performs stateless validation on MsgSwapOutRequest.
 func (m MsgSwapOutRequest) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(m.VaultAddress)
 	if err != nil {
-		return fmt.Errorf("invalid vault address %s : %w", m.VaultAddress, err)
+		return fmt.Errorf("invalid vault address: %q: %w", m.VaultAddress, err)
 	}
 	_, err = sdk.AccAddressFromBech32(m.Owner)
 	if err != nil {
-		return fmt.Errorf("invalid owner address %s : %w", m.Owner, err)
+		return fmt.Errorf("invalid owner address: %q: %w", m.Owner, err)
 	}
 
 	err = m.Assets.Validate()

--- a/types/msgs_test.go
+++ b/types/msgs_test.go
@@ -6,7 +6,6 @@ import (
 
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/provlabs/vault/types"
@@ -22,80 +21,16 @@ func TestMsgCreateVaultRequest_ValidateBasic(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name: "A successful MsgCreateVault",
-			msg: types.MsgCreateVaultRequest{
-				Admin:           admin,
-				ShareDenom:      "uatom",
-				UnderlyingAsset: "uusd",
-			},
-			expectedErr: nil,
-		},
-		{
-			name: "Admin is empty",
-			msg: types.MsgCreateVaultRequest{
-				Admin:           "",
-				ShareDenom:      "uatom",
-				UnderlyingAsset: "uusd",
-			},
-			expectedErr: fmt.Errorf("invalid admin address: %q", ""),
-		},
-		{
-			name: "Admin with invalid address",
-			msg: types.MsgCreateVaultRequest{
-				Admin:           "invalid address",
-				ShareDenom:      "uatom",
-				UnderlyingAsset: "uusd",
-			},
-			expectedErr: fmt.Errorf("invalid admin address: %q", "invalid address"),
-		},
-		{
-			name: "ShareDenom is empty",
-			msg: types.MsgCreateVaultRequest{
-				Admin:           admin,
-				ShareDenom:      "",
-				UnderlyingAsset: "uusd",
-			},
-			expectedErr: fmt.Errorf("invalid share denom: %q", ""),
-		},
-		{
-			name: "ShareDenom with invalid denom",
-			msg: types.MsgCreateVaultRequest{
-				Admin:           admin,
-				ShareDenom:      "inv@lid$",
-				UnderlyingAsset: "uusd",
-			},
-			expectedErr: fmt.Errorf("invalid share denom: %q", "inv@lid$"),
-		},
-		{
-			name: "UnderlyingAsset is empty",
-			msg: types.MsgCreateVaultRequest{
-				Admin:           admin,
-				ShareDenom:      "uatom",
-				UnderlyingAsset: "",
-			},
-			expectedErr: fmt.Errorf("invalid underlying asset: %q", ""),
-		},
-		{
-			name: "UnderlyingAsset with invalid denom",
-			msg: types.MsgCreateVaultRequest{
-				Admin:           admin,
-				ShareDenom:      "uatom",
-				UnderlyingAsset: "inv@lid$",
-			},
-			expectedErr: fmt.Errorf("invalid underlying asset: %q", "inv@lid$"),
-		},
-		{
-			name: "PaymentDenom omitted (valid)",
+			name: "success without payment denom",
 			msg: types.MsgCreateVaultRequest{
 				Admin:           admin,
 				ShareDenom:      "vaultshare",
 				UnderlyingAsset: "uusd",
-				PaymentDenom:    "",
 			},
 			expectedErr: nil,
 		},
 		{
-			name: "PaymentDenom present and valid (distinct from underlying)",
+			name: "success with distinct payment denom",
 			msg: types.MsgCreateVaultRequest{
 				Admin:           admin,
 				ShareDenom:      "vaultshare",
@@ -105,36 +40,89 @@ func TestMsgCreateVaultRequest_ValidateBasic(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name: "PaymentDenom invalid format",
+			name: "admin empty",
+			msg: types.MsgCreateVaultRequest{
+				Admin:           "",
+				ShareDenom:      "vaultshare",
+				UnderlyingAsset: "uusd",
+			},
+			expectedErr: fmt.Errorf("invalid admin address: %q", ""),
+		},
+		{
+			name: "admin invalid",
+			msg: types.MsgCreateVaultRequest{
+				Admin:           "bad",
+				ShareDenom:      "vaultshare",
+				UnderlyingAsset: "uusd",
+			},
+			expectedErr: fmt.Errorf("invalid admin address: %q", "bad"),
+		},
+		{
+			name: "share denom empty",
+			msg: types.MsgCreateVaultRequest{
+				Admin:           admin,
+				ShareDenom:      "",
+				UnderlyingAsset: "uusd",
+			},
+			expectedErr: fmt.Errorf("invalid share denom: %q", ""),
+		},
+		{
+			name: "share denom invalid",
+			msg: types.MsgCreateVaultRequest{
+				Admin:           admin,
+				ShareDenom:      "inv@lid$",
+				UnderlyingAsset: "uusd",
+			},
+			expectedErr: fmt.Errorf("invalid share denom: %q", "inv@lid$"),
+		},
+		{
+			name: "underlying empty",
+			msg: types.MsgCreateVaultRequest{
+				Admin:           admin,
+				ShareDenom:      "vaultshare",
+				UnderlyingAsset: "",
+			},
+			expectedErr: fmt.Errorf("invalid underlying asset: %q", ""),
+		},
+		{
+			name: "underlying invalid",
+			msg: types.MsgCreateVaultRequest{
+				Admin:           admin,
+				ShareDenom:      "vaultshare",
+				UnderlyingAsset: "inv@lid$",
+			},
+			expectedErr: fmt.Errorf("invalid underlying asset: %q: %w", "inv@lid$", fmt.Errorf("invalid denom: %s", "inv@lid$")),
+		},
+		{
+			name: "payment denom invalid",
 			msg: types.MsgCreateVaultRequest{
 				Admin:           admin,
 				ShareDenom:      "vaultshare",
 				UnderlyingAsset: "uusd",
 				PaymentDenom:    "inv@lid$",
 			},
-			expectedErr: fmt.Errorf("invalid payment denom: %q", "inv@lid$"),
+			expectedErr: fmt.Errorf("invalid payment denom: %q: %w", "inv@lid$", fmt.Errorf("invalid denom: %s", "inv@lid$")),
 		},
 		{
-			name: "PaymentDenom equals UnderlyingAsset (not allowed)",
+			name: "payment denom equals underlying (not allowed)",
 			msg: types.MsgCreateVaultRequest{
 				Admin:           admin,
 				ShareDenom:      "vaultshare",
 				UnderlyingAsset: "uusd",
 				PaymentDenom:    "uusd",
 			},
-			expectedErr: fmt.Errorf("cannot equal underlying asset denom"),
+			expectedErr: fmt.Errorf("payment (%q) denom cannot equal underlying asset denom (%q)", "uusd", "uusd"),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.msg.ValidateBasic()
-
 			if tc.expectedErr != nil {
-				assert.Error(t, err, "expected an error for %q", tc.name)
-				assert.Contains(t, err.Error(), tc.expectedErr.Error(), "error should contain expected message for %q", tc.name)
+				assert.Error(t, err, "expected error for case %q", tc.name)
+				assert.Contains(t, err.Error(), tc.expectedErr.Error(), "error should contain expected substring for case %q", tc.name)
 			} else {
-				assert.NoError(t, err, "expected no error for %q", tc.name)
+				assert.NoError(t, err, "expected no error for case %q", tc.name)
 			}
 		})
 	}
@@ -147,43 +135,43 @@ func TestMsgSwapInRequest_ValidateBasic(t *testing.T) {
 	tests := []struct {
 		name        string
 		msg         types.MsgSwapInRequest
-		expectedErr string
+		expectedErr error
 	}{
 		{
-			name: "valid request",
+			name: "valid",
 			msg: types.MsgSwapInRequest{
 				Owner:        owner,
 				VaultAddress: vault,
 				Assets:       sdk.NewInt64Coin("uusd", 100),
 			},
-			expectedErr: "",
+			expectedErr: nil,
 		},
 		{
 			name: "invalid vault address",
 			msg: types.MsgSwapInRequest{
 				Owner:        owner,
-				VaultAddress: "invalid",
+				VaultAddress: "bad",
 				Assets:       sdk.NewInt64Coin("uusd", 100),
 			},
-			expectedErr: "invalid vault address",
+			expectedErr: fmt.Errorf("invalid vault address: %q", "bad"),
 		},
 		{
 			name: "invalid owner address",
 			msg: types.MsgSwapInRequest{
-				Owner:        "invalid",
+				Owner:        "bad",
 				VaultAddress: vault,
 				Assets:       sdk.NewInt64Coin("uusd", 100),
 			},
-			expectedErr: "invalid owner address",
+			expectedErr: fmt.Errorf("invalid owner address: %q", "bad"),
 		},
 		{
-			name: "invalid denom",
+			name: "invalid asset denom",
 			msg: types.MsgSwapInRequest{
 				Owner:        owner,
 				VaultAddress: vault,
 				Assets:       sdk.Coin{Denom: "inv@lid$", Amount: sdkmath.NewInt(100)},
 			},
-			expectedErr: "invalid assets coin",
+			expectedErr: fmt.Errorf("invalid assets coin %v: %w", sdk.Coin{Denom: "inv@lid$", Amount: sdkmath.NewInt(100)}, fmt.Errorf("invalid denom: %s", "inv@lid$")),
 		},
 		{
 			name: "zero amount",
@@ -192,19 +180,18 @@ func TestMsgSwapInRequest_ValidateBasic(t *testing.T) {
 				VaultAddress: vault,
 				Assets:       sdk.NewInt64Coin("uusd", 0),
 			},
-			expectedErr: "must be greater than zero",
+			expectedErr: fmt.Errorf("invalid amount: assets %s must be greater than zero", "uusd"),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.msg.ValidateBasic()
-
-			if tc.expectedErr != "" {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tc.expectedErr)
+			if tc.expectedErr != nil {
+				assert.Error(t, err, "expected error for case %q", tc.name)
+				assert.Contains(t, err.Error(), tc.expectedErr.Error(), "error should contain expected substring for case %q", tc.name)
 			} else {
-				assert.NoError(t, err)
+				assert.NoError(t, err, "expected no error for case %q", tc.name)
 			}
 		})
 	}
@@ -217,43 +204,43 @@ func TestMsgSwapOutRequest_ValidateBasic(t *testing.T) {
 	tests := []struct {
 		name        string
 		msg         types.MsgSwapOutRequest
-		expectedErr string
+		expectedErr error
 	}{
 		{
-			name: "valid request",
+			name: "valid",
 			msg: types.MsgSwapOutRequest{
 				Owner:        owner,
 				VaultAddress: vault,
 				Assets:       sdk.NewInt64Coin("uusd", 100),
 			},
-			expectedErr: "",
+			expectedErr: nil,
 		},
 		{
 			name: "invalid vault address",
 			msg: types.MsgSwapOutRequest{
 				Owner:        owner,
-				VaultAddress: "invalid",
+				VaultAddress: "bad",
 				Assets:       sdk.NewInt64Coin("uusd", 100),
 			},
-			expectedErr: "invalid vault address",
+			expectedErr: fmt.Errorf("invalid vault address: %q", "bad"),
 		},
 		{
 			name: "invalid owner address",
 			msg: types.MsgSwapOutRequest{
-				Owner:        "invalid",
+				Owner:        "bad",
 				VaultAddress: vault,
 				Assets:       sdk.NewInt64Coin("uusd", 100),
 			},
-			expectedErr: "invalid owner address",
+			expectedErr: fmt.Errorf("invalid owner address: %q", "bad"),
 		},
 		{
-			name: "invalid denom",
+			name: "invalid asset denom",
 			msg: types.MsgSwapOutRequest{
 				Owner:        owner,
 				VaultAddress: vault,
 				Assets:       sdk.Coin{Denom: "inv@lid$", Amount: sdkmath.NewInt(100)},
 			},
-			expectedErr: "invalid assets coin",
+			expectedErr: fmt.Errorf("invalid assets coin %v: %w", sdk.Coin{Denom: "inv@lid$", Amount: sdkmath.NewInt(100)}, fmt.Errorf("invalid denom: %s", "inv@lid$")),
 		},
 		{
 			name: "zero amount",
@@ -262,268 +249,18 @@ func TestMsgSwapOutRequest_ValidateBasic(t *testing.T) {
 				VaultAddress: vault,
 				Assets:       sdk.NewInt64Coin("uusd", 0),
 			},
-			expectedErr: "must be greater than zero",
+			expectedErr: fmt.Errorf("invalid amount: assets %s must be greater than zero", "uusd"),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.msg.ValidateBasic()
-
-			if tc.expectedErr != "" {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tc.expectedErr)
+			if tc.expectedErr != nil {
+				assert.Error(t, err, "expected error for case %q", tc.name)
+				assert.Contains(t, err.Error(), tc.expectedErr.Error(), "error should contain expected substring for case %q", tc.name)
 			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestMsgUpdateInterestRateRequest_ValidateBasic(t *testing.T) {
-	addr := utils.TestAddress().Bech32
-
-	tests := []struct {
-		name    string
-		msg     types.MsgUpdateInterestRateRequest
-		wantErr string
-	}{
-		{
-			name: "valid",
-			msg: types.MsgUpdateInterestRateRequest{
-				Admin:        addr,
-				VaultAddress: addr,
-				NewRate:      "1.5",
-			},
-		},
-		{
-			name: "invalid admin",
-			msg: types.MsgUpdateInterestRateRequest{
-				Admin:        "bad",
-				VaultAddress: addr,
-				NewRate:      "1.5",
-			},
-			wantErr: "invalid admin address",
-		},
-		{
-			name: "invalid vault address",
-			msg: types.MsgUpdateInterestRateRequest{
-				Admin:        addr,
-				VaultAddress: "bad",
-				NewRate:      "1.5",
-			},
-			wantErr: "invalid vault address",
-		},
-		{
-			name: "invalid new rate",
-			msg: types.MsgUpdateInterestRateRequest{
-				Admin:        addr,
-				VaultAddress: addr,
-				NewRate:      "bad",
-			},
-			wantErr: "invalid interest rate",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.msg.ValidateBasic()
-			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestMsgDepositInterestFundsRequest_ValidateBasic(t *testing.T) {
-	addr := utils.TestAddress().Bech32
-
-	tests := []struct {
-		name    string
-		msg     types.MsgDepositInterestFundsRequest
-		wantErr string
-	}{
-		{
-			name: "valid",
-			msg: types.MsgDepositInterestFundsRequest{
-				Admin:        addr,
-				VaultAddress: addr,
-				Amount:       sdk.NewInt64Coin("uusd", 1000),
-			},
-		},
-		{
-			name: "zero amount",
-			msg: types.MsgDepositInterestFundsRequest{
-				Admin:        addr,
-				VaultAddress: addr,
-				Amount:       sdk.NewInt64Coin("uusd", 0),
-			},
-			wantErr: "greater than zero",
-		},
-		{
-			name: "invalid admin",
-			msg: types.MsgDepositInterestFundsRequest{
-				Admin:        "bad",
-				VaultAddress: addr,
-				Amount:       sdk.NewInt64Coin("uusd", 1000),
-			},
-			wantErr: "invalid admin address",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.msg.ValidateBasic()
-			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestMsgWithdrawInterestFundsRequest_ValidateBasic(t *testing.T) {
-	addr := utils.TestAddress().Bech32
-
-	tests := []struct {
-		name    string
-		msg     types.MsgWithdrawInterestFundsRequest
-		wantErr string
-	}{
-		{
-			name: "valid",
-			msg: types.MsgWithdrawInterestFundsRequest{
-				Admin:        addr,
-				VaultAddress: addr,
-				Amount:       sdk.NewInt64Coin("uusd", 1000),
-			},
-		},
-		{
-			name: "zero amount",
-			msg: types.MsgWithdrawInterestFundsRequest{
-				Admin:        addr,
-				VaultAddress: addr,
-				Amount:       sdk.NewInt64Coin("uusd", 0),
-			},
-			wantErr: "greater than zero",
-		},
-		{
-			name: "invalid interest admin",
-			msg: types.MsgWithdrawInterestFundsRequest{
-				Admin:        "bad",
-				VaultAddress: addr,
-				Amount:       sdk.NewInt64Coin("uusd", 1000),
-			},
-			wantErr: "invalid interest admin address",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.msg.ValidateBasic()
-			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestMsgToggleSwapInRequest_ValidateBasic(t *testing.T) {
-	addr := utils.TestAddress().Bech32
-
-	tests := []struct {
-		name    string
-		msg     types.MsgToggleSwapInRequest
-		wantErr string
-	}{
-		{
-			name: "valid",
-			msg: types.MsgToggleSwapInRequest{
-				Admin:        addr,
-				VaultAddress: addr,
-				Enabled:      true,
-			},
-		},
-		{
-			name: "invalid admin",
-			msg: types.MsgToggleSwapInRequest{
-				Admin:        "bad",
-				VaultAddress: addr,
-				Enabled:      false,
-			},
-			wantErr: "invalid admin address",
-		},
-		{
-			name: "invalid vault address",
-			msg: types.MsgToggleSwapInRequest{
-				Admin:        addr,
-				VaultAddress: "bad",
-				Enabled:      true,
-			},
-			wantErr: "invalid vault address",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.msg.ValidateBasic()
-			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestMsgToggleSwapOutRequest_ValidateBasic(t *testing.T) {
-	addr := utils.TestAddress().Bech32
-
-	tests := []struct {
-		name    string
-		msg     types.MsgToggleSwapOutRequest
-		wantErr string
-	}{
-		{
-			name: "valid",
-			msg: types.MsgToggleSwapOutRequest{
-				Admin:        addr,
-				VaultAddress: addr,
-				Enabled:      true,
-			},
-		},
-		{
-			name: "invalid admin",
-			msg: types.MsgToggleSwapOutRequest{
-				Admin:        "bad",
-				VaultAddress: addr,
-				Enabled:      false,
-			},
-			wantErr: "invalid admin address",
-		},
-		{
-			name: "invalid vault address",
-			msg: types.MsgToggleSwapOutRequest{
-				Admin:        addr,
-				VaultAddress: "bad",
-				Enabled:      true,
-			},
-			wantErr: "invalid vault address",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.msg.ValidateBasic()
-			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
-			} else {
-				assert.NoError(t, err)
+				assert.NoError(t, err, "expected no error for case %q", tc.name)
 			}
 		})
 	}
@@ -533,43 +270,45 @@ func TestMsgUpdateMinInterestRateRequest_ValidateBasic(t *testing.T) {
 	addr := utils.TestAddress().Bech32
 
 	tests := []struct {
-		name    string
-		msg     types.MsgUpdateMinInterestRateRequest
-		wantErr string
+		name        string
+		msg         types.MsgUpdateMinInterestRateRequest
+		expectedErr error
 	}{
 		{
-			name: "valid min rate",
+			name: "valid with negative min rate",
 			msg: types.MsgUpdateMinInterestRateRequest{
 				Admin:        addr,
 				VaultAddress: addr,
 				MinRate:      "-0.75",
 			},
+			expectedErr: nil,
 		},
 		{
-			name: "empty min rate allowed (clears limit)",
+			name: "empty min rate clears",
 			msg: types.MsgUpdateMinInterestRateRequest{
 				Admin:        addr,
 				VaultAddress: addr,
 				MinRate:      "",
 			},
+			expectedErr: nil,
 		},
 		{
-			name: "invalid admin address",
+			name: "invalid admin",
 			msg: types.MsgUpdateMinInterestRateRequest{
 				Admin:        "bad",
 				VaultAddress: addr,
-				MinRate:      "-1.0",
+				MinRate:      "0.10",
 			},
-			wantErr: "invalid admin address",
+			expectedErr: fmt.Errorf("invalid admin address: %q", "bad"),
 		},
 		{
-			name: "invalid vault address",
+			name: "invalid vault",
 			msg: types.MsgUpdateMinInterestRateRequest{
 				Admin:        addr,
 				VaultAddress: "bad",
-				MinRate:      "-1.0",
+				MinRate:      "0.10",
 			},
-			wantErr: "invalid vault address",
+			expectedErr: fmt.Errorf("invalid vault address: %q", "bad"),
 		},
 		{
 			name: "invalid min rate",
@@ -578,17 +317,18 @@ func TestMsgUpdateMinInterestRateRequest_ValidateBasic(t *testing.T) {
 				VaultAddress: addr,
 				MinRate:      "abc",
 			},
-			wantErr: "invalid min rate",
+			expectedErr: fmt.Errorf("invalid min rate: %q", "abc"),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.msg.ValidateBasic()
-			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+			if tc.expectedErr != nil {
+				assert.Error(t, err, "expected error for case %q", tc.name)
+				assert.Contains(t, err.Error(), tc.expectedErr.Error(), "error should contain expected substring for case %q", tc.name)
 			} else {
-				assert.NoError(t, err)
+				assert.NoError(t, err, "expected no error for case %q", tc.name)
 			}
 		})
 	}
@@ -598,43 +338,45 @@ func TestMsgUpdateMaxInterestRateRequest_ValidateBasic(t *testing.T) {
 	addr := utils.TestAddress().Bech32
 
 	tests := []struct {
-		name    string
-		msg     types.MsgUpdateMaxInterestRateRequest
-		wantErr string
+		name        string
+		msg         types.MsgUpdateMaxInterestRateRequest
+		expectedErr error
 	}{
 		{
-			name: "valid max rate",
+			name: "valid with positive max rate",
 			msg: types.MsgUpdateMaxInterestRateRequest{
 				Admin:        addr,
 				VaultAddress: addr,
 				MaxRate:      "3.25",
 			},
+			expectedErr: nil,
 		},
 		{
-			name: "empty max rate allowed (clears limit)",
+			name: "empty max rate clears",
 			msg: types.MsgUpdateMaxInterestRateRequest{
 				Admin:        addr,
 				VaultAddress: addr,
 				MaxRate:      "",
 			},
+			expectedErr: nil,
 		},
 		{
-			name: "invalid admin address",
+			name: "invalid admin",
 			msg: types.MsgUpdateMaxInterestRateRequest{
 				Admin:        "bad",
 				VaultAddress: addr,
 				MaxRate:      "2.0",
 			},
-			wantErr: "invalid admin address",
+			expectedErr: fmt.Errorf("invalid admin address: %q", "bad"),
 		},
 		{
-			name: "invalid vault address",
+			name: "invalid vault",
 			msg: types.MsgUpdateMaxInterestRateRequest{
 				Admin:        addr,
 				VaultAddress: "bad",
 				MaxRate:      "2.0",
 			},
-			wantErr: "invalid vault address",
+			expectedErr: fmt.Errorf("invalid vault address: %q", "bad"),
 		},
 		{
 			name: "invalid max rate",
@@ -643,17 +385,449 @@ func TestMsgUpdateMaxInterestRateRequest_ValidateBasic(t *testing.T) {
 				VaultAddress: addr,
 				MaxRate:      "notanumber",
 			},
-			wantErr: "invalid max rate",
+			expectedErr: fmt.Errorf("invalid max rate: %q", "notanumber"),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.msg.ValidateBasic()
-			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+			if tc.expectedErr != nil {
+				assert.Error(t, err, "expected error for case %q", tc.name)
+				assert.Contains(t, err.Error(), tc.expectedErr.Error(), "error should contain expected substring for case %q", tc.name)
 			} else {
-				assert.NoError(t, err)
+				assert.NoError(t, err, "expected no error for case %q", tc.name)
+			}
+		})
+	}
+}
+
+func TestMsgUpdateInterestRateRequest_ValidateBasic(t *testing.T) {
+	addr := utils.TestAddress().Bech32
+
+	tests := []struct {
+		name        string
+		msg         types.MsgUpdateInterestRateRequest
+		expectedErr error
+	}{
+		{
+			name: "valid",
+			msg: types.MsgUpdateInterestRateRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				NewRate:      "1.5",
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "invalid admin",
+			msg: types.MsgUpdateInterestRateRequest{
+				Admin:        "bad",
+				VaultAddress: addr,
+				NewRate:      "1.5",
+			},
+			expectedErr: fmt.Errorf("invalid admin address: %q", "bad"),
+		},
+		{
+			name: "invalid vault address",
+			msg: types.MsgUpdateInterestRateRequest{
+				Admin:        addr,
+				VaultAddress: "bad",
+				NewRate:      "1.5",
+			},
+			expectedErr: fmt.Errorf("invalid vault address: %q", "bad"),
+		},
+		{
+			name: "invalid new rate",
+			msg: types.MsgUpdateInterestRateRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				NewRate:      "bad",
+			},
+			expectedErr: fmt.Errorf("invalid interest rate: %q", "bad"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr != nil {
+				assert.Error(t, err, "expected error for case %q", tc.name)
+				assert.Contains(t, err.Error(), tc.expectedErr.Error(), "error should contain expected substring for case %q", tc.name)
+			} else {
+				assert.NoError(t, err, "expected no error for case %q", tc.name)
+			}
+		})
+	}
+}
+
+func TestMsgToggleSwapInRequest_ValidateBasic(t *testing.T) {
+	addr := utils.TestAddress().Bech32
+
+	tests := []struct {
+		name        string
+		msg         types.MsgToggleSwapInRequest
+		expectedErr error
+	}{
+		{
+			name: "valid",
+			msg: types.MsgToggleSwapInRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				Enabled:      true,
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "invalid admin",
+			msg: types.MsgToggleSwapInRequest{
+				Admin:        "bad",
+				VaultAddress: addr,
+				Enabled:      false,
+			},
+			expectedErr: fmt.Errorf("invalid admin address: %q", "bad"),
+		},
+		{
+			name: "invalid vault address",
+			msg: types.MsgToggleSwapInRequest{
+				Admin:        addr,
+				VaultAddress: "bad",
+				Enabled:      true,
+			},
+			expectedErr: fmt.Errorf("invalid vault address: %q", "bad"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr != nil {
+				assert.Error(t, err, "expected error for case %q", tc.name)
+				assert.Contains(t, err.Error(), tc.expectedErr.Error(), "error should contain expected substring for case %q", tc.name)
+			} else {
+				assert.NoError(t, err, "expected no error for case %q", tc.name)
+			}
+		})
+	}
+}
+
+func TestMsgToggleSwapOutRequest_ValidateBasic(t *testing.T) {
+	addr := utils.TestAddress().Bech32
+
+	tests := []struct {
+		name        string
+		msg         types.MsgToggleSwapOutRequest
+		expectedErr error
+	}{
+		{
+			name: "valid",
+			msg: types.MsgToggleSwapOutRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				Enabled:      true,
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "invalid admin",
+			msg: types.MsgToggleSwapOutRequest{
+				Admin:        "bad",
+				VaultAddress: addr,
+				Enabled:      false,
+			},
+			expectedErr: fmt.Errorf("invalid admin address: %q", "bad"),
+		},
+		{
+			name: "invalid vault address",
+			msg: types.MsgToggleSwapOutRequest{
+				Admin:        addr,
+				VaultAddress: "bad",
+				Enabled:      true,
+			},
+			expectedErr: fmt.Errorf("invalid vault address: %q", "bad"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr != nil {
+				assert.Error(t, err, "expected error for case %q", tc.name)
+				assert.Contains(t, err.Error(), tc.expectedErr.Error(), "error should contain expected substring for case %q", tc.name)
+			} else {
+				assert.NoError(t, err, "expected no error for case %q", tc.name)
+			}
+		})
+	}
+}
+
+func TestMsgDepositInterestFundsRequest_ValidateBasic(t *testing.T) {
+	addr := utils.TestAddress().Bech32
+
+	tests := []struct {
+		name        string
+		msg         types.MsgDepositInterestFundsRequest
+		expectedErr error
+	}{
+		{
+			name: "valid",
+			msg: types.MsgDepositInterestFundsRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				Amount:       sdk.NewInt64Coin("uusd", 1000),
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "zero amount",
+			msg: types.MsgDepositInterestFundsRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				Amount:       sdk.NewInt64Coin("uusd", 0),
+			},
+			expectedErr: fmt.Errorf("deposit amount must be greater than zero"),
+		},
+		{
+			name: "invalid admin",
+			msg: types.MsgDepositInterestFundsRequest{
+				Admin:        "bad",
+				VaultAddress: addr,
+				Amount:       sdk.NewInt64Coin("uusd", 1000),
+			},
+			expectedErr: fmt.Errorf("invalid admin address: %q", "bad"),
+		},
+		{
+			name: "invalid vault",
+			msg: types.MsgDepositInterestFundsRequest{
+				Admin:        addr,
+				VaultAddress: "bad",
+				Amount:       sdk.NewInt64Coin("uusd", 1000),
+			},
+			expectedErr: fmt.Errorf("invalid vault address: %q", "bad"),
+		},
+		{
+			name: "invalid denom",
+			msg: types.MsgDepositInterestFundsRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				Amount:       sdk.Coin{Denom: "inv@lid$", Amount: sdkmath.NewInt(1000)},
+			},
+			expectedErr: fmt.Errorf("invalid deposit amount: %w", fmt.Errorf("invalid denom: %s", "inv@lid$")),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr != nil {
+				assert.Error(t, err, "expected error for case %q", tc.name)
+				assert.Contains(t, err.Error(), tc.expectedErr.Error(), "error should contain expected substring for case %q", tc.name)
+			} else {
+				assert.NoError(t, err, "expected no error for case %q", tc.name)
+			}
+		})
+	}
+}
+
+func TestMsgWithdrawInterestFundsRequest_ValidateBasic(t *testing.T) {
+	addr := utils.TestAddress().Bech32
+
+	tests := []struct {
+		name        string
+		msg         types.MsgWithdrawInterestFundsRequest
+		expectedErr error
+	}{
+		{
+			name: "valid",
+			msg: types.MsgWithdrawInterestFundsRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				Amount:       sdk.NewInt64Coin("uusd", 1000),
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "zero amount",
+			msg: types.MsgWithdrawInterestFundsRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				Amount:       sdk.NewInt64Coin("uusd", 0),
+			},
+			expectedErr: fmt.Errorf("withdrawal amount must be greater than zero"),
+		},
+		{
+			name: "invalid interest admin",
+			msg: types.MsgWithdrawInterestFundsRequest{
+				Admin:        "bad",
+				VaultAddress: addr,
+				Amount:       sdk.NewInt64Coin("uusd", 1000),
+			},
+			expectedErr: fmt.Errorf("invalid interest admin address: %q", "bad"),
+		},
+		{
+			name: "invalid vault",
+			msg: types.MsgWithdrawInterestFundsRequest{
+				Admin:        addr,
+				VaultAddress: "bad",
+				Amount:       sdk.NewInt64Coin("uusd", 1000),
+			},
+			expectedErr: fmt.Errorf("invalid vault address: %q", "bad"),
+		},
+		{
+			name: "invalid denom",
+			msg: types.MsgWithdrawInterestFundsRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				Amount:       sdk.Coin{Denom: "inv@lid$", Amount: sdkmath.NewInt(1000)},
+			},
+			expectedErr: fmt.Errorf("invalid withdrawal amount: %w", fmt.Errorf("invalid denom: %s", "inv@lid$")),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr != nil {
+				assert.Error(t, err, "expected error for case %q", tc.name)
+				assert.Contains(t, err.Error(), tc.expectedErr.Error(), "error should contain expected substring for case %q", tc.name)
+			} else {
+				assert.NoError(t, err, "expected no error for case %q", tc.name)
+			}
+		})
+	}
+}
+
+func TestMsgDepositPrincipalFundsRequest_ValidateBasic(t *testing.T) {
+	addr := utils.TestAddress().Bech32
+
+	tests := []struct {
+		name        string
+		msg         types.MsgDepositPrincipalFundsRequest
+		expectedErr error
+	}{
+		{
+			name: "valid",
+			msg: types.MsgDepositPrincipalFundsRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				Amount:       sdk.NewInt64Coin("uusd", 1000),
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "zero amount",
+			msg: types.MsgDepositPrincipalFundsRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				Amount:       sdk.NewInt64Coin("uusd", 0),
+			},
+			expectedErr: fmt.Errorf("deposit amount must be greater than zero"),
+		},
+		{
+			name: "invalid admin",
+			msg: types.MsgDepositPrincipalFundsRequest{
+				Admin:        "bad",
+				VaultAddress: addr,
+				Amount:       sdk.NewInt64Coin("uusd", 1000),
+			},
+			expectedErr: fmt.Errorf("invalid admin address: %q", "bad"),
+		},
+		{
+			name: "invalid vault",
+			msg: types.MsgDepositPrincipalFundsRequest{
+				Admin:        addr,
+				VaultAddress: "bad",
+				Amount:       sdk.NewInt64Coin("uusd", 1000),
+			},
+			expectedErr: fmt.Errorf("invalid vault address: %q", "bad"),
+		},
+		{
+			name: "invalid denom",
+			msg: types.MsgDepositPrincipalFundsRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				Amount:       sdk.Coin{Denom: "inv@lid$", Amount: sdkmath.NewInt(1000)},
+			},
+			expectedErr: fmt.Errorf("invalid deposit amount: %w", fmt.Errorf("invalid denom: %s", "inv@lid$")),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr != nil {
+				assert.Error(t, err, "expected error for case %q", tc.name)
+				assert.Contains(t, err.Error(), tc.expectedErr.Error(), "error should contain expected substring for case %q", tc.name)
+			} else {
+				assert.NoError(t, err, "expected no error for case %q", tc.name)
+			}
+		})
+	}
+}
+
+func TestMsgWithdrawPrincipalFundsRequest_ValidateBasic(t *testing.T) {
+	addr := utils.TestAddress().Bech32
+
+	tests := []struct {
+		name        string
+		msg         types.MsgWithdrawPrincipalFundsRequest
+		expectedErr error
+	}{
+		{
+			name: "valid",
+			msg: types.MsgWithdrawPrincipalFundsRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				Amount:       sdk.NewInt64Coin("uusd", 1000),
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "zero amount",
+			msg: types.MsgWithdrawPrincipalFundsRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				Amount:       sdk.NewInt64Coin("uusd", 0),
+			},
+			expectedErr: fmt.Errorf("withdrawal amount must be greater than zero"),
+		},
+		{
+			name: "invalid admin",
+			msg: types.MsgWithdrawPrincipalFundsRequest{
+				Admin:        "bad",
+				VaultAddress: addr,
+				Amount:       sdk.NewInt64Coin("uusd", 1000),
+			},
+			expectedErr: fmt.Errorf("invalid admin address: %q", "bad"),
+		},
+		{
+			name: "invalid vault",
+			msg: types.MsgWithdrawPrincipalFundsRequest{
+				Admin:        addr,
+				VaultAddress: "bad",
+				Amount:       sdk.NewInt64Coin("uusd", 1000),
+			},
+			expectedErr: fmt.Errorf("invalid vault address: %q", "bad"),
+		},
+		{
+			name: "invalid denom",
+			msg: types.MsgWithdrawPrincipalFundsRequest{
+				Admin:        addr,
+				VaultAddress: addr,
+				Amount:       sdk.Coin{Denom: "inv@lid$", Amount: sdkmath.NewInt(1000)},
+			},
+			expectedErr: fmt.Errorf("invalid withdrawal amount: %w", fmt.Errorf("invalid denom: %s", "inv@lid$")),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr != nil {
+				assert.Error(t, err, "expected error for case %q", tc.name)
+				assert.Contains(t, err.Error(), tc.expectedErr.Error(), "error should contain expected substring for case %q", tc.name)
+			} else {
+				assert.NoError(t, err, "expected no error for case %q", tc.name)
 			}
 		})
 	}

--- a/types/vault.go
+++ b/types/vault.go
@@ -174,30 +174,6 @@ func (v *VaultAccount) ValuationDenom() string {
 	return v.UnderlyingAsset
 }
 
-func (v *VaultAccount) IsPaymentOrAssetDenom(denom string) bool {
-	return denom == v.UnderlyingAsset || (v.PaymentDenom != "" && denom == v.PaymentDenom)
-}
-
-func (v *VaultAccount) ValidateDepositCoin(c sdk.Coin) error {
-	if c.IsZero() {
-		return fmt.Errorf("zero deposit")
-	}
-	if !v.IsPaymentOrAssetDenom(c.Denom) {
-		return fmt.Errorf("deposit denom %s not accepted", c.Denom)
-	}
-	return nil
-}
-
-func (v *VaultAccount) ValidateRedeemDenom(denom string) error {
-	if denom == "" {
-		return fmt.Errorf("empty redeem denom")
-	}
-	if !v.IsPaymentOrAssetDenom(denom) {
-		return fmt.Errorf("redeem denom %s not accepted", denom)
-	}
-	return nil
-}
-
 // AcceptedDenoms returns the list of coin denoms accepted for I/O.
 // Always includes the underlying asset; includes payment_denom only if set and distinct.
 func (v *VaultAccount) AcceptedDenoms() []string {

--- a/types/vault.go
+++ b/types/vault.go
@@ -8,6 +8,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	proto "github.com/cosmos/gogoproto/proto"
+
+	markertypes "github.com/provenance-io/provenance/x/marker/types"
 )
 
 const (
@@ -209,4 +211,10 @@ func (v *VaultAccount) ValidateAcceptedCoin(c sdk.Coin) error {
 		return fmt.Errorf("amount must be greater than zero")
 	}
 	return v.ValidateAcceptedDenom(c.Denom)
+}
+
+// PrincipalMarkerAddress returns the share-denom marker address that holds the
+// vault’s principal (i.e., the marker account backing the vault’s shares).
+func (v VaultAccount) PrincipalMarkerAddress() sdk.AccAddress {
+	return markertypes.MustGetMarkerAddress(v.ShareDenom)
 }

--- a/types/vault_test.go
+++ b/types/vault_test.go
@@ -113,6 +113,58 @@ func TestVaultAccount_Validate(t *testing.T) {
 			expectedErr: fmt.Sprintf("invalid underlying asset denom: %s", invalidDenom),
 		},
 		{
+			name: "payment denom omitted => ok",
+			vaultAccount: types.VaultAccount{
+				BaseAccount:         baseAcc,
+				Admin:               validAdmin,
+				ShareDenom:          validDenom,
+				UnderlyingAsset:     "uusd",
+				PaymentDenom:        "",
+				CurrentInterestRate: validInterest,
+				DesiredInterestRate: validInterest,
+			},
+			expectedErr: "",
+		},
+		{
+			name: "payment denom valid and distinct => ok",
+			vaultAccount: types.VaultAccount{
+				BaseAccount:         baseAcc,
+				Admin:               validAdmin,
+				ShareDenom:          validDenom,
+				UnderlyingAsset:     "uusd",
+				PaymentDenom:        "usdc",
+				CurrentInterestRate: validInterest,
+				DesiredInterestRate: validInterest,
+			},
+			expectedErr: "",
+		},
+		{
+			name: "payment denom invalid format => error",
+			vaultAccount: types.VaultAccount{
+				BaseAccount:         baseAcc,
+				Admin:               validAdmin,
+				ShareDenom:          validDenom,
+				UnderlyingAsset:     "uusd",
+				PaymentDenom:        "inv@lid$",
+				CurrentInterestRate: validInterest,
+				DesiredInterestRate: validInterest,
+			},
+			expectedErr: "invalid payment denom",
+		},
+		{
+			name: "payment denom equals underlying => error",
+			vaultAccount: types.VaultAccount{
+				BaseAccount:         baseAcc,
+				Admin:               validAdmin,
+				ShareDenom:          validDenom,
+				UnderlyingAsset:     "uusd",
+				PaymentDenom:        "uusd",
+				CurrentInterestRate: validInterest,
+				DesiredInterestRate: validInterest,
+			},
+			expectedErr: "cannot equal underlying asset denom",
+		},
+		{
 			name: "invalid current interest rate",
 			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,

--- a/types/vault_test.go
+++ b/types/vault_test.go
@@ -22,13 +22,13 @@ func TestVaultAccount_Validate(t *testing.T) {
 	baseAcc := authtypes.NewBaseAccountWithAddress(sdk.MustAccAddressFromBech32(validAdmin))
 
 	tests := []struct {
-		name        string
-		account     types.VaultAccount
-		expectedErr string
+		name         string
+		vaultAccount types.VaultAccount
+		expectedErr  string
 	}{
 		{
 			name: "valid vault account with interest rates (current==desired)",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -40,7 +40,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "valid vault account with bounds and current==0",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -54,7 +54,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "invalid admin address",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               "invalid-address",
 				ShareDenom:          validDenom,
@@ -66,7 +66,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "empty share denom",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          "",
@@ -78,7 +78,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "invalid share denom",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          invalidDenom,
@@ -90,7 +90,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "empty underlying assets",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -102,7 +102,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "invalid underlying asset denom",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -114,7 +114,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "invalid current interest rate",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -126,7 +126,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "invalid desired interest rate",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -138,7 +138,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "valid min/max equal",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -152,7 +152,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "valid min < max",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -166,7 +166,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "invalid min format (max empty)",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -180,7 +180,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "invalid max format (min empty)",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -194,7 +194,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "min > max => error",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -208,7 +208,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "desired < min => error",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -222,7 +222,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "desired > max => error",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -236,7 +236,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "current non-zero and not equal desired => error",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -248,7 +248,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "min only and desired == min => ok",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -261,7 +261,7 @@ func TestVaultAccount_Validate(t *testing.T) {
 		},
 		{
 			name: "max only and desired == max => ok",
-			account: types.VaultAccount{
+			vaultAccount: types.VaultAccount{
 				BaseAccount:         baseAcc,
 				Admin:               validAdmin,
 				ShareDenom:          validDenom,
@@ -276,13 +276,112 @@ func TestVaultAccount_Validate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.account.Validate()
+			err := tc.vaultAccount.Validate()
 			if tc.expectedErr != "" {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tc.expectedErr)
+				assert.Error(t, err, "expected an error")
+				assert.Contains(t, err.Error(), tc.expectedErr, "error should contain expected message")
 			} else {
-				assert.NoError(t, err)
+				assert.NoError(t, err, "expected no error")
 			}
 		})
 	}
+}
+
+func TestVaultAccount_AcceptedDenoms(t *testing.T) {
+	tests := []struct {
+		name            string
+		underlyingAsset string
+		paymentDenom    string
+		expectedDenoms  []string
+	}{
+		{
+			name:            "only underlying when payment empty",
+			underlyingAsset: "uusd",
+			paymentDenom:    "",
+			expectedDenoms:  []string{"uusd"},
+		},
+		{
+			name:            "only underlying when payment equals underlying",
+			underlyingAsset: "uusd",
+			paymentDenom:    "uusd",
+			expectedDenoms:  []string{"uusd"},
+		},
+		{
+			name:            "underlying and payment when distinct",
+			underlyingAsset: "uusd",
+			paymentDenom:    "usdc",
+			expectedDenoms:  []string{"uusd", "usdc"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := types.VaultAccount{UnderlyingAsset: tc.underlyingAsset, PaymentDenom: tc.paymentDenom}
+			got := v.AcceptedDenoms()
+			assert.ElementsMatch(t, tc.expectedDenoms, got, "accepted denoms should match expected")
+		})
+	}
+}
+
+func TestVaultAccount_IsAcceptedDenom(t *testing.T) {
+	vaWithMulti := types.VaultAccount{UnderlyingAsset: "uusd", PaymentDenom: "usdc"}
+	assert.True(t, vaWithMulti.IsAcceptedDenom("uusd"), "underlying should be accepted")
+	assert.True(t, vaWithMulti.IsAcceptedDenom("usdc"), "payment denom should be accepted")
+	assert.False(t, vaWithMulti.IsAcceptedDenom("uatom"), "unlisted denom should not be accepted")
+
+	vaUnderlyingOnly := types.VaultAccount{UnderlyingAsset: "uusd", PaymentDenom: ""}
+	assert.True(t, vaUnderlyingOnly.IsAcceptedDenom("uusd"), "underlying should be accepted when payment empty")
+	assert.False(t, vaUnderlyingOnly.IsAcceptedDenom("usdc"), "payment should not be accepted when not configured")
+
+	vaMultiSameDenom := types.VaultAccount{UnderlyingAsset: "uusd", PaymentDenom: "uusd"}
+	assert.True(t, vaMultiSameDenom.IsAcceptedDenom("uusd"), "underlying should be accepted when payment equals underlying")
+	assert.False(t, vaMultiSameDenom.IsAcceptedDenom("usdc"), "unlisted denom should not be accepted when payment equals underlying")
+}
+
+func TestVaultAccount_ValidateAcceptedDenom(t *testing.T) {
+	vaUnderlyingOnly := types.VaultAccount{UnderlyingAsset: "uusd"}
+	err := vaUnderlyingOnly.ValidateAcceptedDenom("uusd")
+	assert.NoError(t, err, "valid underlying should pass")
+
+	err = vaUnderlyingOnly.ValidateAcceptedDenom("usdc")
+	assert.Error(t, err, "unlisted denom should error")
+	assert.Contains(t, err.Error(), `denom not supported for vault`, "error should indicate unsupported denom")
+	assert.Contains(t, err.Error(), `"uusd"`, "error should list allowed denom")
+	assert.Contains(t, err.Error(), `"usdc"`, "error should include the provided denom")
+
+	vaWithMulti := types.VaultAccount{UnderlyingAsset: "uusd", PaymentDenom: "usdc"}
+	err = vaWithMulti.ValidateAcceptedDenom("uusd")
+	assert.NoError(t, err, "underlying should pass when dual")
+
+	err = vaWithMulti.ValidateAcceptedDenom("usdc")
+	assert.NoError(t, err, "payment denom should pass when dual")
+
+	err = vaWithMulti.ValidateAcceptedDenom("uatom")
+	assert.Error(t, err, "unlisted denom should error when dual")
+	assert.Contains(t, err.Error(), `"uusd"`, "error should include first allowed denom")
+	assert.Contains(t, err.Error(), `"usdc"`, "error should include second allowed denom")
+	assert.Contains(t, err.Error(), `"uatom"`, "error should include provided denom")
+}
+
+func TestVaultAccount_ValidateAcceptedCoin(t *testing.T) {
+	vaWithMulti := types.VaultAccount{UnderlyingAsset: "uusd", PaymentDenom: "usdc"}
+
+	err := vaWithMulti.ValidateAcceptedCoin(sdk.NewInt64Coin("uusd", 1))
+	assert.NoError(t, err, "non-zero underlying coin should be accepted")
+
+	err = vaWithMulti.ValidateAcceptedCoin(sdk.NewInt64Coin("usdc", 5))
+	assert.NoError(t, err, "non-zero payment coin should be accepted")
+
+	err = vaWithMulti.ValidateAcceptedCoin(sdk.NewInt64Coin("uatom", 7))
+	assert.Error(t, err, "unlisted denom should error")
+	assert.Contains(t, err.Error(), "denom not supported for vault", "error should indicate unsupported denom")
+
+	err = vaWithMulti.ValidateAcceptedCoin(sdk.NewInt64Coin("uusd", 0))
+	assert.Error(t, err, "zero amount should error")
+	assert.Equal(t, "amount must be greater than zero", err.Error(), "error should match expected message")
+
+	vaUnderlyingOnly := types.VaultAccount{UnderlyingAsset: "uusd"}
+	err = vaUnderlyingOnly.ValidateAcceptedCoin(sdk.NewInt64Coin("usdc", 3))
+	assert.Error(t, err, "payment denom should not be accepted when not configured")
+	assert.Contains(t, err.Error(), "denom not supported for vault", "error should indicate unsupported denom")
 }


### PR DESCRIPTION
### **PR Description**

This PR introduces Phase 2 of the new vault architecture, focusing on integrating the `valuation_engine.go` functions directly into the `SwapIn` and `SwapOut` keeper methods. This refactor enables multi-asset support and corrects core calculation logic.

### **Key Changes**

* **`SwapIn`/`SwapOut` Refactor:** The `SwapIn` and `SwapOut` methods have been completely refactored to delegate all monetary conversions to `ConvertDepositToSharesInUnderlyingAsset` and `ConvertSharesToRedeemCoin`. This removes the old calculation logic and ensures all swaps use the central, pro-rata pricing model from the valuation engine.

* **Multi-Asset Support:** A `PaymentDenom` field has been added to the `VaultAccount` to allow the vault to transact in an optional, secondary asset. The two asset types have distinct roles:
    * **`UnderlyingAsset` (The Unit of Account):** This is the core currency of the vault. All internal accounting, such as Total Vault Value (TVV) and share price, is calculated in terms of this asset. Swaps involving the `UnderlyingAsset` are direct value transfers that do not require price conversion.
    * **`PaymentDenom` (The Convenience Asset):** This is an alternative asset for deposits and withdrawals. All transactions in the `PaymentDenom` are first converted to their `UnderlyingAsset` equivalent by the valuation engine (using the on-chain Net Asset Value) before any share calculations occur.

* **Critical TVV Calculation Fix:** Corrected `GetTVVInUnderlyingAsset` to source balances from the vault's `PrincipalMarkerAddress()` instead of the vault's own account address (reserves). This is a critical fix ensuring the valuation engine operates on the correct asset base.

* **API and Test Updates:**
    * Updated `DepositPrincipalFunds` and `WithdrawPrincipalFunds` to also accept the `PaymentDenom`.
    * Added a new `vault_test.go` suite with extensive test coverage for the updated swap logic, multi-asset paths, and various failure cases.
    * Refactored existing tests to use new helper functions for cleaner setup.