### PR TITLE
Allow toggling of swap in/out when vault paused

### DIFF
--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -201,9 +201,6 @@ func (k msgServer) ToggleSwapIn(goCtx context.Context, msg *types.MsgToggleSwapI
 	if err := vault.ValidateAdmin(msg.Admin); err != nil {
 		return nil, err
 	}
-	if vault.Paused {
-		return nil, fmt.Errorf("vault %s is paused", msg.VaultAddress)
-	}
 
 	k.SetSwapInEnable(ctx, vault, msg.Enabled)
 
@@ -225,9 +222,6 @@ func (k msgServer) ToggleSwapOut(goCtx context.Context, msg *types.MsgToggleSwap
 	}
 	if err := vault.ValidateAdmin(msg.Admin); err != nil {
 		return nil, err
-	}
-	if vault.Paused {
-		return nil, fmt.Errorf("vault %s is paused", msg.VaultAddress)
 	}
 
 	k.SetSwapOutEnable(ctx, vault, msg.Enabled)


### PR DESCRIPTION
This PR changes the toggling of swap in/out to be allowed when vault is paused.  

## Updated State Chart:

| Endpoint                 | Admin required | Works when UNPAUSED | Works when PAUSED | Notes / gates that still apply                                                                                |
| ------------------------ | -------------- | ------------------: | ----------------: | ------------------------------------------------------------------------------------------------------------- |
| `CreateVault`            | No             |                   ✅ |                 ✅ | Creation only.                                                                                                |
| `SwapIn`                 | No             |                   ✅ |                 ❌ | Keeper `SwapIn` enforces `!vault.Paused`, `SwapInEnabled`, accepted denom, reconcile.                         |
| `SwapOut`                | No             |                   ✅ |                 ❌ | Keeper `SwapOut` enforces `!vault.Paused`, `SwapOutEnabled`, share denom match, payout restrictions, enqueue. |
| `UpdateMinInterestRate`  | Yes            |                   ✅ |                 ✅ | Calls `SetMinInterestRate`.                                                                                   |
| `UpdateMaxInterestRate`  | Yes            |                   ✅ |                 ✅ | Calls `SetMaxInterestRate`.                                                                                   |
| `UpdateInterestRate`     | Yes            |                   ✅ |                 ✅ | Validates bounds, may reconcile, updates enable/disable flows.                                                |
| `ToggleSwapIn`           | Yes            |                   ✅ |                   ✅ | Allow toggle on pause                                                                               |
| `ToggleSwapOut`          | Yes            |                   ✅ |                   ✅ | Allow toggle on pause                                                                                 |
| `DepositInterestFunds`   | Yes            |                   ✅ |                 ✅ | Underlying denom only; reconciles after deposit.                                                              |
| `WithdrawInterestFunds`  | Yes            |                   ✅ |                 ✅ | Underlying denom only; reconciles before withdrawal.                                                          |
| `DepositPrincipalFunds`  | Yes            |                   ❌ |                 ✅ | Requires paused; reconciles then deposit to principal marker.                                                 |
| `WithdrawPrincipalFunds` | Yes            |                   ❌ |                 ✅ | Requires paused; reconciles then withdraw from principal marker.                                              |
| `ExpeditePendingSwapOut` | Yes            |                   ✅ |                 ✅ | No pause gating; admin-only expedite.                                                                         |
| `PauseVault`             | Yes            |                   ✅ |                 ❌ | Reconciles, snapshots `PausedBalance`, sets paused.                                                           |
| `UnpauseVault`           | Yes            |                   ❌ |                 ✅ | Clears `PausedBalance`, unpauses, emits with current TVV.                                                     |
