### PR TITLE
Add bypass to deposit interest funds

### DIFF
--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -252,7 +252,7 @@ func (k msgServer) DepositInterestFunds(goCtx context.Context, msg *types.MsgDep
 		return nil, fmt.Errorf("denom not supported for vault must be of type \"%s\" : got \"%s\"", vault.UnderlyingAsset, msg.Amount.Denom)
 	}
 
-	if err := k.BankKeeper.SendCoins(ctx, adminAddr, vaultAddr, sdk.NewCoins(msg.Amount)); err != nil {
+	if err := k.BankKeeper.SendCoins(markertypes.WithBypass(ctx), adminAddr, vaultAddr, sdk.NewCoins(msg.Amount)); err != nil {
 		return nil, fmt.Errorf("failed to deposit funds: %w", err)
 	}
 


### PR DESCRIPTION
This update modifies the **`DepositInterestFunds`** message server to bypass marker transfer restrictions when an administrator deposits funds into a vault.

Previously, an administrator could not deposit an `underlying_asset` that was a restricted coin if the vault account itself did not possess the marker's required attributes. The `BankKeeper.SendCoins` call is now wrapped with **`markertypes.WithBypass(ctx)`** to solve this.

This change is justified because the administrator is a trusted, vetted account that must have already satisfied the marker's restrictions to hold the funds in the first place. The vault is a programmatic, non-wallet account, and requiring it to hold arbitrary user-level attributes is impractical.

**Note:** This bypass is only for administrative *deposits into* the vault. The inverse operation, an admin withdrawing funds, will still correctly enforce that the receiving admin address possesses any required attributes. A new test case has been added to verify this functionality.

closes: #64 