### PR TITLE
Check for Nav pricing in forward and reverse order

### DIFF
--- a/keeper/suite_test.go
+++ b/keeper/suite_test.go
@@ -394,6 +394,23 @@ func (s *TestSuite) setupSinglePaymentDenomVault(underlyingDenom, shareDenom, pa
 	return vault
 }
 
+// setReverseNAV sets a reverse net asset value on the underlying denom marker,
+// allowing the vault to value the underlying in terms of the payment denom.
+func (s *TestSuite) setReverseNAV(underlyingDenom, paymentDenom string, price, volume int64) {
+	underlyingMarkerAddr := markertypes.MustGetMarkerAddress(underlyingDenom)
+	underlyingMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, underlyingMarkerAddr)
+	s.Require().NoError(err, "should fetch underlying marker for reverse NAV setup")
+	s.Require().NoError(s.k.MarkerKeeper.SetNetAssetValue(s.ctx, underlyingMarkerAccount, markertypes.NetAssetValue{
+		Price:  sdk.NewInt64Coin(paymentDenom, price),
+		Volume: uint64(volume),
+	}, "test-reverse"), "should set reverse NAV %s->%s=%d/%d", underlyingDenom, paymentDenom, price, volume)
+}
+
+// bumpHeight increments the suite's context block height by 1.
+func (s *TestSuite) bumpHeight() {
+	s.ctx = s.ctx.WithBlockHeight(s.ctx.BlockHeight() + 1)
+}
+
 // createBridgeMintSharesEventsExact returns the exact ordered events a successful
 // BridgeMintShares emits: marker mint to the share marker, withdraw to the bridge,
 // then the vault EventBridgeMintShares—suitable for strict equality checks in tests.


### PR DESCRIPTION
The existing `UnitPriceFraction` implementation only supported forward NAV lookups (`srcDenom → underlyingAsset`). This caused failures when only a reverse NAV (`underlyingAsset → srcDenom`) was available (Figure only saves `uylds.fcc` in one direction). In practice, depending on how NAVs are emitted, sometimes the price relationship may only exist in the reverse direction. Without support for this, vault operations that require price conversions could not proceed, leading to "nav not found" errors even when valid NAV data existed.
