### PR TITLE
Fix vault account validation check in genesis

### DIFF
--- a/keeper/genesis.go
+++ b/keeper/genesis.go
@@ -21,7 +21,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 	accounts := k.AuthKeeper.GetAllAccounts(ctx)
 	for _, acc := range accounts {
 		if v, ok := acc.(types.VaultAccountI); ok {
-			if err := v.Validate(); err == nil {
+			if err := v.Validate(); err != nil {
 				panic(err)
 			}
 			k.SetVaultLookup(ctx, v.Clone())


### PR DESCRIPTION
This check was not exercised in test, because when importing a genesis anything from auth module will be of type AccountI not VaultAccountI.  Later in the import process we check the account address if it is a vault and apply the VaultAccountI.