### PR TITLE
Add hardcoded uylds.fcc to vault valuation engine

### DIFF
--- a/keeper/valuation_engine.go
+++ b/keeper/valuation_engine.go
@@ -24,7 +24,11 @@ import (
 //   - Errors if no NAV exists for (srcDenom → underlyingAsset).
 //   - Errors if NAV.Volume == 0.
 func (k Keeper) UnitPriceFraction(ctx sdk.Context, srcDenom, underlyingAsset string) (num, den math.Int, err error) {
-	if srcDenom == underlyingAsset {
+	// Currently, we are treating "uylds.fcc" as a universal stablecoin equivalent to the underlying asset.
+	// This is a temporary measure until we have a more robust multi-currency support and stablecoin handling.
+	// The assumption is that "uylds.fcc" is always pegged 1:1 with the underlying asset for vault valuation purposes.
+	// For more information, see https://github.com/ProvLabs/vault/issues/73
+	if srcDenom == underlyingAsset || underlyingAsset == "uylds.fcc" {
 		return math.NewInt(1), math.NewInt(1), nil
 	}
 	nav, err := k.MarkerKeeper.GetNetAssetValue(ctx, srcDenom, underlyingAsset)

--- a/keeper/valuation_engine.go
+++ b/keeper/valuation_engine.go
@@ -27,6 +27,9 @@ import (
 //
 // Source selection
 //   - If srcDenom == underlyingAsset, returns (1, 1).
+//   - If underlyingAsset == "uylds.fcc", returns (1, 1) regardless of any NAVs.
+//     This is a temporary 1:1 stablecoin peg used for valuation until broader multi-currency
+//     support exists. See https://github.com/ProvLabs/vault/issues/73.
 //   - Attempt to read both forward and reverse NAVs.
 //   - If only one exists, use it.
 //   - If both exist, choose the one with the greater UpdatedBlockHeight (newest).


### PR DESCRIPTION
**Summary**
Upstream settlement NAVs aren’t reliable enough yet. For the first vault iteration, we hard-code our main case and keep everything else as beta.

**Changes**

* Treat `uylds.fcc` as a 1:1 peg to the underlying: `UnitPriceFraction` returns `(1,1)` when `srcDenom == underlyingAsset` **or** `underlyingAsset == "uylds.fcc"`.
* For other pairs, still compute via NAV (supports forward/reverse lookups, picks the newest) with stricter zero checks.
* Tests add a case proving `uylds.fcc` overrides any non-1:1 NAV. Godoc notes the temporary behavior.

**Notes**

* Non-`uylds.fcc` NAV pricing remains beta.
* We’ll remove the hard-code once upstream NAVs are trustworthy (see issue #73).
