### PR TITLE
Add MaxSwapOutBatchSize

### DIFF
--- a/keeper/abci.go
+++ b/keeper/abci.go
@@ -4,6 +4,13 @@ import (
 	"context"
 )
 
+const (
+	// MaxSwapOutBatchSize is the maximum number of pending swap-out requests
+	// to process in a single EndBlocker invocation. This prevents a large queue
+	// from consuming excessive block time and memory.
+	MaxSwapOutBatchSize = 100
+)
+
 // BeginBlocker is a hook that is called at the beginning of every block.
 func (k *Keeper) BeginBlocker(ctx context.Context) error {
 	return k.handleVaultInterestTimeouts(ctx)
@@ -11,7 +18,7 @@ func (k *Keeper) BeginBlocker(ctx context.Context) error {
 
 // EndBlocker is a hook that is called at the end of every block.
 func (k *Keeper) EndBlocker(ctx context.Context) error {
-	if err := k.ProcessPendingSwapOuts(ctx); err != nil {
+	if err := k.ProcessPendingSwapOuts(ctx, MaxSwapOutBatchSize); err != nil {
 		return err
 	}
 

--- a/keeper/abci.go
+++ b/keeper/abci.go
@@ -7,7 +7,9 @@ import (
 const (
 	// MaxSwapOutBatchSize is the maximum number of pending swap-out requests
 	// to process in a single EndBlocker invocation. This prevents a large queue
-	// from consuming excessive block time and memory.
+	// from consuming excessive block time and memory. This is a temporary value
+	// and we will need to do more analysis on a proper batch size.
+	// See https://github.com/ProvLabs/vault/issues/75.
 	MaxSwapOutBatchSize = 100
 )
 

--- a/keeper/msg_server_security_test.go
+++ b/keeper/msg_server_security_test.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	markertypes "github.com/provenance-io/provenance/x/marker/types"
 
+	"github.com/provlabs/vault/keeper"
 	"github.com/provlabs/vault/types"
 	"github.com/provlabs/vault/utils"
 )
@@ -86,7 +87,7 @@ func (s *TestSuite) TestMsgServer_SmallFirstSwapIn_HugeDonation_SwapOut() {
 	_, err = s.k.SwapOut(s.ctx, vaultAddr, owner, sharesToBurn, "")
 	s.Require().NoError(err, "swap-out of all tiny depositor shares should succeed")
 
-	s.simApp.VaultKeeper.ProcessPendingSwapOuts(s.ctx)
+	s.simApp.VaultKeeper.ProcessPendingSwapOuts(s.ctx, keeper.MaxSwapOutBatchSize)
 	vault, err = s.k.GetVault(s.ctx, vaultAddr)
 	s.Require().NoError(err, "should successfully get vault after tiny swap-out")
 	s.Require().NotNil(vault, "vault should not be nil after tiny swap-out")

--- a/keeper/vault_test.go
+++ b/keeper/vault_test.go
@@ -205,7 +205,7 @@ func (s *TestSuite) TestSwapOut_MultiAsset() {
 	s.Require().NoError(err, "should successfully queue swap out for the default underlying asset")
 	s.Require().Equal(uint64(1), reqID2, "second request id should be 1")
 
-	err = s.k.ProcessPendingSwapOuts(s.ctx)
+	err = s.k.ProcessPendingSwapOuts(s.ctx, keeper.MaxSwapOutBatchSize)
 	s.Require().NoError(err, "processing pending withdrawals should not fail")
 
 	// --- Assert Final Balances ---
@@ -407,7 +407,7 @@ func (s *TestSuite) TestSwapOut_SucceedsWithRestrictedUnderlyingAssetRequiredAtt
 
 	s.assertBalance(redeemerAddr, shareDenom, sharesForRedeemer.Sub(sharesToRedeem.Amount))
 	s.assertBalance(vault.GetAddress(), shareDenom, sharesToRedeem.Amount)
-	err = s.k.ProcessPendingSwapOuts(s.ctx)
+	err = s.k.ProcessPendingSwapOuts(s.ctx, keeper.MaxSwapOutBatchSize)
 	s.Require().NoError(err, "processing pending withdrawals should not fail")
 
 	s.assertBalance(redeemerAddr, restrictedUnderlyingDenom, math.NewInt(50))

--- a/spec/06_blocker.md
+++ b/spec/06_blocker.md
@@ -88,6 +88,8 @@ Ordering is intentional:
 
 At block end, the module fulfills **due swap-out requests**:
 
+To prevent a large queue from consuming excessive block time and memory, a maximum of `MaxSwapOutBatchSize` (currently 100) requests are processed per block.
+
 1. **Collect due requests** from `PendingSwapOutQueue` with `dueTime <= now`.
 
    * Skip paused vaults; they remain queued.


### PR DESCRIPTION
### Summary:

This PR introduces a batching mechanism to the swap-out process to prevent potential withdrawal exhaustion and excessive block time consumption.

### Key changes:

- A MaxSwapOutBatchSize constant has been added to limit the number of pending swap-out requests processed per block.
- The ProcessPendingSwapOuts function now accepts a batchSize parameter to control the number of swaps processed.
- The EndBlocker has been updated to use this new batching functionality.
- Tests have been updated to reflect these changes and ensure the batching mechanism works as expected.