### PR TITLE
Publish NAV for the share denom on reconcile

### DIFF
--- a/keeper/payout_test.go
+++ b/keeper/payout_test.go
@@ -155,6 +155,7 @@ func (s *TestSuite) TestKeeper_ProcessPendingSwapOuts() {
 				reconcileEvent, err := sdk.TypedEventToEvent(types.NewEventVaultReconcile(vaultAddr.String(), assets, assets, vault.CurrentInterestRate, testBlockTime.Unix()-1, math.NewInt(0)))
 				s.Require().NoError(err, "should not error converting typed EventVaultReconciled")
 				expectedEvents = append(expectedEvents, reconcileEvent)
+				expectedEvents = append(expectedEvents, createMarkerSetNAV(shareDenom, assets, "vault", shares.Amount.Uint64()))
 				expectedEvents = append(expectedEvents, createSendCoinEvents(principalAddress.String(), ownerAddr.String(), sdk.NewCoins(assets).String())...)
 				expectedEvents = append(expectedEvents, createSendCoinEvents(vaultAddr.String(), principalAddress.String(), shares.String())...)
 				expectedEvents = append(expectedEvents, createMarkerBurn(vaultAddr, principalAddress, shares)...)

--- a/keeper/reconcile_test.go
+++ b/keeper/reconcile_test.go
@@ -17,6 +17,7 @@ func (s *TestSuite) TestKeeper_ReconcileVaultInterest() {
 	twoMonths := -24 * 60 * time.Hour
 	shareDenom := "vaultshares"
 	underlying := sdk.NewInt64Coin("underlying", 1_000_000_000)
+	totalShares := sdk.NewInt64Coin(shareDenom, 1_000_000_000_000_000)
 	vaultAddress := types.GetVaultAddress(shareDenom)
 	testBlockTime := time.Now()
 	futureTime := testBlockTime.Add(100 * time.Second)
@@ -37,11 +38,14 @@ func (s *TestSuite) TestKeeper_ReconcileVaultInterest() {
 		vault.DesiredInterestRate = interestRate
 		vault.PeriodStart = periodStartSeconds
 		vault.Paused = paused
+		vault.TotalShares = totalShares
 		s.k.AuthKeeper.SetAccount(s.ctx, vault)
+
 		err = FundAccount(s.ctx, s.simApp.BankKeeper, vaultAddress, sdk.NewCoins(underlying))
 		s.Require().NoError(err)
 		err = FundAccount(s.ctx, s.simApp.BankKeeper, markertypes.MustGetMarkerAddress(shareDenom), sdk.NewCoins(underlying))
 		s.Require().NoError(err)
+
 		s.ctx = s.ctx.WithBlockTime(testBlockTime)
 		s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
 	}
@@ -84,7 +88,25 @@ func (s *TestSuite) TestKeeper_ReconcileVaultInterest() {
 				s.assertInPayoutVerificationQueue(vaultAddress, true)
 				s.assertVaultAndMarkerBalances(vaultAddress, shareDenom, underlying.Denom, sdkmath.NewInt(958047987), sdkmath.NewInt(1041952013))
 			},
-			expectedEvents: createReconcileEvents(vaultAddress, markertypes.MustGetMarkerAddress(shareDenom), sdkmath.NewInt(41952013), sdkmath.NewInt(1_000_000_000), sdkmath.NewInt(1041952013), underlying.Denom, "0.25", 5_184_000),
+			expectedEvents: func() sdk.Events {
+				ev := createReconcileEvents(
+					vaultAddress,
+					markertypes.MustGetMarkerAddress(shareDenom),
+					sdkmath.NewInt(41952013),
+					sdkmath.NewInt(1_000_000_000),
+					sdkmath.NewInt(1_041_952_013),
+					underlying.Denom,
+					"0.25",
+					5_184_000,
+				)
+				nav := createMarkerSetNAV(
+					shareDenom,
+					sdk.NewCoin(underlying.Denom, sdkmath.NewInt(1_041_952_013)),
+					"vault",
+					totalShares.Amount.Uint64(),
+				)
+				return append(ev, nav)
+			}(),
 		},
 		{
 			name: "interest period has elasped, should pay negative interest and update period start",
@@ -93,9 +115,27 @@ func (s *TestSuite) TestKeeper_ReconcileVaultInterest() {
 			},
 			posthander: func() {
 				s.assertInPayoutVerificationQueue(vaultAddress, true)
-				s.assertVaultAndMarkerBalances(vaultAddress, shareDenom, underlying.Denom, sdkmath.NewInt(1040262904), sdkmath.NewInt(959737096))
+				s.assertVaultAndMarkerBalances(vaultAddress, shareDenom, underlying.Denom, sdkmath.NewInt(1_040_262_904), sdkmath.NewInt(959_737_096))
 			},
-			expectedEvents: createReconcileEvents(vaultAddress, markertypes.MustGetMarkerAddress(shareDenom), sdkmath.NewInt(-40262904), sdkmath.NewInt(1_000_000_000), sdkmath.NewInt(959737096), underlying.Denom, "-0.25", 5_184_000),
+			expectedEvents: func() sdk.Events {
+				ev := createReconcileEvents(
+					vaultAddress,
+					markertypes.MustGetMarkerAddress(shareDenom),
+					sdkmath.NewInt(-40_262_904),
+					sdkmath.NewInt(1_000_000_000),
+					sdkmath.NewInt(959_737_096),
+					underlying.Denom,
+					"-0.25",
+					5_184_000,
+				)
+				nav := createMarkerSetNAV(
+					shareDenom,
+					sdk.NewCoin(underlying.Denom, sdkmath.NewInt(959_737_096)),
+					"vault",
+					totalShares.Amount.Uint64(),
+				)
+				return append(ev, nav)
+			}(),
 		},
 		{
 			name: "paused vault, should do nothing",
@@ -106,7 +146,7 @@ func (s *TestSuite) TestKeeper_ReconcileVaultInterest() {
 				s.assertInPayoutVerificationQueue(vaultAddress, false)
 				vault, err := s.k.GetVault(s.ctx, vaultAddress)
 				s.Require().NoError(err)
-				s.Require().Equal(pastTime.Unix(), vault.PeriodStart, "PeriodStart should not be updated for paused vault")
+				s.Require().Equal(pastTime.Unix(), vault.PeriodStart)
 			},
 			expectedEvents: sdk.Events{},
 		},
@@ -120,7 +160,7 @@ func (s *TestSuite) TestKeeper_ReconcileVaultInterest() {
 			}
 
 			vault, err := s.k.GetVault(s.ctx, vaultAddress)
-			s.Require().NoError(err, "failed to get vault for test setup")
+			s.Require().NoError(err)
 			err = s.k.ReconcileVaultInterest(s.ctx, vault)
 
 			if tc.posthander != nil {

--- a/keeper/reconcile_test.go
+++ b/keeper/reconcile_test.go
@@ -180,37 +180,6 @@ func (s *TestSuite) TestKeeper_ReconcileVaultInterest() {
 	}
 }
 
-func createReconcileEvents(vaultAddr, markerAddr sdk.AccAddress, interest, principle, principleAfter sdkmath.Int, denom, rate string, durations int64) []sdk.Event {
-	var allEvents []sdk.Event
-
-	r, err := sdkmath.LegacyNewDecFromStr(rate)
-	if err != nil {
-		panic(fmt.Sprintf("invalid rate %s: %v", rate, err))
-	}
-	var fromAddress string
-	var toAddress string
-	if r.IsNegative() {
-		fromAddress = markerAddr.String()
-		toAddress = vaultAddr.String()
-	} else {
-		fromAddress = vaultAddr.String()
-		toAddress = markerAddr.String()
-	}
-	sendToMarkerEvents := createSendCoinEvents(fromAddress, toAddress, sdk.NewCoin(denom, interest.Abs()).String())
-	allEvents = append(allEvents, sendToMarkerEvents...)
-
-	reconcileEvent := sdk.NewEvent("vault.v1.EventVaultReconcile",
-		sdk.NewAttribute("interest_earned", CoinToJSON(sdk.Coin{Denom: denom, Amount: interest})),
-		sdk.NewAttribute("principal_after", CoinToJSON(sdk.NewCoin(denom, principleAfter))),
-		sdk.NewAttribute("principal_before", CoinToJSON(sdk.NewCoin(denom, principle))),
-		sdk.NewAttribute("rate", rate),
-		sdk.NewAttribute("time", fmt.Sprintf("%v", durations)),
-		sdk.NewAttribute("vault_address", vaultAddr.String()),
-	)
-	allEvents = append(allEvents, reconcileEvent)
-	return allEvents
-}
-
 func (s *TestSuite) TestKeeper_CalculateVaultTotalAssets() {
 	shareDenom := "vaultshares"
 	underlying := sdk.NewInt64Coin("underlying", 1_000_000_000)

--- a/keeper/suite_test.go
+++ b/keeper/suite_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -429,4 +430,15 @@ func createBridgeMintSharesEventsExact(vaultAddr, bridgeAddr sdk.AccAddress, sha
 	))
 
 	return events
+}
+
+// createMarkerSetNAV constructs the expected event emitted when a marker's NAV
+func createMarkerSetNAV(shareDenom string, price sdk.Coin, source string, volume uint64) sdk.Event {
+	return sdk.NewEvent(
+		"provenance.marker.v1.EventSetNetAssetValue",
+		sdk.NewAttribute("denom", shareDenom),
+		sdk.NewAttribute("price", price.String()),
+		sdk.NewAttribute("source", source),
+		sdk.NewAttribute("volume", strconv.FormatUint(volume, 10)),
+	)
 }


### PR DESCRIPTION
**Summary**

* Publish NAV for the share denom (expressed in underlying) when interest is actually applied during reconcile.
* Emits `provenance.marker.v1.EventSetNetAssetValue` with `denom=share`, `price=TVV in underlying`, `volume=total shares`, `source=vault`.

**Changes**

* Add `publishShareNav(...)` and call it after `PerformVaultInterestTransfer`.
* Update/extend tests to expect the NAV event (helper added), plus small test refactors with clearer assertions.

**Notes**

* No-op if paused, period not elapsed, zero shares, or non-positive TVV.
* Existing balances and flows unchanged outside of the new NAV publish.
