### PR TITLE
Add missing validation to `MsgCreateVaultRequest` and `MsgSwapOutRequest`

### DIFF
--- a/types/msgs.go
+++ b/types/msgs.go
@@ -62,6 +62,10 @@ func (m MsgCreateVaultRequest) ValidateBasic() error {
 		return fmt.Errorf("share denom (%q) cannot equal payment denom (%q)", m.ShareDenom, m.PaymentDenom)
 	}
 
+	if m.WithdrawalDelaySeconds > MaxWithdrawalDelay {
+		return fmt.Errorf("withdrawal delay cannot exceed %d seconds", MaxWithdrawalDelay)
+	}
+
 	return nil
 }
 

--- a/types/msgs.go
+++ b/types/msgs.go
@@ -55,6 +55,12 @@ func (m MsgCreateVaultRequest) ValidateBasic() error {
 	if m.UnderlyingAsset == m.PaymentDenom {
 		return fmt.Errorf("payment (%q) denom cannot equal underlying asset denom (%q)", m.PaymentDenom, m.UnderlyingAsset)
 	}
+	if m.ShareDenom == m.UnderlyingAsset {
+		return fmt.Errorf("share denom (%q) cannot equal underlying asset denom (%q)", m.ShareDenom, m.UnderlyingAsset)
+	}
+	if m.ShareDenom == m.PaymentDenom {
+		return fmt.Errorf("share denom (%q) cannot equal payment denom (%q)", m.ShareDenom, m.PaymentDenom)
+	}
 
 	return nil
 }
@@ -100,6 +106,12 @@ func (m MsgSwapOutRequest) ValidateBasic() error {
 
 	if !m.Assets.Amount.GT(sdkmath.NewInt(0)) {
 		return fmt.Errorf("invalid amount: assets %s must be greater than zero", m.Assets.Denom)
+	}
+
+	if m.RedeemDenom != "" {
+		if err := sdk.ValidateDenom(m.RedeemDenom); err != nil {
+			return fmt.Errorf("invalid redeem_denom: %w", err)
+		}
 	}
 
 	return nil

--- a/types/msgs_test.go
+++ b/types/msgs_test.go
@@ -113,6 +113,26 @@ func TestMsgCreateVaultRequest_ValidateBasic(t *testing.T) {
 			},
 			expectedErr: fmt.Errorf("payment (%q) denom cannot equal underlying asset denom (%q)", "uusd", "uusd"),
 		},
+		{
+			name: "share denom equals underlying (not allowed)",
+			msg: types.MsgCreateVaultRequest{
+				Admin:           admin,
+				ShareDenom:      "uusd",
+				UnderlyingAsset: "uusd",
+				PaymentDenom:    "usdc",
+			},
+			expectedErr: fmt.Errorf("share denom (%q) cannot equal underlying asset denom (%q)", "uusd", "uusd"),
+		},
+		{
+			name: "share denom equals payment denom (not allowed)",
+			msg: types.MsgCreateVaultRequest{
+				Admin:           admin,
+				ShareDenom:      "usdc",
+				UnderlyingAsset: "uusd",
+				PaymentDenom:    "usdc",
+			},
+			expectedErr: fmt.Errorf("share denom (%q) cannot equal payment denom (%q)", "usdc", "usdc"),
+		},
 	}
 
 	for _, tc := range tests {
@@ -216,6 +236,16 @@ func TestMsgSwapOutRequest_ValidateBasic(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name: "valid with redeem denom",
+			msg: types.MsgSwapOutRequest{
+				Owner:        owner,
+				VaultAddress: vault,
+				Assets:       sdk.NewInt64Coin("uusd", 100),
+				RedeemDenom:  "usdc",
+			},
+			expectedErr: nil,
+		},
+		{
 			name: "invalid vault address",
 			msg: types.MsgSwapOutRequest{
 				Owner:        owner,
@@ -250,6 +280,16 @@ func TestMsgSwapOutRequest_ValidateBasic(t *testing.T) {
 				Assets:       sdk.NewInt64Coin("uusd", 0),
 			},
 			expectedErr: fmt.Errorf("invalid amount: assets %s must be greater than zero", "uusd"),
+		},
+		{
+			name: "invalid redeem denom",
+			msg: types.MsgSwapOutRequest{
+				Owner:        owner,
+				VaultAddress: vault,
+				Assets:       sdk.NewInt64Coin("uusd", 100),
+				RedeemDenom:  "inv@lid$",
+			},
+			expectedErr: fmt.Errorf("invalid redeem_denom: %w", fmt.Errorf("invalid denom: %s", "inv@lid$")),
 		},
 	}
 

--- a/types/msgs_test.go
+++ b/types/msgs_test.go
@@ -133,6 +133,16 @@ func TestMsgCreateVaultRequest_ValidateBasic(t *testing.T) {
 			},
 			expectedErr: fmt.Errorf("share denom (%q) cannot equal payment denom (%q)", "usdc", "usdc"),
 		},
+		{
+			name: "swap out delay over two years (not allowed)",
+			msg: types.MsgCreateVaultRequest{
+				Admin:                  admin,
+				ShareDenom:             "vaultshare",
+				UnderlyingAsset:        "uusd",
+				WithdrawalDelaySeconds: types.MaxWithdrawalDelay + 1,
+			},
+			expectedErr: fmt.Errorf("withdrawal delay cannot exceed %d seconds", types.MaxWithdrawalDelay),
+		},
 	}
 
 	for _, tc := range tests {

--- a/types/vault.go
+++ b/types/vault.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	ZeroInterestRate = "0.0"
+	ZeroInterestRate   = "0.0"
+	MaxWithdrawalDelay = 31536000 * 2
 )
 
 var (

--- a/types/vault.go
+++ b/types/vault.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	ZeroInterestRate   = "0.0"
-	MaxWithdrawalDelay = 31536000 * 2
+	MaxWithdrawalDelay = 31536000 * 2 // 2 years in seconds
 )
 
 var (


### PR DESCRIPTION
**Summary:**
Enforces sane inputs for vault creation and swap-out.

**What changed**

* `MsgCreateVaultRequest.ValidateBasic`

  * Disallow `share_denom == underlying_asset`.
  * Disallow `share_denom == payment_denom`.
  * Enforce `WithdrawalDelaySeconds <= MaxWithdrawalDelay` (two years).
* `MsgSwapOutRequest.ValidateBasic`

  * Validate optional `redeem_denom` with `sdk.ValidateDenom`.
* Add `MaxWithdrawalDelay` constant.
* Update tests to cover new checks and happy paths.

**Why:**
Prevents ambiguous denom semantics, rejects malformed redeem denoms, and blocks unbounded withdrawal delays. No behavior changes for valid callers.
