### PR TITLE
Temporarily hardcode 1:1 nav ration when payment token is "uylds.fcc"

### DIFF
--- a/keeper/query_server.go
+++ b/keeper/query_server.go
@@ -116,7 +116,7 @@ func (k queryServer) EstimateSwapIn(goCtx context.Context, req *types.QueryEstim
 		return nil, status.Errorf(codes.InvalidArgument, "unsupported deposit denom: %q", req.Assets.Denom)
 	}
 
-	priceNum, priceDen, err := k.UnitPriceFraction(ctx, req.Assets.Denom, vault.UnderlyingAsset)
+	priceNum, priceDen, err := k.UnitPriceFraction(ctx, req.Assets.Denom, *vault)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "no NAV for %s/%s: %v", req.Assets.Denom, vault.UnderlyingAsset, err)
 	}
@@ -189,7 +189,7 @@ func (k queryServer) EstimateSwapOut(goCtx context.Context, req *types.QueryEsti
 		return nil, status.Errorf(codes.Internal, "failed to estimate total assets: %v", err)
 	}
 
-	priceNum, priceDen, err := k.UnitPriceFraction(ctx, redeemDenom, vault.UnderlyingAsset)
+	priceNum, priceDen, err := k.UnitPriceFraction(ctx, redeemDenom, *vault)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "no NAV for %s/%s: %v", redeemDenom, vault.UnderlyingAsset, err)
 	}

--- a/keeper/valuation_engine.go
+++ b/keeper/valuation_engine.go
@@ -12,42 +12,40 @@ import (
 )
 
 // UnitPriceFraction returns the unit price of srcDenom expressed in underlyingAsset
-// as an integer fraction (numerator, denominator), using marker Net Asset Value (NAV).
+// as an integer fraction (numerator, denominator) using marker Net Asset Value (NAV).
 //
 // Semantics
 //   - Forward NAV (srcDenom → underlyingAsset):
-//     NAV.Price is the total value in underlyingAsset units for NAV.Volume units of srcDenom.
-//     => 1 srcDenom = NAV.Price.Amount / NAV.Volume underlyingAsset.
-//     => returns (NAV.Price.Amount, NAV.Volume).
+//     NAV.Price is total underlying units for NAV.Volume units of srcDenom.
+//     1 srcDenom = NAV.Price.Amount / NAV.Volume underlyingAsset → (num, den) = (NAV.Price.Amount, NAV.Volume).
 //   - Reverse NAV (underlyingAsset → srcDenom):
-//     NAV.Price is the total value in srcDenom units for NAV.Volume units of underlyingAsset.
-//     => 1 srcDenom = NAV.Volume / NAV.Price.Amount underlyingAsset.
-//     => returns (NAV.Volume, NAV.Price.Amount).
-//   - The fraction is returned in integers so callers can apply floor-safe arithmetic.
+//     NAV.Price is total srcDenom units for NAV.Volume units of underlyingAsset.
+//     1 srcDenom = NAV.Volume / NAV.Price.Amount underlyingAsset → (num, den) = (NAV.Volume, NAV.Price.Amount).
+//
+// The result is integer (floor-safe) arithmetic.
 //
 // Source selection
-//   - If srcDenom == underlyingAsset, returns (1, 1).
-//   - If underlyingAsset == "uylds.fcc", returns (1, 1) regardless of any NAVs.
-//     This is a temporary 1:1 stablecoin peg used for valuation until broader multi-currency
-//     support exists. See https://github.com/ProvLabs/vault/issues/73.
-//   - Attempt to read both forward and reverse NAVs.
+// - Identity/peg fast-paths return (1, 1):
+//   - If srcDenom == underlyingAsset
+//   - If underlyingAsset == "uylds.fcc" (temporary 1:1 peg; see https://github.com/ProvLabs/vault/issues/73)
+//   - If vault.PaymentDenom == "uylds.fcc" (temporary 1:1 peg; see https://github.com/ProvLabs/vault/issues/73)
+//
+// - Otherwise read both forward and reverse NAVs:
 //   - If only one exists, use it.
 //   - If both exist, choose the one with the greater UpdatedBlockHeight (newest).
 //
 // Errors
-//   - If neither forward nor reverse NAV exists, returns an error. If one lookup errored,
-//     that error is returned; otherwise "nav not found for src/underlying".
-//   - For the chosen NAV direction:
+// - If neither NAV exists, return the lookup error (if any) or "nav not found for src/underlying".
+// - For the selected NAV direction:
 //   - Forward: error if NAV.Volume == 0.
 //   - Reverse: error if NAV.Price.Amount == 0.
 //
 // Returns
-//   - (num, den) as math.Int, suitable for computing: floor(x * num / den).
+// - (num, den) as math.Int, suitable for floor(x * num / den).
 func (k Keeper) UnitPriceFraction(ctx sdk.Context, srcDenom string, vault types.VaultAccount) (num, den math.Int, err error) {
-	// Currently, we are treating "uylds.fcc" as a universal stablecoin equivalent to the underlying asset.
-	// This is a temporary measure until we have a more robust multi-currency support and stablecoin handling.
-	// The assumption is that "uylds.fcc" is always pegged 1:1 with the underlying asset for vault valuation purposes.
-	// For more information, see https://github.com/ProvLabs/vault/issues/73
+	// For now, if either the vault’s underlying asset or payment denom is "uylds.fcc",
+	// we assume a 1:1 equivalence between the payment denom and the underlying denom.
+	// See https://github.com/ProvLabs/vault/issues/73 for details.
 	underlyingAsset := vault.UnderlyingAsset
 	if srcDenom == underlyingAsset || underlyingAsset == "uylds.fcc" || vault.PaymentDenom == "uylds.fcc" {
 		return math.NewInt(1), math.NewInt(1), nil

--- a/keeper/valuation_engine.go
+++ b/keeper/valuation_engine.go
@@ -43,11 +43,16 @@ import (
 // Returns
 // - (num, den) as math.Int, suitable for floor(x * num / den).
 func (k Keeper) UnitPriceFraction(ctx sdk.Context, srcDenom string, vault types.VaultAccount) (num, den math.Int, err error) {
+	underlyingAsset := vault.UnderlyingAsset
+	if srcDenom == underlyingAsset {
+		return math.NewInt(1), math.NewInt(1), nil
+	}
+
 	// For now, if either the vault’s underlying asset or payment denom is "uylds.fcc",
 	// we assume a 1:1 equivalence between the payment denom and the underlying denom.
 	// See https://github.com/ProvLabs/vault/issues/73 for details.
-	underlyingAsset := vault.UnderlyingAsset
-	if srcDenom == underlyingAsset || underlyingAsset == "uylds.fcc" || vault.PaymentDenom == "uylds.fcc" {
+	const uyldsFccDenom = "uylds.fcc"
+	if srcDenom == uyldsFccDenom && (vault.PaymentDenom == uyldsFccDenom || underlyingAsset == uyldsFccDenom) {
 		return math.NewInt(1), math.NewInt(1), nil
 	}
 

--- a/keeper/valuation_engine.go
+++ b/keeper/valuation_engine.go
@@ -52,7 +52,7 @@ func (k Keeper) UnitPriceFraction(ctx sdk.Context, srcDenom string, vault types.
 	// we assume a 1:1 equivalence between the payment denom and the underlying denom.
 	// See https://github.com/ProvLabs/vault/issues/73 for details.
 	const uyldsFccDenom = "uylds.fcc"
-	if srcDenom == uyldsFccDenom && (vault.PaymentDenom == uyldsFccDenom || underlyingAsset == uyldsFccDenom) {
+	if vault.PaymentDenom == uyldsFccDenom || underlyingAsset == uyldsFccDenom {
 		return math.NewInt(1), math.NewInt(1), nil
 	}
 

--- a/keeper/valuation_engine_test.go
+++ b/keeper/valuation_engine_test.go
@@ -7,6 +7,7 @@ import (
 	markertypes "github.com/provenance-io/provenance/x/marker/types"
 
 	"github.com/provlabs/vault/keeper"
+	"github.com/provlabs/vault/types"
 	"github.com/provlabs/vault/utils"
 )
 
@@ -19,17 +20,28 @@ func (s *TestSuite) TestUnitPriceFraction_Table() {
 	cases := []struct {
 		name                  string
 		fromDenom             string
-		toDenom               string
+		underlyingOverride    string
+		paymentOverride       string
 		setup                 func()
 		expectedNumerator     int64
 		expectedDenominator   int64
 		expectedErrorContains string
 	}{
-		{name: "identity", fromDenom: underlyingDenom, toDenom: underlyingDenom, expectedNumerator: 1, expectedDenominator: 1},
-		{name: "nav-present", fromDenom: paymentDenom, toDenom: underlyingDenom, expectedNumerator: 1, expectedDenominator: 2},
+		{
+			name:                "identity",
+			fromDenom:           underlyingDenom,
+			expectedNumerator:   1,
+			expectedDenominator: 1,
+		},
+		{
+			name:                "forward-nav-present",
+			fromDenom:           paymentDenom,
+			expectedNumerator:   1,
+			expectedDenominator: 2,
+		},
 		{
 			name:      "reverse-nav-present-newer",
-			fromDenom: paymentDenom, toDenom: underlyingDenom,
+			fromDenom: paymentDenom,
 			setup: func() {
 				s.bumpHeight()
 				s.setReverseNAV(underlyingDenom, paymentDenom, 2, 1)
@@ -39,7 +51,7 @@ func (s *TestSuite) TestUnitPriceFraction_Table() {
 		},
 		{
 			name:      "reverse-nav-selected-zero-price-errors",
-			fromDenom: paymentDenom, toDenom: underlyingDenom,
+			fromDenom: paymentDenom,
 			setup: func() {
 				s.bumpHeight()
 				s.setReverseNAV(underlyingDenom, paymentDenom, 0, 1)
@@ -47,40 +59,102 @@ func (s *TestSuite) TestUnitPriceFraction_Table() {
 			expectedErrorContains: "nav price is zero",
 		},
 		{
-			name:      "underlying-uylds.fcc-overrides-nav",
-			fromDenom: paymentDenom, toDenom: "uylds.fcc",
+			name:               "underlying-uylds.fcc-overrides-nav",
+			fromDenom:          paymentDenom,
+			underlyingOverride: "uylds.fcc",
 			setup: func() {
 				pmtMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
 				pmtMarkerAcct, err := s.k.MarkerKeeper.GetMarker(s.ctx, pmtMarkerAddr)
-				s.Require().NoError(err, "setup(%s): fetch payment marker", "underlying-uylds.fcc-overrides-nav")
+				s.Require().NoError(err)
 				err = s.k.MarkerKeeper.SetNetAssetValue(s.ctx, pmtMarkerAcct, markertypes.NetAssetValue{
 					Price:  sdk.NewInt64Coin("uylds.fcc", 5),
 					Volume: 2,
 				}, "test-uylds-fcc")
-				s.Require().NoError(err, "setup(%s): set forward NAV usdc->uylds.fcc", "underlying-uylds.fcc-overrides-nav")
+				s.Require().NoError(err)
 			},
 			expectedNumerator:   1,
 			expectedDenominator: 1,
 		},
-		{name: "nav-missing", fromDenom: "unknown", toDenom: underlyingDenom, expectedErrorContains: "nav not found"},
+		{
+			name:              "payment-uylds.fcc-overrides-nav",
+			fromDenom:         paymentDenom,
+			paymentOverride:   "uylds.fcc",
+			expectedNumerator: 1, expectedDenominator: 1,
+		},
+		{
+			name:                  "nav-missing",
+			fromDenom:             "unknown",
+			expectedErrorContains: "nav not found",
+		},
+		{
+			name:      "both-present-forward-newer-selected",
+			fromDenom: paymentDenom,
+			setup: func() {
+				pmtMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
+				pmtMarkerAcct, err := s.k.MarkerKeeper.GetMarker(s.ctx, pmtMarkerAddr)
+				s.Require().NoError(err)
+				err = s.k.MarkerKeeper.SetNetAssetValue(s.ctx, pmtMarkerAcct, markertypes.NetAssetValue{
+					Price:  sdk.NewInt64Coin(underlyingDenom, 3),
+					Volume: 2,
+				}, "fwd-newer")
+				s.Require().NoError(err)
+				s.setReverseNAV(underlyingDenom, paymentDenom, 5, 7)
+				s.bumpHeight()
+				err = s.k.MarkerKeeper.SetNetAssetValue(s.ctx, pmtMarkerAcct, markertypes.NetAssetValue{
+					Price:  sdk.NewInt64Coin(underlyingDenom, 6),
+					Volume: 4,
+				}, "fwd-newest")
+				s.Require().NoError(err)
+			},
+			expectedNumerator:   6,
+			expectedDenominator: 4,
+		},
+		{
+			name:      "both-present-same-height-forward-wins",
+			fromDenom: paymentDenom,
+			setup: func() {
+				pmtMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
+				pmtMarkerAcct, err := s.k.MarkerKeeper.GetMarker(s.ctx, pmtMarkerAddr)
+				s.Require().NoError(err)
+				s.setReverseNAV(underlyingDenom, paymentDenom, 11, 5)
+				err = s.k.MarkerKeeper.SetNetAssetValue(s.ctx, pmtMarkerAcct, markertypes.NetAssetValue{
+					Price:  sdk.NewInt64Coin(underlyingDenom, 9),
+					Volume: 3,
+				}, "fwd-same-height")
+				s.Require().NoError(err)
+			},
+			expectedNumerator:   9,
+			expectedDenominator: 3,
+		},
 	}
 
-	for _, scenario := range cases {
-		s.Run(scenario.name, func() {
-			if scenario.setup != nil {
-				scenario.setup()
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			if tc.setup != nil {
+				tc.setup()
+			}
+			vault := types.VaultAccount{
+				UnderlyingAsset: underlyingDenom,
+				PaymentDenom:    paymentDenom,
+				TotalShares:     sdk.NewInt64Coin(shareDenom, 0),
+			}
+			if tc.underlyingOverride != "" {
+				vault.UnderlyingAsset = tc.underlyingOverride
+			}
+			if tc.paymentOverride != "" {
+				vault.PaymentDenom = tc.paymentOverride
 			}
 			testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-			numerator, denominator, err := testKeeper.UnitPriceFraction(s.ctx, scenario.fromDenom, scenario.toDenom)
-			if scenario.expectedErrorContains != "" {
-				s.Require().Error(err, "case %q: expected an error", scenario.name)
-				s.Require().Contains(err.Error(), scenario.expectedErrorContains, "case %q: error message mismatch", scenario.name)
+			num, den, err := testKeeper.UnitPriceFraction(s.ctx, tc.fromDenom, vault)
+			if tc.expectedErrorContains != "" {
+				s.Require().Error(err, "case %q", tc.name)
+				s.Require().Contains(err.Error(), tc.expectedErrorContains, "case %q", tc.name)
 				return
 			}
-			s.Require().NoError(err, "case %q: unexpected error", scenario.name)
-			s.Require().Equal(math.NewInt(scenario.expectedNumerator), numerator, "case %q: numerator mismatch", scenario.name)
-			s.Require().Equal(math.NewInt(scenario.expectedDenominator), denominator, "case %q: denominator mismatch", scenario.name)
-			s.Require().True(denominator.IsPositive(), "case %q: expected positive denominator", scenario.name)
+			s.Require().NoError(err, "case %q", tc.name)
+			s.Require().Equal(math.NewInt(tc.expectedNumerator), num, "case %q numerator", tc.name)
+			s.Require().Equal(math.NewInt(tc.expectedDenominator), den, "case %q denominator", tc.name)
+			s.Require().True(den.IsPositive(), "case %q denominator positive", tc.name)
 		})
 	}
 }


### PR DESCRIPTION
This update adds to the `UnitPriceFraction` logic to also check the vault’s **payment denom** for `uylds.fcc`, treating it as a 1:1 peg with the underlying asset.

This change is needed because upcoming interest payout logic will require the **receipt token** to serve as the vault’s underlying asset when distributing interest from reserves on a block-by-block basis.

However, this also means that the **vault’s Total Vault Value (TVV)** will now be expressed in receipt tokens instead of YLDS. In the future, we may want to have the queries return the vault’s valuation in both units.  Not just the underlying asset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic 1:1 peg handling for uylds.fcc payments in pricing and conversions.

- Bug Fixes
  - Unit price calculations now derive context from the selected vault for more accurate pricing.
  - Improved forward/reverse NAV resolution and safer behavior when NAV data is missing.
  - Validation to prevent invalid denominators and mismatched conversions.

- Tests
  - Expanded coverage for vault-based scenarios, NAV presence/absence, peg interactions, and edge cases.

- Refactor
  - Pricing and conversion flows now consistently use vault-based context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->