### PR TITLE
Fix duplicate proto interfaces naming

### DIFF
--- a/module.go
+++ b/module.go
@@ -60,22 +60,6 @@ func (AppModuleBasic) RegisterLegacyAminoCodec(_ *codec.LegacyAmino) {}
 // RegisterInterfaces registers vault interfaces to the interface registry.
 func (AppModuleBasic) RegisterInterfaces(reg codectypes.InterfaceRegistry) {
 	types.RegisterInterfaces(reg)
-
-	reg.RegisterInterface(
-		"provlabs.vault.v1.VaultAccount",
-		(*types.VaultAccountI)(nil),
-		&types.VaultAccount{},
-	)
-	reg.RegisterInterface(
-		"provlabs.vault.v1.VaultAccount",
-		(*sdk.AccountI)(nil),
-		&types.VaultAccount{},
-	)
-	reg.RegisterInterface(
-		"provlabs.vault.v1.VaultAccount",
-		(*authtypes.GenesisAccount)(nil),
-		&types.VaultAccount{},
-	)
 }
 
 // RegisterGRPCGatewayRoutes sets up gRPC gateway routes.

--- a/types/codec.go
+++ b/types/codec.go
@@ -8,6 +8,12 @@ import (
 	proto "github.com/cosmos/gogoproto/proto"
 )
 
+var (
+	_ VaultAccountI            = (*VaultAccount)(nil)
+	_ sdk.AccountI             = (*VaultAccount)(nil)
+	_ authtypes.GenesisAccount = (*VaultAccount)(nil)
+)
+
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	messages := make([]proto.Message, len(AllRequestMsgs))
 	copy(messages, AllRequestMsgs)

--- a/types/codec.go
+++ b/types/codec.go
@@ -8,20 +8,27 @@ import (
 	proto "github.com/cosmos/gogoproto/proto"
 )
 
-// RegisterInterfaces registers the vault module's message types for protobuf interface compatibility.
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	messages := make([]proto.Message, len(AllRequestMsgs))
 	copy(messages, AllRequestMsgs)
 	registry.RegisterImplementations((*sdk.Msg)(nil), messages...)
 
 	registry.RegisterInterface(
-		"provlabs.vault.v1.VaultAccount",
+		"provlabs.vault.v1.VaultAccountI",
+		(*VaultAccountI)(nil),
+	)
+
+	registry.RegisterImplementations(
+		(*VaultAccountI)(nil),
+		&VaultAccount{},
+	)
+
+	registry.RegisterImplementations(
 		(*sdk.AccountI)(nil),
 		&VaultAccount{},
 	)
 
-	registry.RegisterInterface(
-		"provlabs.vault.v1.VaultAccount",
+	registry.RegisterImplementations(
 		(*authtypes.GenesisAccount)(nil),
 		&VaultAccount{},
 	)

--- a/types/codec_test.go
+++ b/types/codec_test.go
@@ -10,14 +10,13 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
-	"github.com/provlabs/vault/types"
 	vaulttypes "github.com/provlabs/vault/types"
 )
 
 func TestVaultAccount_UnpackIntoAllInterfaces(t *testing.T) {
 	reg := codectypes.NewInterfaceRegistry()
 	authtypes.RegisterInterfaces(reg)
-	types.RegisterInterfaces(reg)
+	vaulttypes.RegisterInterfaces(reg)
 
 	cdc := codec.NewProtoCodec(reg)
 	any, err := codectypes.NewAnyWithValue(&vaulttypes.VaultAccount{})

--- a/types/codec_test.go
+++ b/types/codec_test.go
@@ -29,8 +29,12 @@ func TestVaultAccount_UnpackIntoAllInterfaces(t *testing.T) {
 	var asAccount sdk.AccountI
 	require.NoError(t, cdc.UnpackAny(any, &asAccount), "failed to unpack Any into AccountI")
 	require.NotNil(t, asAccount, "unpacked AccountI is nil")
+	_, ok := asAccount.(*vaulttypes.VaultAccount)
+	require.True(t, ok, "AccountI did not unwrap to *VaultAccount")
 
 	var asGenesis authtypes.GenesisAccount
 	require.NoError(t, cdc.UnpackAny(any, &asGenesis), "failed to unpack Any into GenesisAccount")
 	require.NotNil(t, asGenesis, "unpacked GenesisAccount is nil")
+	_, ok = asGenesis.(*vaulttypes.VaultAccount)
+	require.True(t, ok, "GenesisAccount did not unwrap to *VaultAccount")
 }

--- a/types/codec_test.go
+++ b/types/codec_test.go
@@ -1,0 +1,37 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/provlabs/vault/types"
+	vaulttypes "github.com/provlabs/vault/types"
+)
+
+func TestVaultAccount_UnpackIntoAllInterfaces(t *testing.T) {
+	reg := codectypes.NewInterfaceRegistry()
+	authtypes.RegisterInterfaces(reg)
+	types.RegisterInterfaces(reg)
+
+	cdc := codec.NewProtoCodec(reg)
+	any, err := codectypes.NewAnyWithValue(&vaulttypes.VaultAccount{})
+	require.NoError(t, err, "failed to pack VaultAccount into Any")
+
+	var asVault vaulttypes.VaultAccountI
+	require.NoError(t, cdc.UnpackAny(any, &asVault), "failed to unpack Any into VaultAccountI")
+	require.NotNil(t, asVault, "unpacked VaultAccountI is nil")
+
+	var asAccount sdk.AccountI
+	require.NoError(t, cdc.UnpackAny(any, &asAccount), "failed to unpack Any into AccountI")
+	require.NotNil(t, asAccount, "unpacked AccountI is nil")
+
+	var asGenesis authtypes.GenesisAccount
+	require.NoError(t, cdc.UnpackAny(any, &asGenesis), "failed to unpack Any into GenesisAccount")
+	require.NotNil(t, asGenesis, "unpacked GenesisAccount is nil")
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized vault account interface registrations and protobuf mappings to streamline how vault accounts are exposed to the codec system.

* **Tests**
  * Added tests to verify vault accounts can be packed/unpacked across the relevant interfaces without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->