### PR TITLE
Fix DepositInterestFunds error message

### DIFF
--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -259,7 +259,7 @@ func (k msgServer) DepositInterestFunds(goCtx context.Context, msg *types.MsgDep
 	}
 
 	if err := k.ReconcileVaultInterest(ctx, vault); err != nil {
-		return nil, fmt.Errorf("failed to reconcile vault interest before withdrawal: %w", err)
+		return nil, fmt.Errorf("failed to reconcile vault interest after deposit: %w", err)
 	}
 
 	k.emitEvent(ctx, types.NewEventInterestDeposit(msg.VaultAddress, msg.Authority, msg.Amount))


### PR DESCRIPTION
closes: #104 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error message clarity for deposit interest reconciliation failures.

* **Tests**
  * Added comprehensive test cases for reconciliation failure scenarios.
  * Enhanced test assertions with descriptive error messages to improve failure diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->