### PR TITLE
Fix permission handling for receipt tokens on withdraw interest and principal

### DIFF
--- a/keeper/abci.go
+++ b/keeper/abci.go
@@ -20,7 +20,7 @@ func (k *Keeper) BeginBlocker(ctx context.Context) error {
 
 // EndBlocker is a hook that is called at the end of every block.
 func (k *Keeper) EndBlocker(ctx context.Context) error {
-	if err := k.ProcessPendingSwapOuts(ctx, MaxSwapOutBatchSize); err != nil {
+	if err := k.processPendingSwapOuts(ctx, MaxSwapOutBatchSize); err != nil {
 		return err
 	}
 

--- a/keeper/export_test.go
+++ b/keeper/export_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/provlabs/vault/types"
 )
 
@@ -41,4 +42,16 @@ func (k Keeper) TestAccessor_processSwapOutJobs(t *testing.T, ctx context.Contex
 func (k Keeper) TestAccessor_autoPauseVault(t *testing.T, ctx context.Context, vault *types.VaultAccount, reason string) {
 	t.Helper()
 	k.autoPauseVault(ctx, vault, reason)
+}
+
+// TestAccessor_reconcileVaultInterest exposes this keeper's reconcileVaultInterest function for unit tests.
+func (k Keeper) TestAccessor_reconcileVaultInterest(t *testing.T, ctx context.Context, vault *types.VaultAccount) error {
+	t.Helper()
+	return k.reconcileVaultInterest(sdk.UnwrapSDKContext(ctx), vault)
+}
+
+// TestAccessor_processPendingSwapOuts exposes this keeper's processPendingSwapOuts function for unit tests.
+func (k Keeper) TestAccessor_processPendingSwapOuts(t *testing.T, ctx context.Context, size int) error {
+	t.Helper()
+	return k.processPendingSwapOuts(ctx, size)
 }

--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -293,7 +293,7 @@ func (k msgServer) WithdrawInterestFunds(goCtx context.Context, msg *types.MsgWi
 		return nil, fmt.Errorf("failed to reconcile vault interest before withdrawal: %w", err)
 	}
 
-	if err := k.BankKeeper.SendCoins(ctx, vaultAddr, authorityAddr, sdk.NewCoins(msg.Amount)); err != nil {
+	if err := k.BankKeeper.SendCoins(markertypes.WithTransferAgents(ctx, authorityAddr), vaultAddr, authorityAddr, sdk.NewCoins(msg.Amount)); err != nil {
 		return nil, fmt.Errorf("failed to withdraw funds: %w", err)
 	}
 
@@ -376,7 +376,7 @@ func (k msgServer) WithdrawPrincipalFunds(goCtx context.Context, msg *types.MsgW
 		return nil, err
 	}
 
-	if err := k.BankKeeper.SendCoins(markertypes.WithTransferAgents(ctx, vaultAddr),
+	if err := k.BankKeeper.SendCoins(markertypes.WithTransferAgents(ctx, withdrawAddress, vaultAddr),
 		principalAddress,
 		withdrawAddress,
 		sdk.NewCoins(msg.Amount),

--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -295,7 +295,7 @@ func (k msgServer) WithdrawInterestFunds(goCtx context.Context, msg *types.MsgWi
 
 	// for receipt tokens, the transfer agent for the authority address is used
 	if err := k.BankKeeper.SendCoins(markertypes.WithTransferAgents(ctx, authorityAddr), vaultAddr, authorityAddr, sdk.NewCoins(msg.Amount)); err != nil {
-		return nil, fmt.Errorf("failed to withdraw funds: %w", err)
+		return nil, fmt.Errorf("failed to withdraw interest funds: %w", err)
 	}
 
 	k.emitEvent(ctx, types.NewEventInterestWithdrawal(msg.VaultAddress, msg.Authority, msg.Amount))

--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -156,7 +156,7 @@ func (k msgServer) UpdateInterestRate(goCtx context.Context, msg *types.MsgUpdat
 
 	prevEnabled := vault.InterestEnabled()
 	if !curRate.IsZero() && !vault.Paused {
-		if err := k.ReconcileVaultInterest(ctx, vault); err != nil {
+		if err := k.reconcileVaultInterest(ctx, vault); err != nil {
 			return nil, fmt.Errorf("failed to reconcile before rate change: %w", err)
 		}
 	}
@@ -258,7 +258,7 @@ func (k msgServer) DepositInterestFunds(goCtx context.Context, msg *types.MsgDep
 		return nil, fmt.Errorf("failed to deposit funds: %w", err)
 	}
 
-	if err := k.ReconcileVaultInterest(ctx, vault); err != nil {
+	if err := k.reconcileVaultInterest(ctx, vault); err != nil {
 		return nil, fmt.Errorf("failed to reconcile vault interest after deposit: %w", err)
 	}
 
@@ -289,7 +289,7 @@ func (k msgServer) WithdrawInterestFunds(goCtx context.Context, msg *types.MsgWi
 		return nil, fmt.Errorf("denom not supported for vault must be of type \"%s\" : got \"%s\"", vault.UnderlyingAsset, msg.Amount.Denom)
 	}
 
-	if err := k.ReconcileVaultInterest(ctx, vault); err != nil {
+	if err := k.reconcileVaultInterest(ctx, vault); err != nil {
 		return nil, fmt.Errorf("failed to reconcile vault interest before withdrawal: %w", err)
 	}
 
@@ -323,7 +323,7 @@ func (k msgServer) DepositPrincipalFunds(goCtx context.Context, msg *types.MsgDe
 		return nil, fmt.Errorf("vault must be paused to deposit principal funds")
 	}
 
-	if err := k.ReconcileVaultInterest(ctx, vault); err != nil {
+	if err := k.reconcileVaultInterest(ctx, vault); err != nil {
 		return nil, fmt.Errorf("failed to reconcile vault interest before principal change: %w", err)
 	}
 
@@ -366,7 +366,7 @@ func (k msgServer) WithdrawPrincipalFunds(goCtx context.Context, msg *types.MsgW
 		return nil, fmt.Errorf("vault must be paused to withdraw principal funds")
 	}
 
-	if err := k.ReconcileVaultInterest(ctx, vault); err != nil {
+	if err := k.reconcileVaultInterest(ctx, vault); err != nil {
 		return nil, fmt.Errorf("failed to reconcile vault interest before principal change: %w", err)
 	}
 
@@ -441,7 +441,7 @@ func (k msgServer) PauseVault(goCtx context.Context, msg *types.MsgPauseVaultReq
 	if vault.Paused {
 		return nil, fmt.Errorf("vault %s is already paused", msg.VaultAddress)
 	}
-	if err := k.ReconcileVaultInterest(ctx, vault); err != nil {
+	if err := k.reconcileVaultInterest(ctx, vault); err != nil {
 		return nil, fmt.Errorf("failed to reconcile interest before pausing: %w", err)
 	}
 

--- a/keeper/msg_server_security_test.go
+++ b/keeper/msg_server_security_test.go
@@ -87,7 +87,7 @@ func (s *TestSuite) TestMsgServer_SmallFirstSwapIn_HugeDonation_SwapOut() {
 	_, err = s.k.SwapOut(s.ctx, vaultAddr, owner, sharesToBurn, "")
 	s.Require().NoError(err, "swap-out of all tiny depositor shares should succeed")
 
-	s.simApp.VaultKeeper.ProcessPendingSwapOuts(s.ctx, keeper.MaxSwapOutBatchSize)
+	s.simApp.VaultKeeper.TestAccessor_processPendingSwapOuts(s.T(), s.ctx, keeper.MaxSwapOutBatchSize)
 	vault, err = s.k.GetVault(s.ctx, vaultAddr)
 	s.Require().NoError(err, "should successfully get vault after tiny swap-out")
 	s.Require().NotNil(vault, "vault should not be nil after tiny swap-out")

--- a/keeper/payout.go
+++ b/keeper/payout.go
@@ -14,12 +14,12 @@ import (
 	markertypes "github.com/provenance-io/provenance/x/marker/types"
 )
 
-// ProcessPendingSwapOuts processes the queue of pending swap-out requests. Called from the EndBlocker,
+// processPendingSwapOuts processes the queue of pending swap-out requests. Called from the EndBlocker,
 // it iterates through requests due for payout at the current block time. It uses a safe "collect-then-mutate"
 // pattern to comply with the SDK iterator contract. It first collects all due requests up to the provided `batchSize`,
 // then passes them to `processSwapOutJobs` for execution. Critical, unrecoverable errors during job processing
 // will cause the associated vault to be automatically paused.
-func (k *Keeper) ProcessPendingSwapOuts(ctx context.Context, batchSize int) error {
+func (k *Keeper) processPendingSwapOuts(ctx context.Context, batchSize int) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	now := sdkCtx.BlockTime().Unix()
 	var jobsToProcess []types.PayoutJob
@@ -125,7 +125,7 @@ func (k *Keeper) processSingleWithdrawal(ctx sdk.Context, id uint64, req types.P
 	ownerAddr := sdk.MustAccAddressFromBech32(req.Owner)
 	principalAddress := markertypes.MustGetMarkerAddress(req.Shares.Denom)
 
-	if err := k.ReconcileVaultInterest(ctx, &vault); err != nil {
+	if err := k.reconcileVaultInterest(ctx, &vault); err != nil {
 		return fmt.Errorf("failed to reconcile vault interest: %w", err)
 	}
 

--- a/keeper/payout_test.go
+++ b/keeper/payout_test.go
@@ -379,7 +379,7 @@ func (s *TestSuite) TestKeeper_ProcessPendingSwapOuts() {
 			s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
 			s.ctx = s.ctx.WithBlockTime(testBlockTime)
 
-			err := s.k.ProcessPendingSwapOuts(s.ctx, tc.batchSize)
+			err := s.k.TestAccessor_processPendingSwapOuts(s.T(), s.ctx, tc.batchSize)
 
 			if tc.expectedError != "" {
 				s.Require().Error(err)

--- a/keeper/reconcile.go
+++ b/keeper/reconcile.go
@@ -21,7 +21,7 @@ const (
 	AutoReconcilePayoutDuration = 24 * interest.SecondsPerHour
 )
 
-// ReconcileVaultInterest updates interest accounting for a vault if a new interest period has started.
+// reconcileVaultInterest updates interest accounting for a vault if a new interest period has started.
 //
 // If this is the first time the vault accrues interest, it triggers the start of a new period
 // and publishes the initial NAV for the share denom in terms of the underlying asset.
@@ -31,7 +31,7 @@ const (
 //
 // This should be called before any transaction that changes vault principal/reserves or depends on the
 // current interest state.
-func (k *Keeper) ReconcileVaultInterest(ctx sdk.Context, vault *types.VaultAccount) error {
+func (k *Keeper) reconcileVaultInterest(ctx sdk.Context, vault *types.VaultAccount) error {
 	if vault.Paused {
 		return nil
 	}

--- a/keeper/reconcile_test.go
+++ b/keeper/reconcile_test.go
@@ -161,7 +161,6 @@ func (s *TestSuite) TestKeeper_ReconcileVaultInterest() {
 
 			vault, err := s.k.GetVault(s.ctx, vaultAddress)
 			s.Require().NoError(err, "GetVault should not error before reconcile")
-			s.k.TestAccessor_reconcileVaultInterest(s.T(), s.ctx, vault)
 			err = s.k.TestAccessor_reconcileVaultInterest(s.T(), s.ctx, vault)
 
 			if tc.posthander != nil {

--- a/keeper/reconcile_test.go
+++ b/keeper/reconcile_test.go
@@ -161,7 +161,8 @@ func (s *TestSuite) TestKeeper_ReconcileVaultInterest() {
 
 			vault, err := s.k.GetVault(s.ctx, vaultAddress)
 			s.Require().NoError(err, "GetVault should not error before reconcile")
-			err = s.k.ReconcileVaultInterest(s.ctx, vault)
+			s.k.TestAccessor_reconcileVaultInterest(s.T(), s.ctx, vault)
+			err = s.k.TestAccessor_reconcileVaultInterest(s.T(), s.ctx, vault)
 
 			if tc.posthander != nil {
 				tc.posthander()

--- a/keeper/vault.go
+++ b/keeper/vault.go
@@ -186,7 +186,7 @@ func (k *Keeper) SwapIn(ctx sdk.Context, vaultAddr, recipient sdk.AccAddress, as
 		return nil, err
 	}
 
-	if err := k.ReconcileVaultInterest(ctx, vault); err != nil {
+	if err := k.reconcileVaultInterest(ctx, vault); err != nil {
 		return nil, fmt.Errorf("failed to reconcile vault interest: %w", err)
 	}
 

--- a/keeper/vault_test.go
+++ b/keeper/vault_test.go
@@ -205,7 +205,7 @@ func (s *TestSuite) TestSwapOut_MultiAsset() {
 	s.Require().NoError(err, "should successfully queue swap out for the default underlying asset")
 	s.Require().Equal(uint64(1), reqID2, "second request id should be 1")
 
-	err = s.k.ProcessPendingSwapOuts(s.ctx, keeper.MaxSwapOutBatchSize)
+	err = s.k.TestAccessor_processPendingSwapOuts(s.T(), s.ctx, keeper.MaxSwapOutBatchSize)
 	s.Require().NoError(err, "processing pending withdrawals should not fail")
 
 	// --- Assert Final Balances ---
@@ -407,7 +407,7 @@ func (s *TestSuite) TestSwapOut_SucceedsWithRestrictedUnderlyingAssetRequiredAtt
 
 	s.assertBalance(redeemerAddr, shareDenom, sharesForRedeemer.Sub(sharesToRedeem.Amount))
 	s.assertBalance(vault.GetAddress(), shareDenom, sharesToRedeem.Amount)
-	err = s.k.ProcessPendingSwapOuts(s.ctx, keeper.MaxSwapOutBatchSize)
+	err = s.k.TestAccessor_processPendingSwapOuts(s.T(), s.ctx, keeper.MaxSwapOutBatchSize)
 	s.Require().NoError(err, "processing pending withdrawals should not fail")
 
 	s.assertBalance(redeemerAddr, restrictedUnderlyingDenom, math.NewInt(50))

--- a/spec/06_blocker.md
+++ b/spec/06_blocker.md
@@ -13,7 +13,7 @@ This document explains how the vault module uses ABCI block hooks to keep vaults
   - [BeginBlocker](#beginblocker)
     - [handleVaultInterestTimeouts](#handlevaultinteresttimeouts)
   - [EndBlocker](#endblocker)
-    - [ProcessPendingSwapOuts](#processpendingswapouts)
+    - [processPendingSwapOuts](#processpendingswapouts)
     - [handleReconciledVaults](#handlereconciledvaults)
   - [Interest Accrual & Transfers](#interest-accrual--transfers)
   - [Payout Processing Details](#payout-processing-details)
@@ -134,7 +134,7 @@ This advances vaults from the **verification set**:
 
 ## Payout Processing Details
 
-* **processSingleWithdrawal** (called from `ProcessPendingSwapOuts`)
+* **processSingleWithdrawal** (called from `processPendingSwapOuts`)
 
   1. **Reconcile interest** for the vault.
   2. Convert **shares → payout coin** (`underlying_asset` or optional **payment denom**), using current NAV and pro-rata TVV.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Stronger transfer authorization for interest and principal withdrawals and more consistent reconciliation sequencing to ensure correct balances.
  * Safer, batched payout processing for pending swap-outs to improve reliability.

* **Tests**
  * Expanded coverage for withdrawal flows, including receipt-token variants, authorization and error cases.

* **Documentation**
  * Updated payout processing references to match revised naming and flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->