### PR TITLE
Restrict TVV calculation to accepted denoms

### DIFF
--- a/.changelog/unreleased/improvements/137-restrict-TVV-calculation-to-accepted-denoms.md
+++ b/.changelog/unreleased/improvements/137-restrict-TVV-calculation-to-accepted-denoms.md
@@ -1,0 +1,1 @@
+* Restrict TVV calculation to accepted denoms [#137](https://github.com/provlabs/vault/issues/137).

--- a/keeper/valuation_engine.go
+++ b/keeper/valuation_engine.go
@@ -137,7 +137,7 @@ func (k Keeper) GetTVVInUnderlyingAsset(ctx sdk.Context, vault types.VaultAccoun
 	balances := k.BankKeeper.GetAllBalances(ctx, vault.PrincipalMarkerAddress())
 	total := math.ZeroInt()
 	for _, balance := range balances {
-		if balance.Denom == vault.TotalShares.Denom {
+		if balance.Denom == vault.TotalShares.Denom || !vault.IsAcceptedDenom(balance.Denom) {
 			continue
 		}
 		val, err := k.ToUnderlyingAssetAmount(ctx, vault, balance)


### PR DESCRIPTION
closes: #137 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Total Vault Value (TVV) calculation to exclude non-accepted denominations from contributing to the overall vault value sum.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->