### PR TITLE
Vault validation using set vault account consistently

### DIFF
--- a/.changelog/unreleased/improvements/138-vault-validation-using-SetVaultAccount-consistently.md
+++ b/.changelog/unreleased/improvements/138-vault-validation-using-SetVaultAccount-consistently.md
@@ -1,1 +1,1 @@
-* Use SetVaultAccount consitently to validate all vault storing [#138](https://github.com/provlabs/vault/issues/138).
+* Use SetVaultAccount consistently to validate all vault storing [#138](https://github.com/provlabs/vault/issues/138).

--- a/.changelog/unreleased/improvements/138-vault-validation-using-SetVaultAccount-consistently.md
+++ b/.changelog/unreleased/improvements/138-vault-validation-using-SetVaultAccount-consistently.md
@@ -1,0 +1,1 @@
+* Use SetVaultAccount consitently to validate all vault storing [#138](https://github.com/provlabs/vault/issues/138).

--- a/keeper/export_test.go
+++ b/keeper/export_test.go
@@ -23,7 +23,8 @@ func (k Keeper) TestAccessor_handlePayableVaults(t *testing.T, ctx context.Conte
 // TestAccessor_handleDepletedVaults exposes this keeper's handleDepletedVaults function for unit tests.
 func (k Keeper) TestAccessor_handleDepletedVaults(t *testing.T, ctx context.Context, failedPayouts []*types.VaultAccount) {
 	t.Helper()
-	k.handleDepletedVaults(ctx, failedPayouts)
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	k.handleDepletedVaults(sdkCtx, failedPayouts)
 }
 
 // TestAccessor_handleDepletedVaults exposes this keeper's handleDepletedVaults function for unit tests.

--- a/keeper/export_test.go
+++ b/keeper/export_test.go
@@ -17,7 +17,8 @@ func (k Keeper) TestAccessor_handleReconciledVaults(t *testing.T, ctx context.Co
 // TestAccessor_handlePayableVaults exposes this keeper's handlePayableVaults function for unit tests.
 func (k Keeper) TestAccessor_handlePayableVaults(t *testing.T, ctx context.Context, payouts []*types.VaultAccount) {
 	t.Helper()
-	k.handlePayableVaults(ctx, payouts)
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	k.handlePayableVaults(sdkCtx, payouts)
 }
 
 // TestAccessor_handleDepletedVaults exposes this keeper's handleDepletedVaults function for unit tests.

--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -193,7 +193,9 @@ func (k msgServer) UpdateInterestRate(goCtx context.Context, msg *types.MsgUpdat
 		}
 	}
 
-	k.UpdateInterestRates(ctx, vault, msg.NewRate, msg.NewRate)
+	if err := k.UpdateInterestRates(ctx, vault, msg.NewRate, msg.NewRate); err != nil {
+		return nil, fmt.Errorf("failed to update interest rates: %w", err)
+	}
 
 	nextEnabled := vault.InterestEnabled()
 
@@ -485,7 +487,10 @@ func (k msgServer) PauseVault(goCtx context.Context, msg *types.MsgPauseVaultReq
 	vault.PausedBalance = sdk.NewCoin(vault.UnderlyingAsset, tvv)
 	vault.Paused = true
 	vault.PausedReason = msg.Reason
-	k.UpdateInterestRates(ctx, vault, types.ZeroInterestRate, vault.DesiredInterestRate)
+
+	if err := k.UpdateInterestRates(ctx, vault, types.ZeroInterestRate, vault.DesiredInterestRate); err != nil {
+		return nil, fmt.Errorf("failed to update interest rates: %w", err)
+	}
 
 	if err := k.SetVaultAccount(ctx, vault); err != nil {
 		return nil, fmt.Errorf("failed to set vault account: %w", err)
@@ -516,7 +521,9 @@ func (k msgServer) UnpauseVault(goCtx context.Context, msg *types.MsgUnpauseVaul
 		return nil, fmt.Errorf("vault %s is not paused", msg.VaultAddress)
 	}
 
-	k.UpdateInterestRates(ctx, vault, vault.DesiredInterestRate, vault.DesiredInterestRate)
+	if err := k.UpdateInterestRates(ctx, vault, vault.DesiredInterestRate, vault.DesiredInterestRate); err != nil {
+		return nil, fmt.Errorf("failed to update interest rates: %w", err)
+	}
 
 	vault.PausedBalance = sdk.Coin{}
 	vault.Paused = false

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -1140,9 +1140,9 @@ func (s *TestSuite) TestMsgServer_UpdateInterestRate() {
 				setup()
 				vaultAcc, err := s.k.GetVault(s.ctx, vaultAddr)
 				s.Require().NoError(err)
-				s.k.UpdateInterestRates(s.ctx, vaultAcc, "4.20", "4.20")
+				s.Require().NoError(s.k.UpdateInterestRates(s.ctx, vaultAcc, "4.20", "4.20"), "initial interest rate update should succeed")
 				vaultAcc.PeriodStart = currentBlockTime.Unix() - 10000
-				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vaultAcc))
+				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vaultAcc), "setting vault account should succeed")
 			},
 			postCheckArgs: postCheckArgs{
 				VaultAddress:              vaultAddr,
@@ -1173,9 +1173,9 @@ func (s *TestSuite) TestMsgServer_UpdateInterestRate() {
 				setup()
 				vaultAcc, err := s.k.GetVault(s.ctx, vaultAddr)
 				s.Require().NoError(err)
-				s.k.UpdateInterestRates(s.ctx, vaultAcc, "6.12", "6.12")
+				s.Require().NoError(s.k.UpdateInterestRates(s.ctx, vaultAcc, "6.12", "6.12"), "initial interest rate update should succeed")
 				vaultAcc.PeriodStart = currentBlockTime.Unix() - 10000
-				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vaultAcc))
+				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vaultAcc), "setting vault account should succeed")
 			},
 			postCheckArgs: postCheckArgs{
 				VaultAddress:              vaultAddr,
@@ -1205,9 +1205,9 @@ func (s *TestSuite) TestMsgServer_UpdateInterestRate() {
 				setup()
 				vaultAcc, err := s.k.GetVault(s.ctx, vaultAddr)
 				s.Require().NoError(err)
-				s.k.UpdateInterestRates(s.ctx, vaultAcc, "3.33", "3.33")
+				s.Require().NoError(s.k.UpdateInterestRates(s.ctx, vaultAcc, "3.33", "3.33"), "initial interest rate update should succeed")
 				vaultAcc.PeriodStart = currentBlockTime.Unix() - 5000
-				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vaultAcc))
+				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vaultAcc), "setting vault account should succeed")
 			},
 			postCheckArgs: postCheckArgs{
 				VaultAddress:              vaultAddr,
@@ -1255,10 +1255,10 @@ func (s *TestSuite) TestMsgServer_UpdateInterestRate() {
 				setup()
 				vaultAcc, err := s.k.GetVault(s.ctx, vaultAddr)
 				s.Require().NoError(err)
-				s.k.UpdateInterestRates(s.ctx, vaultAcc, "0.0", "0.0")
+				s.Require().NoError(s.k.UpdateInterestRates(s.ctx, vaultAcc, "0.0", "0.0"), "initial interest rate update should succeed")
 				vaultAcc.PeriodStart = currentBlockTime.Unix() - 1234
 				vaultAcc.PeriodTimeout = currentBlockTime.Unix() + 9999
-				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vaultAcc))
+				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vaultAcc), "setting vault account should succeed")
 			},
 			postCheckArgs: postCheckArgs{
 				VaultAddress:              vaultAddr,
@@ -1281,11 +1281,11 @@ func (s *TestSuite) TestMsgServer_UpdateInterestRate() {
 				setup()
 				vaultAcc, err := s.k.GetVault(s.ctx, vaultAddr)
 				s.Require().NoError(err)
-				s.k.UpdateInterestRates(s.ctx, vaultAcc, "4.20", "4.20")
+				s.Require().NoError(s.k.UpdateInterestRates(s.ctx, vaultAcc, "4.20", "4.20"), "initial interest rate update should succeed")
 				priorStart := currentBlockTime.Unix() - 7777
 				vaultAcc.PeriodStart = priorStart
 				vaultAcc.Paused = true
-				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vaultAcc))
+				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vaultAcc), "setting vault account should succeed")
 				s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
 			},
 			postCheckArgs: postCheckArgs{
@@ -1309,9 +1309,9 @@ func (s *TestSuite) TestMsgServer_UpdateInterestRate() {
 				setup()
 				vaultAcc, err := s.k.GetVault(s.ctx, vaultAddr)
 				s.Require().NoError(err)
-				s.k.UpdateInterestRates(s.ctx, vaultAcc, "0.0", "0.0")
+				s.Require().NoError(s.k.UpdateInterestRates(s.ctx, vaultAcc, "0.0", "0.0"), "initial interest rate update should succeed")
 				vaultAcc.Paused = true
-				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vaultAcc))
+				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vaultAcc), "setting vault account should succeed")
 				s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
 			},
 			postCheckArgs: postCheckArgs{
@@ -1333,12 +1333,12 @@ func (s *TestSuite) TestMsgServer_UpdateInterestRate() {
 			setup: func() {
 				setup()
 				vaultAcc, err := s.k.GetVault(s.ctx, vaultAddr)
-				s.Require().NoError(err)
-				s.k.UpdateInterestRates(s.ctx, vaultAcc, "2.50", "2.50")
+				s.Require().NoError(err, "error getting vault account")
+				s.Require().NoError(s.k.UpdateInterestRates(s.ctx, vaultAcc, "2.50", "2.50"), "initial interest rate update should succeed")
 				vaultAcc.PeriodStart = currentBlockTime.Unix() - 5000
 				vaultAcc.PeriodTimeout = currentBlockTime.Unix() + 3600
 				vaultAcc.Paused = true
-				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vaultAcc))
+				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vaultAcc), "setting vault account should succeed")
 				s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
 			},
 			postCheckArgs: postCheckArgs{
@@ -3323,7 +3323,7 @@ func (s *TestSuite) TestMsgServer_PauseVault() {
 		s.Require().NoError(err)
 		vault, err := s.k.GetVault(s.ctx, vaultAddr)
 		s.Require().NoError(err, "failed to get vault in setup")
-		s.k.UpdateInterestRates(s.ctx, vault, interestRate, interestRate)
+		s.Require().NoError(s.k.UpdateInterestRates(s.ctx, vault, interestRate, interestRate), "initial interest rate update should succeed")
 		s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
 	}
 
@@ -3556,7 +3556,7 @@ func (s *TestSuite) TestMsgServer_UnpauseVault() {
 		s.Require().NoError(err)
 		vault, err := s.k.GetVault(s.ctx, vaultAddr)
 		s.Require().NoError(err, "failed to get vault in setup")
-		s.k.UpdateInterestRates(s.ctx, vault, interestRate, interestRate)
+		s.Require().NoError(s.k.UpdateInterestRates(s.ctx, vault, interestRate, interestRate), "initial interest rate update should succeed")
 		vault.PeriodStart = s.ctx.BlockTime().Unix()
 		vault.PeriodTimeout = s.ctx.BlockTime().Add(24 * time.Hour).Unix()
 		err = s.k.SetVaultAccount(s.ctx, vault)

--- a/keeper/payout.go
+++ b/keeper/payout.go
@@ -167,7 +167,15 @@ func (k *Keeper) processSingleWithdrawal(ctx sdk.Context, id uint64, req types.P
 		ctx.Logger().Error("CRITICAL: "+errMsg, "error", err)
 		return types.CriticalErr(errMsg, fmt.Errorf("%s: %w", errMsg, err))
 	}
-	k.AuthKeeper.SetAccount(ctx, &vault)
+
+	if err := k.SetVaultAccount(ctx, &vault); err != nil {
+		errMsg := fmt.Sprintf(
+			"failed to update vault account %s after successful payout",
+			vaultAddr,
+		)
+		ctx.Logger().Error("CRITICAL: "+errMsg, "error", err)
+		return types.CriticalErr(errMsg, fmt.Errorf("%s: %w", errMsg, err))
+	}
 
 	k.emitEvent(ctx, types.NewEventSwapOutCompleted(req.VaultAddress, req.Owner, assets, id))
 	return nil

--- a/keeper/reconcile.go
+++ b/keeper/reconcile.go
@@ -226,7 +226,7 @@ func (k *Keeper) UpdateInterestRates(ctx sdk.Context, vault *types.VaultAccount,
 	if err := k.SetVaultAccount(ctx, vault); err != nil {
 		return err
 	}
-	k.emitEvent(sdk.UnwrapSDKContext(ctx), event)
+	k.emitEvent(ctx, event)
 	return nil
 }
 

--- a/keeper/reconcile.go
+++ b/keeper/reconcile.go
@@ -219,12 +219,15 @@ func (k *Keeper) CanPayoutDuration(ctx sdk.Context, vault *types.VaultAccount, d
 
 // UpdateInterestRates sets the vault's current and desired interest rates and emits
 // an EventVaultInterestChange. The modified account is persisted via the auth keeper.
-func (k *Keeper) UpdateInterestRates(ctx context.Context, vault *types.VaultAccount, currentRate, desiredRate string) {
+func (k *Keeper) UpdateInterestRates(ctx sdk.Context, vault *types.VaultAccount, currentRate, desiredRate string) error {
 	event := types.NewEventVaultInterestChange(vault.GetAddress().String(), currentRate, desiredRate)
 	vault.CurrentInterestRate = currentRate
 	vault.DesiredInterestRate = desiredRate
-	k.AuthKeeper.SetAccount(ctx, vault)
+	if err := k.SetVaultAccount(ctx, vault); err != nil {
+		return err
+	}
 	k.emitEvent(sdk.UnwrapSDKContext(ctx), event)
+	return nil
 }
 
 // CalculateVaultTotalAssets returns the total value of the vault's assets, including the interest
@@ -317,8 +320,8 @@ func (k *Keeper) handleVaultInterestTimeouts(ctx context.Context) error {
 		reconciled = append(reconciled, vault)
 	}
 
-	k.resetVaultInterestPeriods(ctx, reconciled)
-	k.handleDepletedVaults(ctx, depleted)
+	k.resetVaultInterestPeriods(sdkCtx, reconciled)
+	k.handleDepletedVaults(sdkCtx, depleted)
 	return nil
 }
 
@@ -372,8 +375,8 @@ func (k *Keeper) handleReconciledVaults(ctx context.Context) error {
 	}
 
 	payable, depleted := k.partitionVaults(sdkCtx, vaultsToProcess)
-	k.handlePayableVaults(ctx, payable)
-	k.handleDepletedVaults(ctx, depleted)
+	k.handlePayableVaults(sdkCtx, payable)
+	k.handleDepletedVaults(sdkCtx, depleted)
 	return nil
 }
 
@@ -399,21 +402,21 @@ func (k *Keeper) partitionVaults(sdkCtx sdk.Context, vaults []*types.VaultAccoun
 
 // handlePayableVaults updates timeout tracking for vaults that remain payable after reconciliation.
 // It sets PeriodTimeout to now + AutoReconcileTimeout, persists the vault, and enqueues the timeout.
-func (k *Keeper) handlePayableVaults(ctx context.Context, payouts []*types.VaultAccount) {
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-
+func (k *Keeper) handlePayableVaults(ctx sdk.Context, payouts []*types.VaultAccount) {
 	for _, v := range payouts {
 		if err := k.SafeEnqueueTimeout(ctx, v); err != nil {
-			sdkCtx.Logger().Error("failed to enqueue timeout", "vault", v.GetAddress().String(), "err", err)
+			ctx.Logger().Error("failed to enqueue timeout", "vault", v.GetAddress().String(), "err", err)
 		}
 	}
 }
 
 // handleDepletedVaults disables interest for vaults that cannot cover the forecasted payout window
 // by setting the current rate to zero while preserving the desired rate.
-func (k *Keeper) handleDepletedVaults(ctx context.Context, failedPayouts []*types.VaultAccount) {
+func (k *Keeper) handleDepletedVaults(ctx sdk.Context, failedPayouts []*types.VaultAccount) {
 	for _, record := range failedPayouts {
-		k.UpdateInterestRates(ctx, record, types.ZeroInterestRate, record.DesiredInterestRate)
+		if err := k.UpdateInterestRates(ctx, record, types.ZeroInterestRate, record.DesiredInterestRate); err != nil {
+			ctx.Logger().Error("failed to update interest rates", "vault", record.GetAddress().String(), "err", err)
+		}
 	}
 }
 
@@ -421,12 +424,10 @@ func (k *Keeper) handleDepletedVaults(ctx context.Context, failedPayouts []*type
 // interest reconciliation by calling SafeEnqueueTimeout for each.
 //
 // This updates PeriodStart and PeriodTimeout, persists the vault, and enqueues the corresponding timeout entry.
-func (k *Keeper) resetVaultInterestPeriods(ctx context.Context, vaults []*types.VaultAccount) {
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-
+func (k *Keeper) resetVaultInterestPeriods(ctx sdk.Context, vaults []*types.VaultAccount) {
 	for _, vault := range vaults {
 		if err := k.SafeEnqueueTimeout(ctx, vault); err != nil {
-			sdkCtx.Logger().Error("failed to enqueue vault timeout", "vault", vault.GetAddress().String(), "err", err)
+			ctx.Logger().Error("failed to enqueue vault timeout", "vault", vault.GetAddress().String(), "err", err)
 		}
 	}
 }

--- a/keeper/reconcile_test.go
+++ b/keeper/reconcile_test.go
@@ -762,10 +762,10 @@ func (s *TestSuite) TestKeeper_UpdateInterestRates() {
 			},
 			postCheck: func(vault *types.VaultAccount) {
 				updatedVault, err := s.k.GetVault(s.ctx, vault.GetAddress())
-				s.Require().NoError(err)
-				s.Require().NotNil(updatedVault)
-				s.Assert().Equal(newRate, updatedVault.CurrentInterestRate)
-				s.Assert().Equal(desiredRate, updatedVault.DesiredInterestRate)
+				s.Require().NoError(err, "retrieving updated vault should not error")
+				s.Require().NotNil(updatedVault, "updated vault should not be nil")
+				s.Assert().Equal(newRate, updatedVault.CurrentInterestRate, "current interest rate should be updated")
+				s.Assert().Equal(desiredRate, updatedVault.DesiredInterestRate, "desired interest rate should be updated")
 			},
 		},
 	}
@@ -776,12 +776,12 @@ func (s *TestSuite) TestKeeper_UpdateInterestRates() {
 			vault := tc.setup()
 
 			s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
-			s.k.UpdateInterestRates(s.ctx, vault, tc.currentRate, tc.desiredRate)
+			s.Require().NoError(s.k.UpdateInterestRates(s.ctx, vault, tc.currentRate, tc.desiredRate), "interest rate update should succeed")
 
 			s.Assert().Equal(
 				normalizeEvents(tc.expectedEvents),
 				normalizeEvents(s.ctx.EventManager().Events()),
-			)
+				"emitted events should match expected events")
 
 			if tc.postCheck != nil {
 				tc.postCheck(vault)

--- a/keeper/reconcile_test.go
+++ b/keeper/reconcile_test.go
@@ -735,7 +735,7 @@ func (s *TestSuite) TestKeeper_UpdateInterestRates() {
 	v1 := NewVaultInfo(1)
 	initialRate := "0.1"
 	newRate := "0.2"
-	desiredRate := "0.3"
+	desiredRate := "0.2"
 
 	tests := []struct {
 		name           string

--- a/keeper/vault_test.go
+++ b/keeper/vault_test.go
@@ -420,28 +420,28 @@ func (s *TestSuite) TestSetMinMaxInterestRate_NoOp_NoEvent() {
 
 	attrs := vaultAttrs{admin: s.adminAddr.String(), share: share, underlying: base}
 	v, err := s.k.CreateVault(s.ctx, attrs)
-	s.Require().NoError(err)
+	s.Require().NoError(err, "vault creation should succeed")
 
-	s.k.UpdateInterestRates(s.ctx, v, "0.10", "0.10")
+	s.Require().NoError(s.k.UpdateInterestRates(s.ctx, v, "0.10", "0.10"), "should set initial min/max rates without error")
 	s.k.AuthKeeper.SetAccount(s.ctx, v)
 
 	s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
 	err = s.k.SetMinInterestRate(s.ctx, v, "0.10")
-	s.Require().NoError(err)
+	s.Require().NoError(err, "setting min interest rate should not error")
 
 	s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
 	err = s.k.SetMinInterestRate(s.ctx, v, "0.10")
-	s.Require().NoError(err)
-	s.Require().Len(s.ctx.EventManager().Events(), 0)
+	s.Require().NoError(err, "setting min interest rate should not error")
+	s.Require().Len(s.ctx.EventManager().Events(), 0, "no events should be emitted when setting the same min interest rate")
 
 	s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
 	err = s.k.SetMaxInterestRate(s.ctx, v, "0.25")
-	s.Require().NoError(err)
+	s.Require().NoError(err, "setting max interest rate should not error")
 
 	s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
 	err = s.k.SetMaxInterestRate(s.ctx, v, "0.25")
-	s.Require().NoError(err)
-	s.Require().Len(s.ctx.EventManager().Events(), 0)
+	s.Require().NoError(err, "setting max interest rate should not error")
+	s.Require().Len(s.ctx.EventManager().Events(), 0, "no events should be emitted when setting the same max interest rate")
 }
 
 func (s *TestSuite) TestSetMinInterestRate_ValidationBlocksWhenAboveExistingMax() {
@@ -606,11 +606,11 @@ func (s *TestSuite) TestUpdateInterestRate_BoundsEnforced() {
 	v, err := s.k.GetVault(s.ctx, addr)
 	s.Require().NoError(err)
 
-	s.k.UpdateInterestRates(s.ctx, v, "0.10", "0.10")
+	s.Require().NoError(s.k.UpdateInterestRates(s.ctx, v, "0.10", "0.10"), "should set initial min/max rates without error")
 	s.k.AuthKeeper.SetAccount(s.ctx, v)
 
-	s.Require().NoError(s.k.SetMinInterestRate(s.ctx, v, "0.10"))
-	s.Require().NoError(s.k.SetMaxInterestRate(s.ctx, v, "0.50"))
+	s.Require().NoError(s.k.SetMinInterestRate(s.ctx, v, "0.10"), "setting min interest rate should not error")
+	s.Require().NoError(s.k.SetMaxInterestRate(s.ctx, v, "0.50"), "setting max interest rate should not error")
 
 	srv := keeper.NewMsgServer(s.simApp.VaultKeeper)
 
@@ -620,9 +620,9 @@ func (s *TestSuite) TestUpdateInterestRate_BoundsEnforced() {
 		VaultAddress: addr.String(),
 		NewRate:      "0.25",
 	})
-	s.Require().NoError(err)
+	s.Require().NoError(err, "updating interest rate to 0.25 should not error")
 	v2, err := s.k.GetVault(s.ctx, addr)
-	s.Require().NoError(err)
+	s.Require().NoError(err, "getting vault after interest rate update should not error")
 	s.Require().Equal("0.25", v2.CurrentInterestRate)
 	s.Require().Equal("0.25", v2.DesiredInterestRate)
 
@@ -632,7 +632,7 @@ func (s *TestSuite) TestUpdateInterestRate_BoundsEnforced() {
 		VaultAddress: addr.String(),
 		NewRate:      "0.05",
 	})
-	s.Require().Error(err)
+	s.Require().Error(err, "updating interest rate to 0.05 should error")
 
 	s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
 	_, err = srv.UpdateInterestRate(s.ctx, &types.MsgUpdateInterestRateRequest{
@@ -640,7 +640,7 @@ func (s *TestSuite) TestUpdateInterestRate_BoundsEnforced() {
 		VaultAddress: addr.String(),
 		NewRate:      "0.60",
 	})
-	s.Require().Error(err)
+	s.Require().Error(err, "updating interest rate to 0.60 should error")
 }
 
 func (s *TestSuite) TestAutoPauseVault_SetsPausedAndEmitsEvent() {


### PR DESCRIPTION
closes: #147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vault operations now surface failures instead of silently continuing; interest-rate updates and post-payout vault persistence return and log errors when they fail.
  * Vault account validation unified across storage operations.

* **Tests**
  * Assertions strengthened with descriptive messages and explicit error checks for vault flows.

* **Documentation**
  * Added changelog entry noting the validation consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->