### PR TITLE
Add zero checking in UnitPriceFraction

### DIFF
--- a/.changelog/unreleased/improvements/133-standardize-zero-checks-in-UnitPriceFraction.md
+++ b/.changelog/unreleased/improvements/133-standardize-zero-checks-in-UnitPriceFraction.md
@@ -1,0 +1,1 @@
+* Standardize Zero Checks in UnitPriceFraction [#133](https://github.com/provlabs/vault/issues/133).

--- a/keeper/valuation_engine.go
+++ b/keeper/valuation_engine.go
@@ -37,8 +37,8 @@ import (
 // Errors
 // - If neither NAV exists, return the lookup error (if any) or "nav not found for src/underlying".
 // - For the selected NAV direction:
-//   - Forward: error if NAV.Volume == 0.
-//   - Reverse: error if NAV.Price.Amount == 0.
+//   - Forward: error if NAV.Volume == 0 or NAV.Price.Amount == 0.
+//   - Reverse: error if NAV.Price.Amount == 0 or NAV.Volume == 0.
 //
 // Returns
 // - (num, den) as math.Int, suitable for floor(x * num / den).
@@ -83,6 +83,9 @@ func (k Keeper) UnitPriceFraction(ctx sdk.Context, srcDenom string, vault types.
 		if fwd.Volume == 0 {
 			return math.Int{}, math.Int{}, fmt.Errorf("nav volume is zero for %s/%s", srcDenom, underlyingAsset)
 		}
+		if fwd.Price.Amount.IsZero() {
+			return math.Int{}, math.Int{}, fmt.Errorf("nav price is zero for %s/%s", srcDenom, underlyingAsset)
+		}
 		priceAmt := fwd.Price.Amount
 		volAmt := math.NewIntFromUint64(fwd.Volume)
 		return priceAmt, volAmt, nil
@@ -90,6 +93,9 @@ func (k Keeper) UnitPriceFraction(ctx sdk.Context, srcDenom string, vault types.
 
 	if rev.Price.Amount.IsZero() {
 		return math.Int{}, math.Int{}, fmt.Errorf("nav price is zero for %s/%s", underlyingAsset, srcDenom)
+	}
+	if rev.Volume == 0 {
+		return math.Int{}, math.Int{}, fmt.Errorf("nav volume is zero for %s/%s", underlyingAsset, srcDenom)
 	}
 	priceAmt := math.NewIntFromUint64(rev.Volume)
 	volAmt := rev.Price.Amount


### PR DESCRIPTION
Note: I did not write tests for these cases.  This is because these values are validated when setting net asset value in the store from within the marker module. I would need to write mocks in order to exercise these.  As long as the other values are tested this should be fine. 

closes: #133 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Standardized Net Asset Value validation to ensure both price and volume are non-zero across all calculation paths, with clearer error messages for validation failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->