### PR TITLE
Resolve InitGenesis Vault bug

### DIFF
--- a/.changelog/unreleased/bug-fixes/173---p.md
+++ b/.changelog/unreleased/bug-fixes/173---p.md
@@ -1,0 +1,1 @@
+* Adds a bug fix to allow init genesis to correctly setup loaded vaults [PR 173](https://github.com/provlabs/vault/pull/173).

--- a/keeper/genesis.go
+++ b/keeper/genesis.go
@@ -24,7 +24,13 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 			if err := v.Validate(); err != nil {
 				panic(err)
 			}
-			k.SetVaultLookup(ctx, v.Clone())
+			vault, ok := v.(*types.VaultAccount)
+			if !ok {
+				panic(fmt.Errorf("unable to cast account %s to VaultAccount", v.GetAddress().String()))
+			}
+			if err := k.SetVaultLookup(ctx, vault); err != nil {
+				panic(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This is an attempt to fix the merging issue that we are facing when cloning our protos. Instead of cloning and making a deep copy of the VaultAccount we are down casting directly to the *types.VaultAccount. This allows us to get around the issue we are encountering with Clone. There should be no other side effects from this since accounts is only used in this loop, and we aren't writing to it.

There is still an issue with the Clone method, but I believe that is separate and stems from how we constructed our protos. Every type under VaultAccount will need to be re-examined, and if it is following the correct type pattern for cosmos-sdk.

Issue: #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Fixed an issue where vaults were not being properly initialized during genesis setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->