### PR TITLE
genesis: persist payout verification set on export and import

### DIFF
--- a/keeper/genesis.go
+++ b/keeper/genesis.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/provlabs/vault/types"
 
@@ -78,6 +79,19 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 	if err := k.PendingSwapOutQueue.Import(ctx, &genState.PendingSwapOutQueue); err != nil {
 		panic(fmt.Errorf("failed to import pending swap out queue: %w", err))
 	}
+
+	for _, addrStr := range genState.PayoutVerificationSet {
+		addr, err := sdk.AccAddressFromBech32(addrStr)
+		if err != nil {
+			panic(fmt.Errorf("invalid address in payout verification set: %w", err))
+		}
+		if _, ok := k.tryGetVault(ctx, addr); !ok {
+			panic(fmt.Errorf("payout verification set entry for unknown vault %s", addrStr))
+		}
+		if err := k.PayoutVerificationSet.Set(ctx, addr); err != nil {
+			panic(fmt.Errorf("failed to restore payout verification entry for %s: %w", addrStr, err))
+		}
+	}
 }
 
 // ExportGenesis exports the current state of the vault module.
@@ -109,10 +123,21 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 		panic(fmt.Errorf("failed to export pending swap out queue: %w", err))
 	}
 
+	var payoutVerificationAddrs []string
+	err = k.PayoutVerificationSet.Walk(ctx, nil, func(addr sdk.AccAddress) (bool, error) {
+		payoutVerificationAddrs = append(payoutVerificationAddrs, addr.String())
+		return false, nil
+	})
+	if err != nil {
+		panic(fmt.Errorf("failed to walk payout verification set: %w", err))
+	}
+	sort.Strings(payoutVerificationAddrs)
+
 	return &types.GenesisState{
-		Vaults:              vaults,
-		PayoutTimeoutQueue:  paymentTimeoutQueue,
-		PendingSwapOutQueue: *pendingSwapOutQueue,
+		Vaults:                  vaults,
+		PayoutTimeoutQueue:      paymentTimeoutQueue,
+		PendingSwapOutQueue:     *pendingSwapOutQueue,
+		PayoutVerificationSet:   payoutVerificationAddrs,
 	}
 }
 

--- a/keeper/genesis_test.go
+++ b/keeper/genesis_test.go
@@ -268,6 +268,126 @@ func (s *TestSuite) TestVaultGenesis_InitPanicsWhenPendingSwapOutHasUnknownVault
 	s.Require().Panics(func() { s.k.InitGenesis(s.ctx, genesis) }, "InitGenesis should panic on invalid genesis state")
 }
 
+func (s *TestSuite) TestVaultGenesis_PayoutVerificationSetRestoredFromGenesis() {
+	shareDenom := "pvverify"
+	underlying := "underpv"
+	admin := s.adminAddr.String()
+	vaultAddr := types.GetVaultAddress(shareDenom)
+
+	vault := types.VaultAccount{
+		BaseAccount:         authtypes.NewBaseAccountWithAddress(vaultAddr),
+		Admin:               admin,
+		TotalShares:         sdk.NewInt64Coin(shareDenom, 0),
+		UnderlyingAsset:     underlying,
+		PaymentDenom:        underlying,
+		CurrentInterestRate: types.ZeroInterestRate,
+		DesiredInterestRate: types.ZeroInterestRate,
+	}
+
+	genesis := &types.GenesisState{
+		Vaults:                []types.VaultAccount{vault},
+		PayoutTimeoutQueue:    []types.QueueEntry{},
+		PendingSwapOutQueue:   types.PendingSwapOutQueue{},
+		PayoutVerificationSet: []string{vaultAddr.String()},
+	}
+
+	s.k.InitGenesis(s.ctx, genesis)
+	s.assertInPayoutVerificationQueue(vaultAddr, true)
+}
+
+func (s *TestSuite) TestVaultGenesis_PayoutVerificationSetExportSortedAndRoundTrip() {
+	shareDenom := "pvverify2"
+	underlying := "underpv2"
+	admin := s.adminAddr.String()
+	vaultAddrA := types.GetVaultAddress(shareDenom)
+	vaultAddrB := types.GetVaultAddress("otherdenom")
+
+	vA := types.VaultAccount{
+		BaseAccount:         authtypes.NewBaseAccountWithAddress(vaultAddrA),
+		Admin:               admin,
+		TotalShares:         sdk.NewInt64Coin(shareDenom, 0),
+		UnderlyingAsset:     underlying,
+		PaymentDenom:        underlying,
+		CurrentInterestRate: types.ZeroInterestRate,
+		DesiredInterestRate: types.ZeroInterestRate,
+	}
+	vB := types.VaultAccount{
+		BaseAccount:         authtypes.NewBaseAccountWithAddress(vaultAddrB),
+		Admin:               admin,
+		TotalShares:         sdk.NewInt64Coin("otherdenom", 0),
+		UnderlyingAsset:     underlying,
+		PaymentDenom:        underlying,
+		CurrentInterestRate: types.ZeroInterestRate,
+		DesiredInterestRate: types.ZeroInterestRate,
+	}
+
+	genesis := &types.GenesisState{
+		Vaults:              []types.VaultAccount{vA, vB},
+		PayoutTimeoutQueue:  []types.QueueEntry{},
+		PendingSwapOutQueue: types.PendingSwapOutQueue{},
+	}
+
+	s.k.InitGenesis(s.ctx, genesis)
+	s.Require().NoError(s.k.PayoutVerificationSet.Set(s.ctx, vaultAddrB))
+	s.Require().NoError(s.k.PayoutVerificationSet.Set(s.ctx, vaultAddrA))
+
+	exported := s.k.ExportGenesis(s.ctx)
+	s.Require().Len(exported.PayoutVerificationSet, 2, "export should list both vaults")
+	s.Require().Equal(vaultAddrA.String(), exported.PayoutVerificationSet[0], "exported set should be sorted")
+	s.Require().Equal(vaultAddrB.String(), exported.PayoutVerificationSet[1], "exported set should be sorted")
+}
+
+func (s *TestSuite) TestVaultGenesis_PayoutVerificationSetDuplicatePanics() {
+	shareDenom := "pvverify4"
+	underlying := "underpv4"
+	admin := s.adminAddr.String()
+	vaultAddr := types.GetVaultAddress(shareDenom)
+
+	vault := types.VaultAccount{
+		BaseAccount:         authtypes.NewBaseAccountWithAddress(vaultAddr),
+		Admin:               admin,
+		TotalShares:         sdk.NewInt64Coin(shareDenom, 0),
+		UnderlyingAsset:     underlying,
+		CurrentInterestRate: types.ZeroInterestRate,
+		DesiredInterestRate: types.ZeroInterestRate,
+	}
+
+	genesis := &types.GenesisState{
+		Vaults:                []types.VaultAccount{vault},
+		PayoutTimeoutQueue:    []types.QueueEntry{},
+		PendingSwapOutQueue:   types.PendingSwapOutQueue{},
+		PayoutVerificationSet: []string{vaultAddr.String(), vaultAddr.String()},
+	}
+
+	s.Require().Panics(func() { s.k.InitGenesis(s.ctx, genesis) }, "duplicate payout verification address should fail validation")
+}
+
+func (s *TestSuite) TestVaultGenesis_PayoutVerificationSetUnknownVaultPanics() {
+	shareDenom := "pvverify3"
+	underlying := "underpv3"
+	admin := s.adminAddr.String()
+	vaultAddr := types.GetVaultAddress(shareDenom)
+	other := types.GetVaultAddress("nope")
+
+	vault := types.VaultAccount{
+		BaseAccount:         authtypes.NewBaseAccountWithAddress(vaultAddr),
+		Admin:               admin,
+		TotalShares:         sdk.NewInt64Coin(shareDenom, 0),
+		UnderlyingAsset:     underlying,
+		CurrentInterestRate: types.ZeroInterestRate,
+		DesiredInterestRate: types.ZeroInterestRate,
+	}
+
+	genesis := &types.GenesisState{
+		Vaults:                []types.VaultAccount{vault},
+		PayoutTimeoutQueue:    []types.QueueEntry{},
+		PendingSwapOutQueue:   types.PendingSwapOutQueue{},
+		PayoutVerificationSet: []string{other.String()},
+	}
+
+	s.Require().Panics(func() { s.k.InitGenesis(s.ctx, genesis) }, "unknown vault in payout verification set should panic")
+}
+
 func (s *TestSuite) TestVaultGenesis_InitPanicsWhenPendingSwapOutHasBadVaultAddress() {
 	shareDenom := "vaultshare"
 	underlying := "undercoin"

--- a/proto/provlabs/vault/v1/genesis.proto
+++ b/proto/provlabs/vault/v1/genesis.proto
@@ -33,7 +33,6 @@ message PendingSwapOutQueue {
 }
 
 // GenesisState defines the vault module's genesis state.
-// NOTE: payout verification queue is not imported or exported.  It will always be empty after endblocker processes it.
 message GenesisState {
   // vaults defines the vaults that exist at genesis.
   repeated VaultAccount vaults = 1 [(gogoproto.nullable) = false];
@@ -45,4 +44,9 @@ message GenesisState {
 
   // pending_swap_out_queue contains entries for pending swap outs.
   PendingSwapOutQueue pending_swap_out_queue = 3 [(gogoproto.nullable) = false];
+
+  // payout_verification_set lists vault addresses (bech32) that are queued for
+  // payout/reconciliation verification in EndBlocker. Export/import preserves this
+  // across chain upgrades so vaults are not dropped from the reconciliation lifecycle.
+  repeated string payout_verification_set = 4;
 }

--- a/types/genesis.go
+++ b/types/genesis.go
@@ -1,5 +1,11 @@
 package types
 
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
 // DefaultGenesisState returns the default genesis state
 func DefaultGenesisState() *GenesisState {
 	return &GenesisState{}
@@ -8,6 +14,15 @@ func DefaultGenesisState() *GenesisState {
 // Validate performs basic genesis state validation returning an error upon any
 // failure.
 func (gs GenesisState) Validate() error {
-	// return gs.Params.Validate()
+	seen := make(map[string]struct{}, len(gs.PayoutVerificationSet))
+	for _, addr := range gs.PayoutVerificationSet {
+		if _, dup := seen[addr]; dup {
+			return fmt.Errorf("duplicate payout verification address %s", addr)
+		}
+		seen[addr] = struct{}{}
+		if _, err := sdk.AccAddressFromBech32(addr); err != nil {
+			return fmt.Errorf("invalid payout verification address %q: %w", addr, err)
+		}
+	}
 	return nil
 }

--- a/types/genesis.pb.go
+++ b/types/genesis.pb.go
@@ -198,7 +198,6 @@ func (m *PendingSwapOutQueue) GetEntries() []PendingSwapOutQueueEntry {
 }
 
 // GenesisState defines the vault module's genesis state.
-// NOTE: payout verification queue is not imported or exported.  It will always be empty after endblocker processes it.
 type GenesisState struct {
 	// vaults defines the vaults that exist at genesis.
 	Vaults []VaultAccount `protobuf:"bytes,1,rep,name=vaults,proto3" json:"vaults"`
@@ -208,6 +207,8 @@ type GenesisState struct {
 	PayoutTimeoutQueue []QueueEntry `protobuf:"bytes,2,rep,name=payout_timeout_queue,json=payoutTimeoutQueue,proto3" json:"payout_timeout_queue"`
 	// pending_swap_out_queue contains entries for pending swap outs.
 	PendingSwapOutQueue PendingSwapOutQueue `protobuf:"bytes,3,opt,name=pending_swap_out_queue,json=pendingSwapOutQueue,proto3" json:"pending_swap_out_queue"`
+	// payout_verification_set lists vault addresses pending payout/reconciliation verification.
+	PayoutVerificationSet []string `protobuf:"bytes,4,rep,name=payout_verification_set,json=payoutVerificationSet,proto3" json:"payout_verification_set,omitempty"`
 }
 
 func (m *GenesisState) Reset()         { *m = GenesisState{} }
@@ -262,6 +263,13 @@ func (m *GenesisState) GetPendingSwapOutQueue() PendingSwapOutQueue {
 		return m.PendingSwapOutQueue
 	}
 	return PendingSwapOutQueue{}
+}
+
+func (m *GenesisState) GetPayoutVerificationSet() []string {
+	if m != nil {
+		return m.PayoutVerificationSet
+	}
+	return nil
 }
 
 func init() {
@@ -444,6 +452,15 @@ func (m *GenesisState) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.PayoutVerificationSet) > 0 {
+		for iNdEx := len(m.PayoutVerificationSet) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.PayoutVerificationSet[iNdEx])
+			copy(dAtA[i:], m.PayoutVerificationSet[iNdEx])
+			i = encodeVarintGenesis(dAtA, i, uint64(len(m.PayoutVerificationSet[iNdEx])))
+			i--
+			dAtA[i] = 0x22
+		}
+	}
 	{
 		size, err := m.PendingSwapOutQueue.MarshalToSizedBuffer(dAtA[:i])
 		if err != nil {
@@ -567,6 +584,12 @@ func (m *GenesisState) Size() (n int) {
 	}
 	l = m.PendingSwapOutQueue.Size()
 	n += 1 + l + sovGenesis(uint64(l))
+	if len(m.PayoutVerificationSet) > 0 {
+		for _, s := range m.PayoutVerificationSet {
+			l = len(s)
+			n += 1 + l + sovGenesis(uint64(l))
+		}
+	}
 	return n
 }
 
@@ -1030,6 +1053,38 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 			if err := m.PendingSwapOutQueue.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PayoutVerificationSet", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PayoutVerificationSet = append(m.PayoutVerificationSet, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex


### PR DESCRIPTION
## summary

this adds \payout_verification_set\ to the vault module genesis state so \PayoutVerificationSet\ is exported and re-imported on chain upgrades and genesis reloads. without this, vaults waiting for payout/reconciliation verification could be dropped from endblock handling after an upgrade (see #136).

## changes

- **proto:** new \
epeated string payout_verification_set\ on \GenesisState\
- **types:** \GenesisState.Validate\ rejects duplicates and invalid bech32 addresses
- **keeper:** \ExportGenesis\ walks the set (sorted for stable exports); \InitGenesis\ restores entries after vaults and queues exist and checks each address resolves to a vault

## tests

- import from genesis populates the keeper set
- export returns sorted addresses when multiple vaults are queued
- duplicate or unknown vault entries fail as expected

## note for maintainers

\	ypes/genesis.pb.go\ was updated for the new field. please run \make proto-all\ locally if you want regenerated gogo file descriptors and \pi/\ pulsar output in lockstep with your toolchain (docker + buf). wire encoding for field 4 is implemented in the hand-updated gogo stubs.

fixes #136



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistence for the payout verification queue during genesis state initialization and export, with deterministic address sorting and validation.

* **Tests**
  * Added comprehensive test coverage for payout verification set behavior, including initialization, export round-tripping, duplicate detection, and vault reference validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->