### PR TITLE
Align autocli arg order with proto

### DIFF
--- a/.changelog/unreleased/improvements/135-align-autocli-arg-order-with-proto.md
+++ b/.changelog/unreleased/improvements/135-align-autocli-arg-order-with-proto.md
@@ -1,0 +1,1 @@
+* Aligned `AutoCLI` positional argument order with proto definitions for `CreateVault` (`[admin] [share_denom] [underlying_asset]`) and `SetShareDenomMetadata` (`[metadata] [admin] [vault_address]`). **Client API breaking:** scripts using the previous positional order must be updated [#135](https://github.com/provlabs/vault/issues/135).

--- a/module.go
+++ b/module.go
@@ -164,15 +164,15 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
 				{
 					RpcMethod: "CreateVault",
-					Use:       "create [admin] [underlying_asset] [share_denom]",
+					Use:       "create [admin] [share_denom] [underlying_asset]",
 					Alias:     []string{"c", "new"},
 					Short:     "Create a new vault",
 					Long:      "Create a new vault with an underlying asset and share denom. Optionally set a default payment denom for redemptions and a withdrawal delay that queues swap-outs until the delay elapses.",
-					Example:   fmt.Sprintf("%s create %s nhash svnhash --payment-denom nhash --withdrawal-delay-seconds 86400", txStart, exampleAdminAddr),
+					Example:   fmt.Sprintf("%s create %s svnhash nhash --payment-denom nhash --withdrawal-delay-seconds 86400", txStart, exampleAdminAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "admin"},
-						{ProtoField: "underlying_asset"},
 						{ProtoField: "share_denom"},
+						{ProtoField: "underlying_asset"},
 					},
 					FlagOptions: map[string]*autocliv1.FlagOptions{
 						"payment_denom": {
@@ -203,15 +203,15 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 				{
 					RpcMethod: "SetShareDenomMetadata",
-					Use:       "set-share-denom-metadata [admin] [vault_address] [metadata]",
+					Use:       "set-share-denom-metadata [metadata] [admin] [vault_address]",
 					Alias:     []string{"ssdm"},
 					Short:     "Set bank metadata for a vault’s share denom",
 					Long:      "Set on-chain bank metadata for the share denom of a vault. Provide a full metadata JSON object.",
-					Example:   fmt.Sprintf("%s set-share-denom-metadata %s %s '%s'", txStart, exampleAdminAddr, exampleVaultAddr, exampleMetadata),
+					Example:   fmt.Sprintf("%s set-share-denom-metadata '%s' %s %s", txStart, exampleMetadata, exampleAdminAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+						{ProtoField: "metadata"},
 						{ProtoField: "admin"},
 						{ProtoField: "vault_address"},
-						{ProtoField: "metadata"},
 					},
 				},
 				{


### PR DESCRIPTION
closes: #135 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CLI argument order for vault module commands. `CreateVault` now expects `[admin] [share_denom] [underlying_asset]` and `SetShareDenomMetadata` now expects `[metadata] [admin] [vault_address]`. This breaking change may require updating automation scripts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProvLabs/vault/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->