### PR TITLE
Use module-scoped logger throughout keeper package

### DIFF
--- a/.changelog/unreleased/improvements/179-keeper-logger-scope.md
+++ b/.changelog/unreleased/improvements/179-keeper-logger-scope.md
@@ -1,0 +1,1 @@
+* Replaced all `ctx.Logger()` calls in the keeper package with the module-scoped `k.getLogger(ctx)` for consistent, structured logging attributed to `x/vault`, and documented the convention in `GEMINI.md` [#179](https://github.com/provlabs/vault/issues/179).

--- a/.claude/skills/go-conventions/SKILL.md
+++ b/.claude/skills/go-conventions/SKILL.md
@@ -40,7 +40,9 @@ All large numeric literals use underscore digit separators: `1_000_000`, not `10
 
 ## 6. Logging
 
-- All logging goes through the module-scoped logger via `k.getLogger(ctx)`.
+- All logging in the `keeper/` package goes through the module-scoped logger via `k.getLogger(ctx)`.
+- `ctx.Logger()` is **not permitted** in keeper files — it produces unscoped logs that are harder to filter and attribute to the vault module. The only exception is the `getLogger` helper itself, which wraps `ctx.Logger()` to add the `module=x/vault` field.
+- When replacing or writing log calls, preserve existing structured fields (e.g. `"vault"`, `"err"`).
 - No `fmt.Println`, `log.Println`, or other unstructured logging.
 - Log messages are structured (key-value fields), informative, and not redundant with the error being returned.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -37,7 +37,7 @@ The agent operates as a **Principal Blockchain Engineer** with deep expertise in
 - **Number Formatting**: Use underscores as digit separators in large numeric literals (e.g., `123_456_789` instead of `123456789`) to improve readability.
 - **Cleanliness**: Proactively eliminate unused code and obsolete comments.
 - **Error Handling**: **Always** wrap errors with context: `fmt.Errorf("failed to [action]: %w", err)`.
-- **Logging**: Use the module-scoped logger via `k.getLogger(ctx)`. Log messages should be structured and informative.
+- **Logging**: Use the module-scoped logger via `k.getLogger(ctx)` for all logging in keeper files. `ctx.Logger()` is **not permitted** in the keeper package because it produces unscoped logs that are harder to filter and attribute to the vault module. The only exception is the `getLogger` helper itself, which wraps `ctx.Logger()` to add the `module=x/vault` field. Log messages should be structured and informative, preserving existing key-value fields (e.g. `"vault"`, `"err"`).
 - **Context Awareness**: `ctx sdk.Context` (or `context.Context` for gRPC) must be the first argument for all service-layer functions.
 
 ### Refactoring & DRY Mandate

--- a/keeper/payout.go
+++ b/keeper/payout.go
@@ -36,7 +36,7 @@ func (k *Keeper) processPendingSwapOuts(ctx sdk.Context, batchSize int) error {
 		return false, nil
 	})
 	if err != nil {
-		ctx.Logger().Error("error during pending withdrawal queue walk", "error", err)
+		k.getLogger(ctx).Error("error during pending withdrawal queue walk", "error", err)
 		return fmt.Errorf("failed to walk pending swap out queue: %w", err)
 	}
 
@@ -60,12 +60,12 @@ func (k *Keeper) processSwapOutJobs(ctx sdk.Context, jobsToProcess []types.Payou
 		vault, ok := k.tryGetVault(ctx, j.VaultAddr)
 		if !ok {
 			if err := k.PendingSwapOutQueue.Dequeue(ctx, j.Timestamp, j.VaultAddr, j.ID); err != nil {
-				ctx.Logger().Error(
+				k.getLogger(ctx).Error(
 					fmt.Sprintf("CRITICAL: failed to dequeue withdrawal request %d for non-existent vault %s", j.ID, j.VaultAddr),
 					"error", err,
 				)
 			} else {
-				ctx.Logger().Error(
+				k.getLogger(ctx).Error(
 					"dequeued and skipped pending withdrawal for non-existent vault",
 					"request_id", j.ID,
 					"vault_address", j.VaultAddr.String(),
@@ -79,7 +79,7 @@ func (k *Keeper) processSwapOutJobs(ctx sdk.Context, jobsToProcess []types.Payou
 		}
 
 		if err := k.PendingSwapOutQueue.Dequeue(ctx, j.Timestamp, j.VaultAddr, j.ID); err != nil {
-			ctx.Logger().Error(
+			k.getLogger(ctx).Error(
 				"failed to dequeue withdrawal request",
 				"request_id", j.ID,
 				"vault_address", j.VaultAddr.String(),
@@ -154,7 +154,7 @@ func (k *Keeper) processSingleWithdrawal(ctx sdk.Context, id uint64, req types.P
 			"failed to transfer %s shares from %s to principal %s for burning",
 			req.Shares, vaultAddr, principalAddress,
 		)
-		ctx.Logger().Error("CRITICAL: "+errMsg, "error", err)
+		k.getLogger(ctx).Error("CRITICAL: "+errMsg, "error", err)
 		return types.CriticalErr(errMsg, fmt.Errorf("%s: %w", errMsg, err))
 	}
 
@@ -163,7 +163,7 @@ func (k *Keeper) processSingleWithdrawal(ctx sdk.Context, id uint64, req types.P
 			"failed to burn %s shares from account %s after successful payout",
 			req.Shares, vaultAddr,
 		)
-		ctx.Logger().Error("CRITICAL: "+errMsg, "error", err)
+		k.getLogger(ctx).Error("CRITICAL: "+errMsg, "error", err)
 		return types.CriticalErr(errMsg, fmt.Errorf("%s: %w", errMsg, err))
 	}
 
@@ -175,7 +175,7 @@ func (k *Keeper) processSingleWithdrawal(ctx sdk.Context, id uint64, req types.P
 			"failed to deduct %s shares from vault %s total shares after successful payout",
 			req.Shares, vaultAddr,
 		)
-		ctx.Logger().Error("CRITICAL: "+errMsg, "error", err)
+		k.getLogger(ctx).Error("CRITICAL: "+errMsg, "error", err)
 		return types.CriticalErr(errMsg, fmt.Errorf("%s: %w", errMsg, err))
 	}
 
@@ -184,7 +184,7 @@ func (k *Keeper) processSingleWithdrawal(ctx sdk.Context, id uint64, req types.P
 			"failed to update vault account %s after successful payout",
 			vaultAddr,
 		)
-		ctx.Logger().Error("CRITICAL: "+errMsg, "error", err)
+		k.getLogger(ctx).Error("CRITICAL: "+errMsg, "error", err)
 		return types.CriticalErr(errMsg, fmt.Errorf("%s: %w", errMsg, err))
 	}
 
@@ -211,7 +211,7 @@ func (k *Keeper) refundWithdrawal(ctx sdk.Context, id uint64, req types.PendingS
 			"failed to refund %s shares from vault %s to owner %s",
 			req.Shares, vaultAddr, ownerAddr,
 		)
-		ctx.Logger().Error("CRITICAL: "+errMsg, "error", err)
+		k.getLogger(ctx).Error("CRITICAL: "+errMsg, "error", err)
 		return types.CriticalErr(errMsg, fmt.Errorf("%s: %w", errMsg, err))
 	}
 

--- a/keeper/query_server.go
+++ b/keeper/query_server.go
@@ -44,11 +44,11 @@ func (k queryServer) Vaults(goCtx context.Context, req *types.QueryVaultsRequest
 		func(key sdk.AccAddress, _ []byte) (include bool, err error) {
 			vault, err := k.GetVault(ctx, key)
 			if err != nil {
-				ctx.Logger().Error("failed to get vault during pagination", "key", key.String(), "error", err)
+				k.getLogger(ctx).Error("failed to get vault during pagination", "key", key.String(), "error", err)
 				return false, nil
 			}
 			if vault == nil {
-				ctx.Logger().Error("nil vault found during pagination", "key", key.String())
+				k.getLogger(ctx).Error("nil vault found during pagination", "key", key.String())
 				return false, nil
 			}
 			vaults = append(vaults, *vault)

--- a/keeper/reconcile.go
+++ b/keeper/reconcile.go
@@ -136,7 +136,7 @@ func (k Keeper) publishShareNav(ctx sdk.Context, vault *types.VaultAccount) erro
 	}
 
 	if err := k.setShareDenomNAV(ctx, vault, vaultMarker, tvv); err != nil {
-		ctx.Logger().Error("failed to publish share NAV", "err", err)
+		k.getLogger(ctx).Error("failed to publish share NAV", "err", err)
 	}
 	return nil
 }
@@ -494,7 +494,7 @@ func (k Keeper) handleVaultInterestTimeouts(ctx sdk.Context) error {
 
 		canPay, err := k.CanPayInterestDuration(ctx, vault, periodDuration)
 		if err != nil {
-			ctx.Logger().Error("failed to check payout ability, rescheduling", "vault", addr.String(), "err", err)
+			k.getLogger(ctx).Error("failed to check payout ability, rescheduling", "vault", addr.String(), "err", err)
 			k.reschedulePayoutTimeout(ctx, vault, int64(timeout))
 			continue
 		}
@@ -502,13 +502,13 @@ func (k Keeper) handleVaultInterestTimeouts(ctx sdk.Context) error {
 		if !canPay {
 			depleted = append(depleted, vault)
 			if err := k.PayoutTimeoutQueue.Dequeue(ctx, int64(timeout), addr); err != nil {
-				ctx.Logger().Error("CRITICAL: failed to dequeue interest timeout, skipping", "vault", addr.String(), "err", err)
+				k.getLogger(ctx).Error("CRITICAL: failed to dequeue interest timeout, skipping", "vault", addr.String(), "err", err)
 			}
 			continue
 		}
 
 		if err := k.atomicallyReconcileInterest(ctx, vault, int64(timeout)); err != nil {
-			ctx.Logger().Error("failed to reconcile interest atomically, rescheduling", "vault", addr.String(), "err", err)
+			k.getLogger(ctx).Error("failed to reconcile interest atomically, rescheduling", "vault", addr.String(), "err", err)
 			k.reschedulePayoutTimeout(ctx, vault, int64(timeout))
 			continue
 		}
@@ -545,7 +545,7 @@ func (k Keeper) atomicallyReconcileInterest(ctx sdk.Context, vault *types.VaultA
 // NOTE: This preserves the PeriodStart to ensure accrued interest is not lost.
 func (k Keeper) reschedulePayoutTimeout(ctx sdk.Context, vault *types.VaultAccount, oldTimeout int64) {
 	if err := k.ReschedulePayoutTimeout(ctx, vault, oldTimeout); err != nil {
-		ctx.Logger().Error("failed to reschedule payout timeout", "vault", vault.GetAddress().String(), "err", err)
+		k.getLogger(ctx).Error("failed to reschedule payout timeout", "vault", vault.GetAddress().String(), "err", err)
 	}
 }
 
@@ -554,11 +554,11 @@ func (k Keeper) reschedulePayoutTimeout(ctx sdk.Context, vault *types.VaultAccou
 func (k Keeper) tryGetVault(ctx sdk.Context, addr sdk.AccAddress) (*types.VaultAccount, bool) {
 	vault, err := k.GetVault(ctx, addr)
 	if err != nil {
-		ctx.Logger().Error("failed to get vault", "address", addr.String(), "error", err)
+		k.getLogger(ctx).Error("failed to get vault", "address", addr.String(), "error", err)
 		return nil, false
 	}
 	if vault == nil {
-		ctx.Logger().Error("vault not found", "address", addr.String())
+		k.getLogger(ctx).Error("vault not found", "address", addr.String())
 		return nil, false
 	}
 	return vault, true
@@ -587,7 +587,7 @@ func (k Keeper) handleReconciledVaults(ctx sdk.Context) error {
 
 	for _, addr := range keysToProcess {
 		if err := k.PayoutVerificationSet.Remove(ctx, addr); err != nil {
-			ctx.Logger().Error("CRITICAL: failed to remove from payout verification set, skipping", "vault", addr.String(), "err", err)
+			k.getLogger(ctx).Error("CRITICAL: failed to remove from payout verification set, skipping", "vault", addr.String(), "err", err)
 			continue
 		}
 
@@ -611,7 +611,7 @@ func (k Keeper) partitionVaults(ctx sdk.Context, vaults []*types.VaultAccount) (
 	for _, v := range vaults {
 		ok, err := k.CanPayInterestDuration(ctx, v, AutoReconcilePayoutDuration)
 		if err != nil {
-			ctx.Logger().Error("failed to check payout ability", "vault", v.GetAddress().String(), "err", err)
+			k.getLogger(ctx).Error("failed to check payout ability", "vault", v.GetAddress().String(), "err", err)
 			continue
 		}
 		if ok {
@@ -628,7 +628,7 @@ func (k Keeper) partitionVaults(ctx sdk.Context, vaults []*types.VaultAccount) (
 func (k Keeper) handlePayableVaults(ctx sdk.Context, payouts []*types.VaultAccount) {
 	for _, v := range payouts {
 		if err := k.SafeEnqueuePayoutTimeout(ctx, v); err != nil {
-			ctx.Logger().Error("failed to enqueue timeout", "vault", v.GetAddress().String(), "err", err)
+			k.getLogger(ctx).Error("failed to enqueue timeout", "vault", v.GetAddress().String(), "err", err)
 		}
 	}
 }
@@ -638,7 +638,7 @@ func (k Keeper) handlePayableVaults(ctx sdk.Context, payouts []*types.VaultAccou
 func (k Keeper) handleDepletedVaults(ctx sdk.Context, failedPayouts []*types.VaultAccount) {
 	for _, record := range failedPayouts {
 		if err := k.UpdateInterestRates(ctx, record, types.ZeroInterestRate, record.DesiredInterestRate); err != nil {
-			ctx.Logger().Error("failed to update interest rates", "vault", record.GetAddress().String(), "err", err)
+			k.getLogger(ctx).Error("failed to update interest rates", "vault", record.GetAddress().String(), "err", err)
 		}
 	}
 }
@@ -675,7 +675,7 @@ func (k Keeper) handleVaultFeeTimeouts(ctx sdk.Context) error {
 		}
 
 		if err := k.atomicallyReconcileFee(ctx, vault, int64(timeout)); err != nil {
-			ctx.Logger().Error("failed to collect AUM fee atomically, rescheduling", "vault", addr.String(), "err", err)
+			k.getLogger(ctx).Error("failed to collect AUM fee atomically, rescheduling", "vault", addr.String(), "err", err)
 			k.rescheduleFeeTimeout(ctx, vault, int64(timeout))
 			continue
 		}
@@ -711,6 +711,6 @@ func (k Keeper) atomicallyReconcileFee(ctx sdk.Context, vault *types.VaultAccoun
 // NOTE: This preserves the FeePeriodStart to ensure accrued fees are not lost.
 func (k Keeper) rescheduleFeeTimeout(ctx sdk.Context, vault *types.VaultAccount, oldTimeout int64) {
 	if err := k.RescheduleFeeTimeout(ctx, vault, oldTimeout); err != nil {
-		ctx.Logger().Error("failed to reschedule fee timeout", "vault", vault.GetAddress().String(), "err", err)
+		k.getLogger(ctx).Error("failed to reschedule fee timeout", "vault", vault.GetAddress().String(), "err", err)
 	}
 }

--- a/keeper/vault.go
+++ b/keeper/vault.go
@@ -480,7 +480,7 @@ func (k *Keeper) SetWithdrawalDelay(ctx sdk.Context, vault *types.VaultAccount, 
 // critical, unrecoverable error for a specific vault. The provided reason should be a stable,
 // hard-coded string suitable for persistence and later auditing.
 func (k *Keeper) autoPauseVault(ctx sdk.Context, vault *types.VaultAccount, reason string) {
-	ctx.Logger().Error(
+	k.getLogger(ctx).Error(
 		"Auto-pausing vault due to critical error",
 		"vault_address", vault.GetAddress().String(),
 		"reason", reason,
@@ -488,7 +488,7 @@ func (k *Keeper) autoPauseVault(ctx sdk.Context, vault *types.VaultAccount, reas
 
 	tvv, err := k.GetTVVInUnderlyingAsset(ctx, *vault)
 	if err != nil {
-		ctx.Logger().Error("Failed to get TVV in underlying asset", "vault_address", vault.GetAddress().String(), "error", err)
+		k.getLogger(ctx).Error("Failed to get TVV in underlying asset", "vault_address", vault.GetAddress().String(), "error", err)
 	}
 
 	vault.Paused = true


### PR DESCRIPTION
Closes #179.

## Summary

Replaces every `ctx.Logger()` call in the `keeper/` package with the module-scoped `k.getLogger(ctx)` so all vault log lines are attributed to `module=x/vault` and consistently filterable. No behavior changes — same messages, same structured fields, just the right logger.

## What changed

- **`keeper/payout.go`** — 7 log sites (queue walk failure, dequeue failures, withdrawal-processing critical errors, refund critical error).
- **`keeper/reconcile.go`** — 11 log sites across interest timeout, fee timeout, payable/depleted partitioning, and the `tryGetVault` helper.
- **`keeper/query_server.go`** — 2 log sites in `Vaults` pagination.
- **`keeper/vault.go`** — 2 log sites in `autoPauseVault`.
- **`GEMINI.md`** and **`.claude/skills/go-conventions/SKILL.md`** — document the convention: `ctx.Logger()` is not permitted in keeper files; the only exception is the `getLogger` helper itself, which wraps `ctx.Logger()` to inject the `module=x/vault` field.
- **`.changelog/unreleased/improvements/179-keeper-logger-scope.md`** — release note.

Existing structured fields (`"vault"`, `"err"`, `"request_id"`, `"vault_address"`, etc.) were preserved verbatim.

## Test plan

- [ ] `make lint` clean
- [ ] `make test` passes
- [ ] Spot-check a keeper log line in a local sim: it carries `module=x/vault`