### PR TITLE
Add safe math operations on NAVs

### DIFF
--- a/.changelog/unreleased/bug-fixes/206-guard-nav-multiplication.md
+++ b/.changelog/unreleased/bug-fixes/206-guard-nav-multiplication.md
@@ -1,0 +1,1 @@
+* Guard NAV valuation multiplications with `SafeMul` so an oversized net asset value returns an error instead of panicking the block hook [#206](https://github.com/provlabs/vault/issues/206).

--- a/keeper/suite_test.go
+++ b/keeper/suite_test.go
@@ -583,6 +583,19 @@ func (s *TestSuite) setupSinglePaymentDenomVault(underlyingDenom, shareDenom, pa
 	return vault
 }
 
+// setupOversizedNAVVault builds a single-payment-denom vault primed for the NAV
+// overflow guard tests. It returns the vault, a keeper wired with the marker and
+// bank keepers, and the underlying and payment denoms used to stage oversized
+// NAVs.
+func (s *TestSuite) setupOversizedNAVVault() (*types.VaultAccount, keeper.Keeper, string, string) {
+	underlyingDenom := "ylds"
+	paymentDenom := "usdc"
+	shareDenom := "vshare"
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
+	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
+	return vault, testKeeper, underlyingDenom, paymentDenom
+}
+
 // setReverseNAV sets a reverse net asset value on the underlying denom marker,
 // allowing the vault to value the underlying in terms of the payment denom.
 func (s *TestSuite) setReverseNAV(underlyingDenom, paymentDenom string, price, volume int64) {

--- a/keeper/suite_test.go
+++ b/keeper/suite_test.go
@@ -608,6 +608,15 @@ func oversizedNAVPrice() sdkmath.Int {
 	return sdkmath.NewIntFromBigInt(new(big.Int).Lsh(big.NewInt(1), 200))
 }
 
+// maxValidNAVPrice returns the largest value an sdkmath.Int can hold (2^256-1).
+// As a NAV price it converts a single unit of a denom to the maximum
+// representable underlying value, leaving no headroom in the TVV accumulator so
+// that any additional balance trips the SafeAdd overflow guard in
+// GetTVVInUnderlyingAsset without the per-balance SafeMul overflowing first.
+func maxValidNAVPrice() sdkmath.Int {
+	return sdkmath.NewIntFromBigInt(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)))
+}
+
 // overrideNAV sets, at a fresh (newest) block height, a net asset value on the
 // marker for navMarkerDenom priced in priceDenom. It lets tests stage oversized
 // prices that the marker module accepts without bound, so the valuation paths

--- a/keeper/suite_test.go
+++ b/keeper/suite_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"strconv"
 	"strings"
 	"testing"
@@ -597,6 +598,28 @@ func (s *TestSuite) setReverseNAV(underlyingDenom, paymentDenom string, price, v
 // bumpHeight increments the suite's context block height by 1.
 func (s *TestSuite) bumpHeight() {
 	s.ctx = s.ctx.WithBlockHeight(s.ctx.BlockHeight() + 1)
+}
+
+// oversizedNAVPrice returns a NAV price amount (2^200) large enough that
+// multiplying it by a comparable balance exceeds the 256-bit sdkmath.Int
+// ceiling. It models the attacker-controlled price the marker module does not
+// bound, and exercises the SafeMul overflow guards on the valuation paths.
+func oversizedNAVPrice() sdkmath.Int {
+	return sdkmath.NewIntFromBigInt(new(big.Int).Lsh(big.NewInt(1), 200))
+}
+
+// overrideNAV sets, at a fresh (newest) block height, a net asset value on the
+// marker for navMarkerDenom priced in priceDenom. It lets tests stage oversized
+// prices that the marker module accepts without bound, so the valuation paths
+// can be driven into overflow.
+func (s *TestSuite) overrideNAV(navMarkerDenom, priceDenom string, price sdkmath.Int, volume uint64) {
+	s.bumpHeight()
+	markerAcct, err := s.k.MarkerKeeper.GetMarker(s.ctx, markertypes.MustGetMarkerAddress(navMarkerDenom))
+	s.Require().NoError(err, "should fetch %s marker for NAV override", navMarkerDenom)
+	s.Require().NoError(s.k.MarkerKeeper.SetNetAssetValue(s.ctx, markerAcct, markertypes.NetAssetValue{
+		Price:  sdk.NewCoin(priceDenom, price),
+		Volume: volume,
+	}, "test-oversized"), "should override NAV on %s priced in %s", navMarkerDenom, priceDenom)
 }
 
 // setupReconcileVault initializes a vault with the provided parameters, including markers and funding.

--- a/keeper/valuation_engine.go
+++ b/keeper/valuation_engine.go
@@ -117,7 +117,11 @@ func (k Keeper) ToUnderlyingAssetAmount(ctx sdk.Context, vault types.VaultAccoun
 	if err != nil {
 		return math.Int{}, fmt.Errorf("failed to get unit price fraction: %w", err)
 	}
-	return in.Amount.Mul(priceAmount).Quo(volume), nil
+	product, err := in.Amount.SafeMul(priceAmount)
+	if err != nil {
+		return math.Int{}, fmt.Errorf("failed to multiply amount %s by price %s: %w", in.Amount, priceAmount, err)
+	}
+	return product.Quo(volume), nil
 }
 
 // FromUnderlyingAssetAmount converts an amount of vault.UnderlyingAsset into
@@ -136,7 +140,11 @@ func (k Keeper) FromUnderlyingAssetAmount(ctx sdk.Context, vault types.VaultAcco
 	if priceNum.IsZero() {
 		return math.Int{}, fmt.Errorf("zero price for %s/%s", targetDenom, vault.UnderlyingAsset)
 	}
-	return inAmount.Mul(priceDen).Quo(priceNum), nil
+	product, err := inAmount.SafeMul(priceDen)
+	if err != nil {
+		return math.Int{}, fmt.Errorf("failed to multiply amount %s by price denominator %s: %w", inAmount, priceDen, err)
+	}
+	return product.Quo(priceNum), nil
 }
 
 // GetTVVInUnderlyingAsset returns the Total Vault Value (TVV) expressed in
@@ -217,7 +225,10 @@ func (k Keeper) ConvertDepositToSharesInUnderlyingAsset(ctx sdk.Context, vault t
 	if err != nil {
 		return sdk.Coin{}, fmt.Errorf("failed to get TVV: %w", err)
 	}
-	amountNumerator := in.Amount.Mul(priceNum)
+	amountNumerator, err := in.Amount.SafeMul(priceNum)
+	if err != nil {
+		return sdk.Coin{}, fmt.Errorf("failed to multiply amount %s by price numerator %s: %w", in.Amount, priceNum, err)
+	}
 	return utils.CalculateSharesProRataFraction(amountNumerator, priceDen, tvv, vault.TotalShares.Amount, vault.TotalShares.Denom)
 }
 

--- a/keeper/valuation_engine.go
+++ b/keeper/valuation_engine.go
@@ -177,7 +177,10 @@ func (k Keeper) GetTVVInUnderlyingAsset(ctx sdk.Context, vault types.VaultAccoun
 		if err != nil {
 			return math.Int{}, fmt.Errorf("failed to convert balance to underlying: %w", err)
 		}
-		total = total.Add(val)
+		total, err = total.SafeAdd(val)
+		if err != nil {
+			return math.Int{}, fmt.Errorf("failed to add balance %s to total vault value: %w", val, err)
+		}
 	}
 	return total, nil
 }

--- a/keeper/valuation_engine_test.go
+++ b/keeper/valuation_engine_test.go
@@ -211,56 +211,53 @@ func (s *TestSuite) TestFromUnderlyingAssetAmount() {
 	s.Require().Contains(err.Error(), "price is zero", "error should mention zero price")
 }
 
-func (s *TestSuite) TestToUnderlyingAssetAmount_OversizedNAVReturnsErrorNotPanic() {
-	underlyingDenom := "ylds"
-	paymentDenom := "usdc"
-	shareDenom := "vshare"
-	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
-	s.overrideNAV(paymentDenom, underlyingDenom, oversizedNAVPrice(), 1)
+func (s *TestSuite) TestNAVConversion_OversizedNAVReturnsErrorNotPanic() {
+	vault, testKeeper, underlyingDenom, paymentDenom := s.setupOversizedNAVVault()
 
-	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	_, err := testKeeper.ToUnderlyingAssetAmount(s.ctx, *vault, sdk.NewCoin(paymentDenom, oversizedNAVPrice()))
-	s.Require().Error(err, "oversized NAV must degrade to an error, not panic, on the TVV multiplication path")
-	s.Require().ErrorContains(err, "integer overflow", "error should originate from the SafeMul overflow guard")
-}
-
-func (s *TestSuite) TestFromUnderlyingAssetAmount_OversizedNAVReturnsErrorNotPanic() {
-	underlyingDenom := "ylds"
-	paymentDenom := "usdc"
-	shareDenom := "vshare"
-	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
-	s.overrideNAV(underlyingDenom, paymentDenom, oversizedNAVPrice(), 1)
-
-	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	_, err := testKeeper.FromUnderlyingAssetAmount(s.ctx, *vault, oversizedNAVPrice(), paymentDenom)
-	s.Require().Error(err, "oversized reverse NAV must degrade to an error, not panic, on the conversion path")
-	s.Require().ErrorContains(err, "integer overflow", "error should originate from the SafeMul overflow guard")
-}
-
-func (s *TestSuite) TestConvertDepositToSharesInUnderlyingAsset_OversizedNAVReturnsErrorNotPanic() {
-	underlyingDenom := "ylds"
-	paymentDenom := "usdc"
-	shareDenom := "vshare"
-	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
-	s.overrideNAV(paymentDenom, underlyingDenom, oversizedNAVPrice(), 1)
-
-	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	_, err := testKeeper.ConvertDepositToSharesInUnderlyingAsset(s.ctx, *vault, sdk.NewCoin(paymentDenom, oversizedNAVPrice()))
-	s.Require().Error(err, "oversized NAV must degrade to an error, not panic, when converting a deposit to shares")
-	s.Require().ErrorContains(err, "integer overflow", "error should originate from the SafeMul overflow guard")
-}
-
-func (s *TestSuite) TestConvertSharesToRedeemCoin_OversizedNAVReturnsErrorNotPanic() {
-	underlyingDenom := "ylds"
-	paymentDenom := "usdc"
-	shareDenom := "vshare"
-	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
-	s.overrideNAV(underlyingDenom, paymentDenom, oversizedNAVPrice(), 1)
-
-	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
-	_, err := testKeeper.ConvertSharesToRedeemCoin(s.ctx, *vault, oversizedNAVPrice(), paymentDenom)
-	s.Require().Error(err, "oversized reverse NAV must degrade to an error, not panic, when redeeming shares to a payout coin")
-	s.Require().ErrorContains(err, "integer overflow", "error should originate from the SafeMul overflow guard")
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "valuing a payment balance in underlying overflows the forward NAV multiply",
+			run: func() error {
+				s.overrideNAV(paymentDenom, underlyingDenom, oversizedNAVPrice(), 1)
+				_, err := testKeeper.ToUnderlyingAssetAmount(s.ctx, *vault, sdk.NewCoin(paymentDenom, oversizedNAVPrice()))
+				return err
+			},
+		},
+		{
+			name: "valuing underlying in a payment denom overflows the reverse NAV multiply",
+			run: func() error {
+				s.overrideNAV(underlyingDenom, paymentDenom, oversizedNAVPrice(), 1)
+				_, err := testKeeper.FromUnderlyingAssetAmount(s.ctx, *vault, oversizedNAVPrice(), paymentDenom)
+				return err
+			},
+		},
+		{
+			name: "converting an oversized deposit to shares overflows the forward NAV multiply",
+			run: func() error {
+				s.overrideNAV(paymentDenom, underlyingDenom, oversizedNAVPrice(), 1)
+				_, err := testKeeper.ConvertDepositToSharesInUnderlyingAsset(s.ctx, *vault, sdk.NewCoin(paymentDenom, oversizedNAVPrice()))
+				return err
+			},
+		},
+		{
+			name: "redeeming shares to a payout coin overflows the reverse NAV multiply",
+			run: func() error {
+				s.overrideNAV(underlyingDenom, paymentDenom, oversizedNAVPrice(), 1)
+				_, err := testKeeper.ConvertSharesToRedeemCoin(s.ctx, *vault, oversizedNAVPrice(), paymentDenom)
+				return err
+			},
+		},
+	}
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			err := tc.run()
+			s.Require().Error(err, "oversized NAV must degrade to an error, not panic: %s", tc.name)
+			s.Require().ErrorContains(err, "integer overflow", "error should originate from the SafeMul overflow guard: %s", tc.name)
+		})
+	}
 }
 
 func (s *TestSuite) TestToUnderlyingAssetAmount_IdentityFastPath() {
@@ -331,11 +328,7 @@ func (s *TestSuite) TestGetTVVInUnderlyingAsset_ErrorPropagation() {
 }
 
 func (s *TestSuite) TestGetTVVInUnderlyingAsset_AccumulatorOverflowReturnsErrorNotPanic() {
-	underlyingDenom := "ylds"
-	paymentDenom := "usdc"
-	shareDenom := "vshare"
-	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 1)
-
+	vault, testKeeper, underlyingDenom, paymentDenom := s.setupOversizedNAVVault()
 	s.overrideNAV(paymentDenom, underlyingDenom, maxValidNAVPrice(), 1)
 
 	principalAddress := vault.PrincipalMarkerAddress()
@@ -346,7 +339,6 @@ func (s *TestSuite) TestGetTVVInUnderlyingAsset_AccumulatorOverflowReturnsErrorN
 		sdk.NewInt64Coin(underlyingDenom, 100),
 	)), "funding principal with a small underlying balance should succeed")
 
-	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
 	_, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vault)
 	s.Require().Error(err, "summing balances past the 256-bit ceiling must degrade to an error, not panic")
 	s.Require().ErrorContains(err, "integer overflow", "error should originate from the SafeAdd accumulator guard")

--- a/keeper/valuation_engine_test.go
+++ b/keeper/valuation_engine_test.go
@@ -250,6 +250,19 @@ func (s *TestSuite) TestConvertDepositToSharesInUnderlyingAsset_OversizedNAVRetu
 	s.Require().ErrorContains(err, "integer overflow", "error should originate from the SafeMul overflow guard")
 }
 
+func (s *TestSuite) TestConvertSharesToRedeemCoin_OversizedNAVReturnsErrorNotPanic() {
+	underlyingDenom := "ylds"
+	paymentDenom := "usdc"
+	shareDenom := "vshare"
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
+	s.overrideNAV(underlyingDenom, paymentDenom, oversizedNAVPrice(), 1)
+
+	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
+	_, err := testKeeper.ConvertSharesToRedeemCoin(s.ctx, *vault, oversizedNAVPrice(), paymentDenom)
+	s.Require().Error(err, "oversized reverse NAV must degrade to an error, not panic, when redeeming shares to a payout coin")
+	s.Require().ErrorContains(err, "integer overflow", "error should originate from the SafeMul overflow guard")
+}
+
 func (s *TestSuite) TestToUnderlyingAssetAmount_IdentityFastPath() {
 	underlyingDenom := "ylds"
 	shareDenom := "vshare"

--- a/keeper/valuation_engine_test.go
+++ b/keeper/valuation_engine_test.go
@@ -330,6 +330,29 @@ func (s *TestSuite) TestGetTVVInUnderlyingAsset_ErrorPropagation() {
 	s.Require().Contains(err.Error(), "nav not found for usdc/ylds", "error should propagate from missing NAV")
 }
 
+func (s *TestSuite) TestGetTVVInUnderlyingAsset_AccumulatorOverflowReturnsErrorNotPanic() {
+	underlyingDenom := "ylds"
+	paymentDenom := "usdc"
+	shareDenom := "vshare"
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 1)
+
+	s.overrideNAV(paymentDenom, underlyingDenom, maxValidNAVPrice(), 1)
+
+	principalAddress := vault.PrincipalMarkerAddress()
+	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, principalAddress, sdk.NewCoins(
+		sdk.NewInt64Coin(paymentDenom, 1),
+	)), "funding principal with one payment unit should succeed")
+	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, principalAddress, sdk.NewCoins(
+		sdk.NewInt64Coin(underlyingDenom, 100),
+	)), "funding principal with a small underlying balance should succeed")
+
+	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
+	_, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vault)
+	s.Require().Error(err, "summing balances past the 256-bit ceiling must degrade to an error, not panic")
+	s.Require().ErrorContains(err, "integer overflow", "error should originate from the SafeAdd accumulator guard")
+	s.Require().ErrorContains(err, "total vault value", "error should carry the accumulator's wrapping context")
+}
+
 func (s *TestSuite) TestGetTVVInUnderlyingAsset_ExcludesReserves() {
 	underlyingDenom := "ylds"
 	shareDenom := "vshare"

--- a/keeper/valuation_engine_test.go
+++ b/keeper/valuation_engine_test.go
@@ -211,6 +211,45 @@ func (s *TestSuite) TestFromUnderlyingAssetAmount() {
 	s.Require().Contains(err.Error(), "price is zero", "error should mention zero price")
 }
 
+func (s *TestSuite) TestToUnderlyingAssetAmount_OversizedNAVReturnsErrorNotPanic() {
+	underlyingDenom := "ylds"
+	paymentDenom := "usdc"
+	shareDenom := "vshare"
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
+	s.overrideNAV(paymentDenom, underlyingDenom, oversizedNAVPrice(), 1)
+
+	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
+	_, err := testKeeper.ToUnderlyingAssetAmount(s.ctx, *vault, sdk.NewCoin(paymentDenom, oversizedNAVPrice()))
+	s.Require().Error(err, "oversized NAV must degrade to an error, not panic, on the TVV multiplication path")
+	s.Require().ErrorContains(err, "integer overflow", "error should originate from the SafeMul overflow guard")
+}
+
+func (s *TestSuite) TestFromUnderlyingAssetAmount_OversizedNAVReturnsErrorNotPanic() {
+	underlyingDenom := "ylds"
+	paymentDenom := "usdc"
+	shareDenom := "vshare"
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
+	s.overrideNAV(underlyingDenom, paymentDenom, oversizedNAVPrice(), 1)
+
+	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
+	_, err := testKeeper.FromUnderlyingAssetAmount(s.ctx, *vault, oversizedNAVPrice(), paymentDenom)
+	s.Require().Error(err, "oversized reverse NAV must degrade to an error, not panic, on the conversion path")
+	s.Require().ErrorContains(err, "integer overflow", "error should originate from the SafeMul overflow guard")
+}
+
+func (s *TestSuite) TestConvertDepositToSharesInUnderlyingAsset_OversizedNAVReturnsErrorNotPanic() {
+	underlyingDenom := "ylds"
+	paymentDenom := "usdc"
+	shareDenom := "vshare"
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
+	s.overrideNAV(paymentDenom, underlyingDenom, oversizedNAVPrice(), 1)
+
+	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
+	_, err := testKeeper.ConvertDepositToSharesInUnderlyingAsset(s.ctx, *vault, sdk.NewCoin(paymentDenom, oversizedNAVPrice()))
+	s.Require().Error(err, "oversized NAV must degrade to an error, not panic, when converting a deposit to shares")
+	s.Require().ErrorContains(err, "integer overflow", "error should originate from the SafeMul overflow guard")
+}
+
 func (s *TestSuite) TestToUnderlyingAssetAmount_IdentityFastPath() {
 	underlyingDenom := "ylds"
 	shareDenom := "vshare"

--- a/utils/shares.go
+++ b/utils/shares.go
@@ -57,14 +57,23 @@ func CalculateSharesProRataFraction(
 		return sdk.Coin{}, fmt.Errorf("invalid input: zero denominator")
 	}
 	if totalAssets.IsZero() && totalShares.IsZero() {
-		shares := amountNumerator.Mul(ShareScalar).Quo(amountDenominator)
-		return sdk.NewCoin(shareDenom, shares), nil
+		scaled, err := amountNumerator.SafeMul(ShareScalar)
+		if err != nil {
+			return sdk.Coin{}, fmt.Errorf("failed to multiply amount numerator %s by share scalar %s: %w", amountNumerator, ShareScalar, err)
+		}
+		return sdk.NewCoin(shareDenom, scaled.Quo(amountDenominator)), nil
 	}
 	ta := totalAssets.Add(VirtualAssets)
 	ts := totalShares.Add(VirtualShares)
-	den := amountDenominator.Mul(ta)
-	shares := amountNumerator.Mul(ts).Quo(den)
-	return sdk.NewCoin(shareDenom, shares), nil
+	den, err := amountDenominator.SafeMul(ta)
+	if err != nil {
+		return sdk.Coin{}, fmt.Errorf("failed to multiply amount denominator %s by total assets %s: %w", amountDenominator, ta, err)
+	}
+	numerator, err := amountNumerator.SafeMul(ts)
+	if err != nil {
+		return sdk.Coin{}, fmt.Errorf("failed to multiply amount numerator %s by total shares %s: %w", amountNumerator, ts, err)
+	}
+	return sdk.NewCoin(shareDenom, numerator.Quo(den)), nil
 }
 
 // CalculateRedeemProRataFraction computes the payout amount for redeeming shares
@@ -100,8 +109,18 @@ func CalculateRedeemProRataFraction(shares math.Int, totalShares math.Int, total
 		return sdk.Coin{}, fmt.Errorf("invalid input: zero price numerator")
 	}
 	ta := totalAssets.Add(VirtualAssets)
-	num := shares.Mul(ta).Mul(priceDenominator)
-	den := ts.Mul(priceNumerator)
+	sharesTa, err := shares.SafeMul(ta)
+	if err != nil {
+		return sdk.Coin{}, fmt.Errorf("failed to multiply shares %s by total assets %s: %w", shares, ta, err)
+	}
+	num, err := sharesTa.SafeMul(priceDenominator)
+	if err != nil {
+		return sdk.Coin{}, fmt.Errorf("failed to multiply shares-assets product %s by price denominator %s: %w", sharesTa, priceDenominator, err)
+	}
+	den, err := ts.SafeMul(priceNumerator)
+	if err != nil {
+		return sdk.Coin{}, fmt.Errorf("failed to multiply total shares %s by price numerator %s: %w", ts, priceNumerator, err)
+	}
 	out := num.Quo(den)
 	return sdk.NewCoin(payoutDenom, out), nil
 }

--- a/utils/shares_test.go
+++ b/utils/shares_test.go
@@ -2,6 +2,7 @@ package utils_test
 
 import (
 	"fmt"
+	"math/big"
 	"testing"
 
 	sdkmath "cosmossdk.io/math"
@@ -9,6 +10,13 @@ import (
 	"github.com/provlabs/vault/utils"
 	"github.com/stretchr/testify/require"
 )
+
+// nearMaxInt returns an sdkmath.Int equal to 2^255, the largest power of two
+// that still fits within sdkmath.Int's 256-bit ceiling. Multiplying two of
+// these overflows, exercising the SafeMul guards on the NAV/TVV paths.
+func nearMaxInt() sdkmath.Int {
+	return sdkmath.NewIntFromBigInt(new(big.Int).Lsh(big.NewInt(1), 255))
+}
 
 func TestCalculateAssetsFromShares(t *testing.T) {
 	assetDenom := "asset"
@@ -24,6 +32,7 @@ func TestCalculateAssetsFromShares(t *testing.T) {
 		expected    sdk.Coin
 		expectErr   bool
 		errMsg      string
+		errContains string
 	}{
 		{
 			name:        "proportional redeem with virtual offsets",
@@ -70,6 +79,14 @@ func TestCalculateAssetsFromShares(t *testing.T) {
 			expectErr:   true,
 			errMsg:      "invalid input: negative values not allowed",
 		},
+		{
+			name:        "oversized shares and assets overflow returns error instead of panicking",
+			shares:      nearMaxInt(),
+			totalShares: sdkmath.NewInt(1_000_000),
+			totalAssets: nearMaxInt(),
+			expectErr:   true,
+			errContains: "integer overflow",
+		},
 	}
 
 	for _, tc := range tests {
@@ -84,7 +101,11 @@ func TestCalculateAssetsFromShares(t *testing.T) {
 			)
 			if tc.expectErr {
 				require.Error(t, err, "expected error for case: %s", tc.name)
-				require.EqualErrorf(t, err, tc.errMsg, "error message mismatch for case: %s", tc.name)
+				if tc.errContains != "" {
+					require.ErrorContains(t, err, tc.errContains, "error message mismatch for case: %s", tc.name)
+				} else {
+					require.EqualErrorf(t, err, tc.errMsg, "error message mismatch for case: %s", tc.name)
+				}
 			} else {
 				require.NoError(t, err, "unexpected error for case: %s", tc.name)
 				require.Equal(t, tc.expected, result, fmt.Sprintf("unexpected assets for shares=%s totalShares=%s totalAssets=%s", tc.shares, tc.totalShares, tc.totalAssets))
@@ -105,6 +126,7 @@ func TestCalculateSharesProRataFraction(t *testing.T) {
 		expected        sdk.Coin
 		expectErr       bool
 		expectedErrText string
+		errContains     string
 	}{
 		{
 			name:        "first deposit mints amount * ShareScalar (price 1:1)",
@@ -182,6 +204,24 @@ func TestCalculateSharesProRataFraction(t *testing.T) {
 			expectErr:       true,
 			expectedErrText: "invalid input: negative values not allowed",
 		},
+		{
+			name:        "oversized first deposit overflows share scalar and returns error",
+			amountNum:   nearMaxInt(),
+			amountDen:   sdkmath.NewInt(1),
+			totalAssets: sdkmath.NewInt(0),
+			totalShares: sdkmath.NewInt(0),
+			expectErr:   true,
+			errContains: "integer overflow",
+		},
+		{
+			name:        "oversized priced deposit overflows pro-rata path and returns error",
+			amountNum:   nearMaxInt(),
+			amountDen:   sdkmath.NewInt(1),
+			totalAssets: sdkmath.NewInt(100),
+			totalShares: nearMaxInt(),
+			expectErr:   true,
+			errContains: "integer overflow",
+		},
 	}
 
 	for _, tc := range tests {
@@ -190,6 +230,10 @@ func TestCalculateSharesProRataFraction(t *testing.T) {
 
 			if tc.expectErr {
 				require.Error(t, err, "expected error for case: %s", tc.name)
+				if tc.errContains != "" {
+					require.ErrorContains(t, err, tc.errContains, "unexpected error text for case: %s", tc.name)
+					return
+				}
 				require.EqualErrorf(t, err, tc.expectedErrText, "unexpected error text for case: %s", tc.name)
 				return
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Guarded NAV and share arithmetic with safe checked operations to return errors on oversized values (preventing panics and accumulator overflows).

* **Tests**
  * Added tests verifying conversions and aggregate valuation report errors (not panics) for oversized NAV and accumulation cases.

* **Documentation**
  * Added unreleased changelog entry documenting the overflow-guard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->