### PR TITLE
Update default AUM fee address for mainnet

### DIFF
--- a/types/keys.go
+++ b/types/keys.go
@@ -68,8 +68,8 @@ var (
 	// Represents 'pb1evyv7neax9qtxxzuexnhylxyz4guvsyjjqke4h'.
 	DefaultTechFeeAddress = sdk.AccAddress{203, 8, 207, 79, 61, 49, 64, 179, 24, 92, 201, 167, 114, 124, 196, 21, 81, 198, 64, 146}
 	// TestnetTechFeeAddress is the ProvLabs fee collection address for pio-testnet-1.
-	// NOTE: Initially the same as DefaultTechFeeAddress; will be updated via upgrade handler.
-	TestnetTechFeeAddress = sdk.AccAddress{203, 8, 207, 79, 61, 49, 64, 179, 24, 92, 201, 167, 114, 124, 196, 21, 81, 198, 64, 146}
+	// Represents 'tp1u7j87uj7e6xrkhgwmq9pqr47kdjdw6mhgv7dm4'.
+	TestnetTechFeeAddress = sdk.AccAddress{231, 164, 127, 114, 94, 206, 140, 59, 93, 14, 216, 10, 16, 14, 190, 179, 100, 215, 107, 119}
 	// MainnetTechFeeAddress is the ProvLabs fee collection group policy address for pio-mainnet-1.
 	// Represents 'pb144z5tr4lk85xvhrplsrh6gmclr8pgpv76fqjt23gzz9awrmh4laqclqdun'.
 	MainnetTechFeeAddress = sdk.AccAddress{173, 69, 69, 142, 191, 177, 232, 102, 92, 97, 252, 7, 125, 35, 120, 248, 206, 20, 5, 158, 210, 65, 37, 170, 40, 16, 139, 215, 15, 119, 175, 250}

--- a/types/keys.go
+++ b/types/keys.go
@@ -70,9 +70,9 @@ var (
 	// TestnetTechFeeAddress is the ProvLabs fee collection address for pio-testnet-1.
 	// NOTE: Initially the same as DefaultTechFeeAddress; will be updated via upgrade handler.
 	TestnetTechFeeAddress = sdk.AccAddress{203, 8, 207, 79, 61, 49, 64, 179, 24, 92, 201, 167, 114, 124, 196, 21, 81, 198, 64, 146}
-	// MainnetTechFeeAddress is the ProvLabs fee collection address for pio-mainnet-1.
-	// NOTE: Initially the same as DefaultTechFeeAddress; will be updated via upgrade handler.
-	MainnetTechFeeAddress = sdk.AccAddress{203, 8, 207, 79, 61, 49, 64, 179, 24, 92, 201, 167, 114, 124, 196, 21, 81, 198, 64, 146}
+	// MainnetTechFeeAddress is the ProvLabs fee collection group policy address for pio-mainnet-1.
+	// Represents 'pb144z5tr4lk85xvhrplsrh6gmclr8pgpv76fqjt23gzz9awrmh4laqclqdun'.
+	MainnetTechFeeAddress = sdk.AccAddress{173, 69, 69, 142, 191, 177, 232, 102, 92, 97, 252, 7, 125, 35, 120, 248, 206, 20, 5, 158, 210, 65, 37, 170, 40, 16, 139, 215, 15, 119, 175, 250}
 )
 
 const (

--- a/types/keys_test.go
+++ b/types/keys_test.go
@@ -3,6 +3,7 @@ package types_test
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/bech32"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -10,17 +11,45 @@ import (
 	"github.com/provlabs/vault/types"
 )
 
-// TestMainnetTechFeeAddress verifies that the hardcoded MainnetTechFeeAddress bytes
-// round-trip to the bech32 string documented in its godoc.
-func TestMainnetTechFeeAddress(t *testing.T) {
-	const expected = "pb144z5tr4lk85xvhrplsrh6gmclr8pgpv76fqjt23gzz9awrmh4laqclqdun"
+// TestTechFeeAddresses verifies that each hardcoded tech fee address constant
+// round-trips to the bech32 string documented in its godoc.
+func TestTechFeeAddresses(t *testing.T) {
+	tests := []struct {
+		name     string
+		addr     sdk.AccAddress
+		hrp      string
+		expected string
+	}{
+		{
+			name:     "default",
+			addr:     types.DefaultTechFeeAddress,
+			hrp:      "pb",
+			expected: "pb1evyv7neax9qtxxzuexnhylxyz4guvsyjjqke4h",
+		},
+		{
+			name:     "testnet",
+			addr:     types.TestnetTechFeeAddress,
+			hrp:      "tp",
+			expected: "tp1u7j87uj7e6xrkhgwmq9pqr47kdjdw6mhgv7dm4",
+		},
+		{
+			name:     "mainnet",
+			addr:     types.MainnetTechFeeAddress,
+			hrp:      "pb",
+			expected: "pb144z5tr4lk85xvhrplsrh6gmclr8pgpv76fqjt23gzz9awrmh4laqclqdun",
+		},
+	}
 
-	hrp, bz, err := bech32.DecodeAndConvert(expected)
-	require.NoError(t, err, "DecodeAndConvert(%q)", expected)
-	assert.Equal(t, "pb", hrp, "human-readable prefix of MainnetTechFeeAddress")
-	assert.Equal(t, []byte(types.MainnetTechFeeAddress), bz, "MainnetTechFeeAddress bytes should match the documented bech32 string")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hrp, bz, err := bech32.DecodeAndConvert(tc.expected)
+			require.NoError(t, err, "DecodeAndConvert(%q)", tc.expected)
+			assert.Equal(t, tc.hrp, hrp, "human-readable prefix of %s tech fee address", tc.name)
+			assert.Equal(t, []byte(tc.addr), bz, "%s tech fee address bytes should match the documented bech32 string", tc.name)
 
-	encoded, err := bech32.ConvertAndEncode("pb", types.MainnetTechFeeAddress)
-	require.NoError(t, err, "ConvertAndEncode(MainnetTechFeeAddress)")
-	assert.Equal(t, expected, encoded, "MainnetTechFeeAddress should encode back to the documented bech32 string")
+			encoded, err := bech32.ConvertAndEncode(tc.hrp, tc.addr)
+			require.NoError(t, err, "ConvertAndEncode(%s tech fee address)", tc.name)
+			assert.Equal(t, tc.expected, encoded, "%s tech fee address should encode back to the documented bech32 string", tc.name)
+		})
+	}
 }

--- a/types/keys_test.go
+++ b/types/keys_test.go
@@ -1,0 +1,26 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types/bech32"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/provlabs/vault/types"
+)
+
+// TestMainnetTechFeeAddress verifies that the hardcoded MainnetTechFeeAddress bytes
+// round-trip to the bech32 string documented in its godoc.
+func TestMainnetTechFeeAddress(t *testing.T) {
+	const expected = "pb144z5tr4lk85xvhrplsrh6gmclr8pgpv76fqjt23gzz9awrmh4laqclqdun"
+
+	hrp, bz, err := bech32.DecodeAndConvert(expected)
+	require.NoError(t, err, "DecodeAndConvert(%q)", expected)
+	assert.Equal(t, "pb", hrp, "human-readable prefix of MainnetTechFeeAddress")
+	assert.Equal(t, []byte(types.MainnetTechFeeAddress), bz, "MainnetTechFeeAddress bytes should match the documented bech32 string")
+
+	encoded, err := bech32.ConvertAndEncode("pb", types.MainnetTechFeeAddress)
+	require.NoError(t, err, "ConvertAndEncode(MainnetTechFeeAddress)")
+	assert.Equal(t, expected, encoded, "MainnetTechFeeAddress should encode back to the documented bech32 string")
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mainnet fee collection address configuration.

* **Tests**
  * Added validation test for the mainnet fee collection address round-trip encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->