### PR TITLE
Add safe math operations to AUM

### DIFF
--- a/.changelog/unreleased/improvements/210-safe-math-aum-calcs.md
+++ b/.changelog/unreleased/improvements/210-safe-math-aum-calcs.md
@@ -1,0 +1,1 @@
+* Add safe-math operations to AUM calculations so overflows return an error instead of panicking [PR 210](https://github.com/provlabs/vault/pull/210).

--- a/interest/interest.go
+++ b/interest/interest.go
@@ -84,7 +84,14 @@ func CalculateInterestEarned(principal sdk.Coin, rate string, periodSeconds int6
 //	Fee = (AUM * (bips / 10000) * duration) / 31536000 (SecondsPerYear)
 //
 // Returns the fee as a truncated sdkmath.Int.
-func CalculateAUMFee(aum sdkmath.Int, bips uint32, duration int64) (sdkmath.Int, error) {
+func CalculateAUMFee(aum sdkmath.Int, bips uint32, duration int64) (fee sdkmath.Int, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			fee = sdkmath.Int{}
+			err = fmt.Errorf("aum fee calculation overflow (aum=%s, bips=%d, duration=%d): %v", aum, bips, duration, rec)
+		}
+	}()
+
 	if aum.IsNegative() {
 		return sdkmath.Int{}, errors.New("aum cannot be negative")
 	}
@@ -103,8 +110,8 @@ func CalculateAUMFee(aum sdkmath.Int, bips uint32, duration int64) (sdkmath.Int,
 	durationDec := sdkmath.LegacyNewDec(duration)
 	yearDec := sdkmath.LegacyNewDec(SecondsPerYear)
 
-	fee := aumDec.Mul(rate).Mul(durationDec).Quo(yearDec)
-	return fee.TruncateInt(), nil
+	feeDec := aumDec.Mul(rate).Mul(durationDec).Quo(yearDec)
+	return feeDec.TruncateInt(), nil
 }
 
 // CalculateExpiration determines the epoch time at which a vault will no longer be

--- a/interest/interest_test.go
+++ b/interest/interest_test.go
@@ -118,12 +118,13 @@ func TestCalculateInterestEarned(t *testing.T) {
 
 func TestCalculateAUMFee(t *testing.T) {
 	tests := []struct {
-		name        string
-		aum         sdkmath.Int
-		bips        uint32
-		duration    int64
-		expectedFee sdkmath.Int
-		expectErr   bool
+		name                string
+		aum                 sdkmath.Int
+		bips                uint32
+		duration            int64
+		expectedFee         sdkmath.Int
+		expectErr           bool
+		expectedErrContains string
 	}{
 		{
 			name:        "zero AUM",
@@ -161,18 +162,36 @@ func TestCalculateAUMFee(t *testing.T) {
 			expectedFee: sdkmath.NewInt(750),
 		},
 		{
-			name:      "negative duration errors",
-			aum:       sdkmath.NewInt(1_000_000),
-			bips:      15,
-			duration:  -1,
-			expectErr: true,
+			name:                "negative duration errors",
+			aum:                 sdkmath.NewInt(1_000_000),
+			bips:                15,
+			duration:            -1,
+			expectErr:           true,
+			expectedErrContains: "duration cannot be negative",
 		},
 		{
-			name:      "negative aum errors",
-			aum:       sdkmath.NewInt(-1_000_000),
-			bips:      15,
-			duration:  interest.SecondsPerYear,
-			expectErr: true,
+			name:                "negative aum errors",
+			aum:                 sdkmath.NewInt(-1_000_000),
+			bips:                15,
+			duration:            interest.SecondsPerYear,
+			expectErr:           true,
+			expectedErrContains: "aum cannot be negative",
+		},
+		{
+			name:                "near-max AUM over a one year period overflows the decimal multiply",
+			aum:                 sdkmath.NewIntFromBigInt(new(big.Int).Lsh(big.NewInt(1), 255)),
+			bips:                10_000,
+			duration:            interest.SecondsPerYear,
+			expectErr:           true,
+			expectedErrContains: "overflow",
+		},
+		{
+			name:                "max AUM over a single second overflows the decimal multiply",
+			aum:                 sdkmath.NewIntFromBigInt(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))),
+			bips:                10_000,
+			duration:            2,
+			expectErr:           true,
+			expectedErrContains: "overflow",
 		},
 	}
 
@@ -181,43 +200,12 @@ func TestCalculateAUMFee(t *testing.T) {
 			fee, err := interest.CalculateAUMFee(tc.aum, tc.bips, tc.duration)
 			if tc.expectErr {
 				require.Errorf(t, err, "test case %q: expected an error but got none", tc.name)
+				require.Containsf(t, err.Error(), tc.expectedErrContains, "test case %q: error %q should contain %q", tc.name, err, tc.expectedErrContains)
+				require.Truef(t, fee.IsNil(), "test case %q: fee should be the zero-value sdkmath.Int on error, got %s", tc.name, fee)
 			} else {
 				require.NoErrorf(t, err, "test case %q: unexpected error during AUM fee calculation", tc.name)
 				require.Truef(t, tc.expectedFee.Equal(fee), "test case %q: fee amount mismatch; expected %s, got %s", tc.name, tc.expectedFee, fee)
 			}
-		})
-	}
-}
-
-// TestCalculateAUMFeeOverflow proves the recover guard turns a LegacyDec overflow into an
-// error instead of panicking.
-func TestCalculateAUMFeeOverflow(t *testing.T) {
-	tests := []struct {
-		name     string
-		aum      sdkmath.Int
-		bips     uint32
-		duration int64
-	}{
-		{
-			name:     "near-max AUM over a one year period overflows the decimal multiply",
-			aum:      sdkmath.NewIntFromBigInt(new(big.Int).Lsh(big.NewInt(1), 255)),
-			bips:     10_000,
-			duration: interest.SecondsPerYear,
-		},
-		{
-			name:     "max AUM over a single second overflows the decimal multiply",
-			aum:      sdkmath.NewIntFromBigInt(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))),
-			bips:     10_000,
-			duration: 2,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			fee, err := interest.CalculateAUMFee(tc.aum, tc.bips, tc.duration)
-			require.Errorf(t, err, "test case %q: oversized AUM must degrade to an error, not panic", tc.name)
-			require.Containsf(t, err.Error(), "overflow", "test case %q: error should originate from the recover guard", tc.name)
-			require.Truef(t, fee.IsNil(), "test case %q: fee should be the zero-value sdkmath.Int on overflow, got %s", tc.name, fee)
 		})
 	}
 }

--- a/interest/interest_test.go
+++ b/interest/interest_test.go
@@ -2,6 +2,7 @@ package interest_test
 
 import (
 	"math"
+	"math/big"
 	"strconv"
 	"testing"
 	"time"
@@ -184,6 +185,39 @@ func TestCalculateAUMFee(t *testing.T) {
 				require.NoErrorf(t, err, "test case %q: unexpected error during AUM fee calculation", tc.name)
 				require.Truef(t, tc.expectedFee.Equal(fee), "test case %q: fee amount mismatch; expected %s, got %s", tc.name, tc.expectedFee, fee)
 			}
+		})
+	}
+}
+
+// TestCalculateAUMFeeOverflow proves the recover guard turns a LegacyDec overflow into an
+// error instead of panicking.
+func TestCalculateAUMFeeOverflow(t *testing.T) {
+	tests := []struct {
+		name     string
+		aum      sdkmath.Int
+		bips     uint32
+		duration int64
+	}{
+		{
+			name:     "near-max AUM over a one year period overflows the decimal multiply",
+			aum:      sdkmath.NewIntFromBigInt(new(big.Int).Lsh(big.NewInt(1), 255)),
+			bips:     10_000,
+			duration: interest.SecondsPerYear,
+		},
+		{
+			name:     "max AUM over a single second overflows the decimal multiply",
+			aum:      sdkmath.NewIntFromBigInt(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))),
+			bips:     10_000,
+			duration: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fee, err := interest.CalculateAUMFee(tc.aum, tc.bips, tc.duration)
+			require.Errorf(t, err, "test case %q: oversized AUM must degrade to an error, not panic", tc.name)
+			require.Containsf(t, err.Error(), "overflow", "test case %q: error should originate from the recover guard", tc.name)
+			require.Truef(t, fee.IsNil(), "test case %q: fee should be the zero-value sdkmath.Int on overflow, got %s", tc.name, fee)
 		})
 	}
 }

--- a/keeper/reconcile.go
+++ b/keeper/reconcile.go
@@ -294,7 +294,11 @@ func (k Keeper) PerformVaultFeeTransfer(ctx sdk.Context, vault *types.VaultAccou
 	}
 
 	periodDuration := currentBlockTime - vault.FeePeriodStart
-	vault.OutstandingAumFee = totalOutstanding.Sub(toCollect)
+	remainingOutstanding, err := totalOutstanding.SafeSub(toCollect)
+	if err != nil {
+		return fmt.Errorf("failed to subtract collected %s from outstanding AUM fee %s: %w", toCollect, totalOutstanding, err)
+	}
+	vault.OutstandingAumFee = remainingOutstanding
 	vault.FeePeriodStart = currentBlockTime
 
 	k.emitEvent(ctx, types.NewEventVaultFeeCollected(

--- a/keeper/reconcile.go
+++ b/keeper/reconcile.go
@@ -259,7 +259,11 @@ func (k Keeper) PerformVaultFeeTransfer(ctx sdk.Context, vault *types.VaultAccou
 		return fmt.Errorf("failed to calculate accrued AUM fee payment: %w", err)
 	}
 
-	totalOutstanding := vault.OutstandingAumFee.Add(newFeePayment)
+	totalOutstandingAmount, err := vault.OutstandingAumFee.Amount.SafeAdd(newFeePayment.Amount)
+	if err != nil {
+		return fmt.Errorf("failed to add new fee payment %s to outstanding AUM fee %s: %w", newFeePayment, vault.OutstandingAumFee, err)
+	}
+	totalOutstanding := sdk.NewCoin(vault.PaymentDenom, totalOutstandingAmount)
 	if totalOutstanding.IsZero() {
 		vault.FeePeriodStart = currentBlockTime
 		return nil

--- a/keeper/reconcile_test.go
+++ b/keeper/reconcile_test.go
@@ -1847,6 +1847,50 @@ func (s *TestSuite) TestKeeper_PerformVaultFeeTransfer() {
 	}
 }
 
+func (s *TestSuite) TestKeeper_PerformVaultFeeTransfer_OversizedTVVDegradesToError() {
+	vault, _, underlyingDenom, paymentDenom := s.setupOversizedNAVVault()
+	s.overrideNAV(paymentDenom, underlyingDenom, maxValidNAVPrice(), 1)
+
+	principalAddress := vault.PrincipalMarkerAddress()
+	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, principalAddress, sdk.NewCoins(
+		sdk.NewInt64Coin(paymentDenom, 1),
+	)), "funding principal with one payment unit should drive TVV to the 256-bit ceiling")
+
+	now := s.ctx.BlockTime()
+	twoMonthsAgo := now.Add(-60 * 24 * time.Hour)
+	vault.AumFeeBips = 10_000
+	s.SetVaultRatesAndPeriod(vault, "0.0", "0.0", twoMonthsAgo.Unix(), 0)
+	s.SetCtxBlockTime(now)
+
+	err := s.k.PerformVaultFeeTransfer(s.ctx, vault)
+	s.Require().Error(err, "an oversized TVV must degrade to an error, not panic the BeginBlock fee hook")
+	s.Require().ErrorContains(err, "overflow", "error should originate from the CalculateAUMFee recover guard")
+}
+
+func (s *TestSuite) TestKeeper_PerformVaultFeeTransfer_OutstandingFeeOverflowDegradesToError() {
+	s.SetupTest()
+	shareDenom := "fee.shares"
+	underlyingDenom := "uylds.fcc.receipt"
+	paymentDenom := "uylds.fcc"
+	underlying := sdk.NewInt64Coin(underlyingDenom, 1_000_000_000)
+	now := s.ctx.BlockTime()
+	twoMonthsAgo := now.Add(-60 * 24 * time.Hour)
+
+	s.requireAddFinalizeAndActivateMarker(underlying, s.adminAddr)
+	vault := s.CreateVaultWithParams(shareDenom, underlyingDenom, paymentDenom)
+	vault.AumFeeBips = 100
+	vault.OutstandingAumFee = sdk.NewCoin(paymentDenom, maxValidNAVPrice())
+	s.SetVaultRatesAndPeriod(vault, "0.0", "0.0", twoMonthsAgo.Unix(), 0)
+
+	s.FundMarker(shareDenom, sdk.NewCoins(underlying))
+	s.FundMarker(shareDenom, sdk.NewCoins(sdk.NewCoin(paymentDenom, sdkmath.NewInt(100_000))))
+	s.SetCtxBlockTime(now)
+
+	err := s.k.PerformVaultFeeTransfer(s.ctx, vault)
+	s.Require().Error(err, "an outstanding fee at the 256-bit ceiling must degrade to an error, not panic the BeginBlock fee hook")
+	s.Require().ErrorContains(err, "overflow", "error should originate from the SafeAdd guard on outstanding AUM fee")
+}
+
 func (s *TestSuite) TestKeeper_CanPayInterestDuration_WithAUMFee() {
 	s.SetupTest()
 	shareDenom := "fee.payout.shares"


### PR DESCRIPTION
## Summary

Adds safe math to the AUM fee calculations so bad inputs return an error instead of failing in an uncontrolled way.

## Changes

- `CalculateAUMFee` now recovers from arithmetic overflow and returns a clear error with the offending inputs.
- `PerformVaultFeeTransfer` uses `SafeAdd` when combining the new fee with the outstanding balance, returning an error on overflow.

## Tests

- Added cases for overflow and edge inputs in `interest_test.go` and `reconcile_test.go`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AUM calculations now safely handle arithmetic overflow by returning errors instead of panicking.
  * Vault fee transfer operations now use safe arithmetic to prevent overflow failures.

* **Tests**
  * Expanded AUM fee calculation tests to cover edge cases including negative values and overflow scenarios.
  * Added tests for vault fee transfer overflow error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->