### PR TITLE
Add GetNetTVVInUnderlyingAsset function

### DIFF
--- a/.changelog/unreleased/improvements/213-net-gross-tvv.md
+++ b/.changelog/unreleased/improvements/213-net-gross-tvv.md
@@ -1,0 +1,1 @@
+* Add a net TVV calculation that subtracts the outstanding AUM fee liability from gross vault value, and use it as the valuation basis for share NAV publication, NAV per share, deposit/redeem conversions, and the captured paused balance [PR 213](https://github.com/provlabs/vault/pull/213).

--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -548,9 +548,9 @@ func (k msgServer) PauseVault(goCtx context.Context, msg *types.MsgPauseVaultReq
 		return nil, fmt.Errorf("failed to reconcile before pausing: %w", err)
 	}
 
-	tvv, err := k.GetTVVInUnderlyingAsset(ctx, *vault)
+	tvv, err := k.GetNetTVVInUnderlyingAsset(ctx, *vault)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get TVV before pausing: %w", err)
+		return nil, fmt.Errorf("failed to get net TVV before pausing: %w", err)
 	}
 
 	vault.PausedBalance = sdk.NewCoin(vault.UnderlyingAsset, tvv)

--- a/keeper/reconcile.go
+++ b/keeper/reconcile.go
@@ -113,8 +113,9 @@ func (k Keeper) setShareDenomNAV(ctx sdk.Context, vault *types.VaultAccount, vau
 
 // publishShareNav records the Net Asset Value (NAV) for the vault's share denom
 // in terms of its underlying asset. It fetches the vault’s principal marker,
-// computes the total value of vault assets in underlying units (TVV), and
-// attempts to set the NAV as (Price = TVV in underlying, Volume = total shares).
+// computes the net total value of vault assets in underlying units (TVV net of the
+// OutstandingAumFee liability), and attempts to set the NAV as
+// (Price = net TVV in underlying, Volume = total shares).
 // If no shares exist or the TVV is non-positive, no NAV is published.
 //
 // If NAV publication fails, the error is logged and the operation continues
@@ -127,7 +128,7 @@ func (k Keeper) publishShareNav(ctx sdk.Context, vault *types.VaultAccount) erro
 	if !vault.TotalShares.IsPositive() {
 		return nil
 	}
-	tvv, err := k.GetTVVInUnderlyingAsset(ctx, *vault)
+	tvv, err := k.GetNetTVVInUnderlyingAsset(ctx, *vault)
 	if err != nil {
 		return fmt.Errorf("failed to get TVV: %w", err)
 	}

--- a/keeper/reconcile_test.go
+++ b/keeper/reconcile_test.go
@@ -416,6 +416,86 @@ func (s *TestSuite) TestKeeper_PerformVaultReconcile_CompositeWithOutstandingFee
 	})
 }
 
+func (s *TestSuite) TestKeeper_ReconcileLeavesUncollectedFee_PricesOffNetTVV() {
+	shareDenom := "underfunded.shares"
+	underlyingDenom := "underlying"
+	paymentDenom := "payment"
+	vaultAddress := types.GetVaultAddress(shareDenom)
+	testBlockTime := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+	pastTime := testBlockTime.Add(-60 * 24 * time.Hour)
+
+	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(underlyingDenom, 10_000_000_000), s.adminAddr)
+	s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 10_000_000_000), s.adminAddr)
+
+	vault := s.CreateVaultWithParams(shareDenom, underlyingDenom, paymentDenom)
+	vault.CurrentInterestRate = "0"
+	vault.DesiredInterestRate = "0"
+	vault.AumFeeBips = 0
+	vault.PeriodStart = pastTime.Unix()
+	vault.FeePeriodStart = pastTime.Unix()
+	vault.OutstandingAumFee = sdk.NewInt64Coin(paymentDenom, 100_000_000)
+	totalShares := sdk.NewInt64Coin(shareDenom, 1_000_000)
+	vault.TotalShares = totalShares
+	s.k.AuthKeeper.SetAccount(s.ctx, vault)
+	s.Require().NoError(s.k.MarkerKeeper.MintCoin(s.ctx, vault.GetAddress(), totalShares), "should mint share supply")
+
+	paymentMarkerAddr := markertypes.MustGetMarkerAddress(paymentDenom)
+	paymentMarkerAccount, err := s.k.MarkerKeeper.GetMarker(s.ctx, paymentMarkerAddr)
+	s.Require().NoError(err, "should fetch payment marker for NAV setup")
+	s.Require().NoError(s.k.MarkerKeeper.SetNetAssetValue(s.ctx, paymentMarkerAccount, markertypes.NetAssetValue{
+		Price:  sdk.NewInt64Coin(underlyingDenom, 1),
+		Volume: 1,
+	}, "test"), "should set payment->underlying NAV at 1:1")
+
+	s.Require().NoError(FundAccount(s.ctx, s.simApp.BankKeeper, vault.PrincipalMarkerAddress(), sdk.NewCoins(
+		sdk.NewInt64Coin(underlyingDenom, 1_000_000_000),
+	)), "should fund principal marker with underlying only, leaving no payment-denom liquidity to pay the fee")
+
+	s.SetCtxBlockTime(testBlockTime)
+
+	err = s.k.TestAccessor_reconcileVault(s.T(), s.ctx, vault)
+	s.Require().NoError(err, "reconcileVault should not error")
+
+	reconciled, err := s.k.GetVault(s.ctx, vaultAddress)
+	s.Require().NoError(err, "should fetch reconciled vault")
+
+	s.Require().Equal(sdkmath.NewInt(100_000_000), reconciled.OutstandingAumFee.Amount, "fee could not be collected, so the full liability survives reconcile")
+	provlabsAddr, err := s.k.GetAUMFeeAddress(s.ctx)
+	s.Require().NoError(err, "should get AUM fee address")
+	s.assertBalance(provlabsAddr, paymentDenom, sdkmath.ZeroInt())
+
+	grossTVV, err := s.k.GetTVVInUnderlyingAsset(s.ctx, *reconciled)
+	s.Require().NoError(err, "should compute gross TVV")
+	s.Require().Equal(sdkmath.NewInt(1_000_000_000), grossTVV, "gross TVV still counts the assets backing the unpaid fee")
+	netTVV, err := s.k.GetNetTVVInUnderlyingAsset(s.ctx, *reconciled)
+	s.Require().NoError(err, "should compute net TVV")
+	s.Require().Equal(sdkmath.NewInt(900_000_000), netTVV, "net TVV = gross 1,000,000,000 minus outstanding fee 100,000,000, so gross > net even after reconcile")
+
+	grossView := *reconciled
+	grossView.OutstandingAumFee = sdk.NewInt64Coin(paymentDenom, 0)
+
+	navNet, err := s.k.GetNAVPerShareInUnderlyingAsset(s.ctx, *reconciled)
+	s.Require().NoError(err, "should compute net NAV per share")
+	s.Require().Equal(sdkmath.NewInt(900), navNet, "net NAV per share = 900,000,000 / 1,000,000")
+	navGross, err := s.k.GetNAVPerShareInUnderlyingAsset(s.ctx, grossView)
+	s.Require().NoError(err, "should compute gross NAV per share")
+	s.Require().Equal(sdkmath.NewInt(1_000), navGross, "gross NAV per share = 1,000,000,000 / 1,000,000")
+
+	deposit := sdk.NewInt64Coin(underlyingDenom, 1_000_000)
+	netMint, err := s.k.ConvertDepositToSharesInUnderlyingAsset(s.ctx, *reconciled, deposit)
+	s.Require().NoError(err, "net deposit conversion should succeed")
+	grossMint, err := s.k.ConvertDepositToSharesInUnderlyingAsset(s.ctx, grossView, deposit)
+	s.Require().NoError(err, "gross deposit conversion should succeed")
+	s.Require().True(netMint.Amount.GT(grossMint.Amount), "net pricing mints more shares per deposit than gross would (gross overstates TVV)")
+
+	redeemShares := sdkmath.NewInt(100_000)
+	netRedeem, err := s.k.ConvertSharesToRedeemCoin(s.ctx, *reconciled, redeemShares, underlyingDenom)
+	s.Require().NoError(err, "net redeem conversion should succeed")
+	grossRedeem, err := s.k.ConvertSharesToRedeemCoin(s.ctx, grossView, redeemShares, underlyingDenom)
+	s.Require().NoError(err, "gross redeem conversion should succeed")
+	s.Require().True(netRedeem.Amount.LT(grossRedeem.Amount), "net pricing pays out less per share than gross would (gross overstates TVV)")
+}
+
 func (s *TestSuite) TestKeeper_CalculateVaultTotalAssets() {
 	shareDenom := "vaultshares"
 	underlying := sdk.NewInt64Coin("underlying", 1_000_000_000)

--- a/keeper/valuation_engine.go
+++ b/keeper/valuation_engine.go
@@ -191,22 +191,28 @@ func (k Keeper) GetTVVInUnderlyingAsset(ctx sdk.Context, vault types.VaultAccoun
 // This is the authoritative valuation basis for share pricing and the published share
 // NAV: it represents the equity actually owned by shareholders, excluding the AUM fee
 // already owed to the fee collector but not yet transferred out of the principal marker.
-// GetTVVInUnderlyingAsset supplies the gross sum of principal-marker balances (and honors
-// the paused fast-path); this method subtracts the OutstandingAumFee converted to
-// underlying units and floors the result at zero.
+//
+// Paused fast-path:
+//   - If vault.Paused is true, this returns vault.PausedBalance.Amount directly. The paused
+//     balance is captured net of the OutstandingAumFee liability at pause time, so paused
+//     pricing stays frozen and NAV-independent.
+//
+// When not paused, GetTVVInUnderlyingAsset supplies the gross sum of principal-marker
+// balances; this method subtracts the OutstandingAumFee converted to underlying units and
+// floors the result at zero.
 func (k Keeper) GetNetTVVInUnderlyingAsset(ctx sdk.Context, vault types.VaultAccount) (math.Int, error) {
 	gross, err := k.GetTVVInUnderlyingAsset(ctx, vault)
 	if err != nil {
-		return math.Int{}, err
+		return math.Int{}, fmt.Errorf("failed to get gross TVV: %w", err)
+	}
+	if vault.Paused {
+		return gross, nil
 	}
 	outstanding, err := k.CalculateOutstandingFeeUnderlying(ctx, vault)
 	if err != nil {
 		return math.Int{}, fmt.Errorf("failed to calculate outstanding AUM fee: %w", err)
 	}
-	net, err := gross.SafeSub(outstanding)
-	if err != nil {
-		return math.Int{}, fmt.Errorf("failed to subtract outstanding AUM fee %s from TVV %s: %w", outstanding, gross, err)
-	}
+	net := gross.Sub(outstanding)
 	if net.IsNegative() {
 		return math.ZeroInt(), nil
 	}

--- a/keeper/valuation_engine.go
+++ b/keeper/valuation_engine.go
@@ -185,6 +185,34 @@ func (k Keeper) GetTVVInUnderlyingAsset(ctx sdk.Context, vault types.VaultAccoun
 	return total, nil
 }
 
+// GetNetTVVInUnderlyingAsset returns the Total Vault Value (TVV) expressed in
+// vault.UnderlyingAsset, net of the vault's OutstandingAumFee liability.
+//
+// This is the authoritative valuation basis for share pricing and the published share
+// NAV: it represents the equity actually owned by shareholders, excluding the AUM fee
+// already owed to the fee collector but not yet transferred out of the principal marker.
+// GetTVVInUnderlyingAsset supplies the gross sum of principal-marker balances (and honors
+// the paused fast-path); this method subtracts the OutstandingAumFee converted to
+// underlying units and floors the result at zero.
+func (k Keeper) GetNetTVVInUnderlyingAsset(ctx sdk.Context, vault types.VaultAccount) (math.Int, error) {
+	gross, err := k.GetTVVInUnderlyingAsset(ctx, vault)
+	if err != nil {
+		return math.Int{}, err
+	}
+	outstanding, err := k.CalculateOutstandingFeeUnderlying(ctx, vault)
+	if err != nil {
+		return math.Int{}, fmt.Errorf("failed to calculate outstanding AUM fee: %w", err)
+	}
+	net, err := gross.SafeSub(outstanding)
+	if err != nil {
+		return math.Int{}, fmt.Errorf("failed to subtract outstanding AUM fee %s from TVV %s: %w", outstanding, gross, err)
+	}
+	if net.IsNegative() {
+		return math.ZeroInt(), nil
+	}
+	return net, nil
+}
+
 // GetNAVPerShareInUnderlyingAsset returns the floor NAV per share in units of
 // vault.UnderlyingAsset.
 //
@@ -193,11 +221,11 @@ func (k Keeper) GetTVVInUnderlyingAsset(ctx sdk.Context, vault types.VaultAccoun
 //     vault.PausedBalance.Amount (ignores live TVV and share supply).
 //
 // Computation (when not paused):
-//   - TVV(underlying) is obtained from GetTVVInUnderlyingAsset (includes current vault holdings in underlying units).
+//   - TVV(underlying) is obtained from GetNetTVVInUnderlyingAsset (net of the OutstandingAumFee liability).
 //   - totalShareSupply is taken from vault.TotalShares.Amount (the recorded share supply).
 //   - If total shares == 0, returns 0. Otherwise returns TVV / totalShareSupply (floor).
 func (k Keeper) GetNAVPerShareInUnderlyingAsset(ctx sdk.Context, vault types.VaultAccount) (math.Int, error) {
-	tvv, err := k.GetTVVInUnderlyingAsset(ctx, vault)
+	tvv, err := k.GetNetTVVInUnderlyingAsset(ctx, vault)
 	if err != nil {
 		return math.Int{}, fmt.Errorf("failed to get TVV: %w", err)
 	}
@@ -224,7 +252,7 @@ func (k Keeper) ConvertDepositToSharesInUnderlyingAsset(ctx sdk.Context, vault t
 	if err != nil {
 		return sdk.Coin{}, fmt.Errorf("failed to get unit price fraction: %w", err)
 	}
-	tvv, err := k.GetTVVInUnderlyingAsset(ctx, vault)
+	tvv, err := k.GetNetTVVInUnderlyingAsset(ctx, vault)
 	if err != nil {
 		return sdk.Coin{}, fmt.Errorf("failed to get TVV: %w", err)
 	}
@@ -251,7 +279,7 @@ func (k Keeper) ConvertSharesToRedeemCoin(ctx sdk.Context, vault types.VaultAcco
 	if !shares.IsPositive() {
 		return sdk.NewCoin(redeemDenom, math.ZeroInt()), nil
 	}
-	tvv, err := k.GetTVVInUnderlyingAsset(ctx, vault)
+	tvv, err := k.GetNetTVVInUnderlyingAsset(ctx, vault)
 	if err != nil {
 		return sdk.Coin{}, fmt.Errorf("failed to get TVV: %w", err)
 	}

--- a/keeper/valuation_engine_test.go
+++ b/keeper/valuation_engine_test.go
@@ -496,6 +496,53 @@ func (s *TestSuite) TestConvertSharesToRedeemCoin_AssetAndPaymentPaths() {
 	s.Require().Contains(err.Error(), "nav not found", "error should indicate missing NAV mapping")
 }
 
+func (s *TestSuite) TestConvertAndNav_PriceNetOfOutstandingAumFee() {
+	underlyingDenom := "ylds"
+	paymentDenom := "usdc"
+	shareDenom := "vshare"
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
+
+	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
+	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vault.PrincipalMarkerAddress(), sdk.NewCoins(
+		sdk.NewInt64Coin(underlyingDenom, 1000),
+		sdk.NewInt64Coin(paymentDenom, 10),
+	)), "should fund vault marker for gross TVV")
+
+	grossTVV, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vault)
+	s.Require().NoError(err, "should compute gross TVV")
+	s.Require().Equal(math.NewInt(1005), grossTVV, "gross TVV = 1000 underlying + 10 payment at 1/2")
+
+	totalShares := sdk.NewCoin(shareDenom, grossTVV.Mul(utils.ShareScalar))
+	s.Require().NoError(s.k.MarkerKeeper.MintCoin(s.ctx, vault.GetAddress(), totalShares), "should mint share supply")
+	vault.TotalShares = totalShares
+	vault.OutstandingAumFee = sdk.NewInt64Coin(paymentDenom, 10)
+	s.k.AuthKeeper.SetAccount(s.ctx, vault)
+
+	netTVV, err := testKeeper.GetNetTVVInUnderlyingAsset(s.ctx, *vault)
+	s.Require().NoError(err, "should compute net TVV")
+	s.Require().Equal(math.NewInt(1000), netTVV, "net TVV = gross 1005 minus outstanding fee (10 payment at 1/2 = 5 underlying)")
+
+	deposit := sdk.NewInt64Coin(underlyingDenom, 1000)
+	mintedShares, err := testKeeper.ConvertDepositToSharesInUnderlyingAsset(s.ctx, *vault, deposit)
+	s.Require().NoError(err, "deposit conversion should succeed")
+	expectedNetMint, err := utils.CalculateSharesProRataFraction(deposit.Amount, math.NewInt(1), netTVV, totalShares.Amount, shareDenom)
+	s.Require().NoError(err, "should compute net-priced deposit shares")
+	expectedGrossMint, err := utils.CalculateSharesProRataFraction(deposit.Amount, math.NewInt(1), grossTVV, totalShares.Amount, shareDenom)
+	s.Require().NoError(err, "should compute gross-priced deposit shares")
+	s.Require().Equal(expectedNetMint.Amount, mintedShares.Amount, "deposit must be priced off net TVV")
+	s.Require().True(mintedShares.Amount.GT(expectedGrossMint.Amount), "net pricing mints more shares per deposit than gross pricing would (gross overstates TVV)")
+
+	redeemShares := grossTVV.Mul(utils.ShareScalar)
+	redeemed, err := testKeeper.ConvertSharesToRedeemCoin(s.ctx, *vault, redeemShares, underlyingDenom)
+	s.Require().NoError(err, "redeem conversion should succeed")
+	expectedNetRedeem, err := utils.CalculateRedeemProRataFraction(redeemShares, totalShares.Amount, netTVV, math.NewInt(1), math.NewInt(1), underlyingDenom)
+	s.Require().NoError(err, "should compute net-priced redemption")
+	expectedGrossRedeem, err := utils.CalculateRedeemProRataFraction(redeemShares, totalShares.Amount, grossTVV, math.NewInt(1), math.NewInt(1), underlyingDenom)
+	s.Require().NoError(err, "should compute gross-priced redemption")
+	s.Require().Equal(expectedNetRedeem.Amount, redeemed.Amount, "redemption must be priced off net TVV")
+	s.Require().True(redeemed.Amount.LT(expectedGrossRedeem.Amount), "net pricing pays out less per share than gross pricing would (gross overstates TVV)")
+}
+
 func (s *TestSuite) TestConvertSharesToRedeemCoin_ZeroAndDustRedemption() {
 	underlyingDenom := "ylds"
 	shareDenom := "vshare"

--- a/keeper/valuation_engine_test.go
+++ b/keeper/valuation_engine_test.go
@@ -543,6 +543,29 @@ func (s *TestSuite) TestConvertAndNav_PriceNetOfOutstandingAumFee() {
 	s.Require().True(redeemed.Amount.LT(expectedGrossRedeem.Amount), "net pricing pays out less per share than gross pricing would (gross overstates TVV)")
 }
 
+func (s *TestSuite) TestGetNetTVVInUnderlyingAsset_FloorsAtZeroWhenOutstandingExceedsGross() {
+	underlyingDenom := "ylds"
+	paymentDenom := "usdc"
+	shareDenom := "vshare"
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
+
+	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
+	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, vault.PrincipalMarkerAddress(), sdk.NewCoins(
+		sdk.NewInt64Coin(underlyingDenom, 100),
+	)), "should fund vault marker for gross TVV")
+
+	grossTVV, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vault)
+	s.Require().NoError(err, "should compute gross TVV")
+	s.Require().Equal(math.NewInt(100), grossTVV, "gross TVV should equal funded underlying balance")
+
+	vault.OutstandingAumFee = sdk.NewInt64Coin(paymentDenom, 1000)
+	s.k.AuthKeeper.SetAccount(s.ctx, vault)
+
+	netTVV, err := testKeeper.GetNetTVVInUnderlyingAsset(s.ctx, *vault)
+	s.Require().NoError(err, "net TVV should not error when outstanding fee exceeds gross TVV")
+	s.Require().True(netTVV.IsZero(), "net TVV should floor at zero when outstanding fee (500 underlying) exceeds gross TVV (100)")
+}
+
 func (s *TestSuite) TestConvertSharesToRedeemCoin_ZeroAndDustRedemption() {
 	underlyingDenom := "ylds"
 	shareDenom := "vshare"
@@ -611,6 +634,29 @@ func (s *TestSuite) TestGetTVVInUnderlyingAsset_PausedUsesPausedBalance() {
 	tvv, err := testKeeper.GetTVVInUnderlyingAsset(s.ctx, *vault)
 	s.Require().NoError(err, "GetTVVInUnderlyingAsset should not error when paused")
 	s.Require().Equal(math.NewInt(42), tvv, "when paused, TVV should equal vault.PausedBalance.Amount regardless of principal contents")
+}
+
+func (s *TestSuite) TestGetNetTVVInUnderlyingAsset_PausedReturnsPausedBalanceWithoutNAV() {
+	underlyingDenom := "ylds"
+	paymentDenom := "usdc"
+	shareDenom := "vshare"
+	vault := s.setupSinglePaymentDenomVault(underlyingDenom, shareDenom, paymentDenom, 1, 2)
+
+	principal := vault.PrincipalMarkerAddress()
+	s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, s.adminAddr, principal, sdk.NewCoins(
+		sdk.NewInt64Coin(underlyingDenom, 9999),
+		sdk.NewInt64Coin(paymentDenom, 9999),
+	)), "funding principal balances before pause should succeed")
+
+	vault.Paused = true
+	vault.PausedBalance = sdk.NewInt64Coin(underlyingDenom, 42)
+	vault.OutstandingAumFee = sdk.NewInt64Coin("nonav", 100)
+	s.k.AuthKeeper.SetAccount(s.ctx, vault)
+
+	testKeeper := keeper.Keeper{MarkerKeeper: s.k.MarkerKeeper, BankKeeper: s.k.BankKeeper}
+	netTVV, err := testKeeper.GetNetTVVInUnderlyingAsset(s.ctx, *vault)
+	s.Require().NoError(err, "paused net TVV must not require a NAV lookup for the outstanding fee")
+	s.Require().Equal(math.NewInt(42), netTVV, "when paused, net TVV should equal vault.PausedBalance.Amount without subtracting the outstanding fee")
 }
 
 func (s *TestSuite) TestGetTVVInUnderlyingAsset_AcceptedDenomFiltering() {

--- a/keeper/vault.go
+++ b/keeper/vault.go
@@ -495,9 +495,9 @@ func (k *Keeper) autoPauseVault(ctx sdk.Context, vault *types.VaultAccount, reas
 		"reason", reason,
 	)
 
-	tvv, err := k.GetTVVInUnderlyingAsset(ctx, *vault)
+	tvv, err := k.GetNetTVVInUnderlyingAsset(ctx, *vault)
 	if err != nil {
-		k.getLogger(ctx).Error("Failed to get TVV in underlying asset", "vault_address", vault.GetAddress().String(), "error", err)
+		k.getLogger(ctx).Error("Failed to get net TVV in underlying asset", "vault_address", vault.GetAddress().String(), "error", err)
 	}
 
 	vault.Paused = true


### PR DESCRIPTION
## Summary
Adds `GetNetTVVInUnderlyingAsset` and routes the share-price conversions and NAV publication through it, so the vault consistently values itself **net of the `OutstandingAumFee` liability**.

## Background — the old code was not broken
A security report flagged a Gross/Net asymmetry: `CalculateVaultTotalAssets` computes **net** TVV (subtracting `OutstandingAumFee`), while the deposit/redeem conversions and NAV publication priced off `GetTVVInUnderlyingAsset` (**gross**, a plain sum of the principal marker's balances that never subtracts the fee).

In practice this produced correct numbers, because of the dynamic state at conversion time:

- Every binding conversion is preceded by `reconcileVault`, which runs `PerformVaultFeeTransfer` to **collect the outstanding/accrued AUM fee out of the principal marker** and reset the fee period.
- Once those fee assets are physically removed from the marker, `OutstandingAumFee` is zero, so **gross TVV equals net TVV** (`net = gross − 0`) and the gross-based pricing gave the right answer. The equality comes from the state, not from gross doing any subtraction.
- SwapIn reconciles before converting; the redeem payout (`processSingleWithdrawal`) reconciles before its binding conversion; NAV is published inside reconcile after the fee transfer.

Having two valuation paths side by side (gross for execution, net for estimate queries) was confusing and easy to misread as a live mispricing — which is what the report did.

## What this changes
- New `GetNetTVVInUnderlyingAsset` = gross principal TVV − `OutstandingAumFee` (in underlying), floored at zero; preserves the paused fast-path.
- `ConvertDepositToSharesInUnderlyingAsset`, `ConvertSharesToRedeemCoin`, `GetNAVPerShareInUnderlyingAsset`, and `publishShareNav` now use it.
- Estimate queries already netted the fee, so all three consumers (execution, published NAV, estimate queries) now share one basis.

## Why it's still worth doing
Beyond removing the confusion, it makes pricing correct in the edge case where the fee **can't be fully collected**: when the principal marker lacks sufficient payment-denom liquidity, `PerformVaultFeeTransfer` collects what it can and carries the shortfall forward in `OutstandingAumFee`. The marker still holds assets spoken-for by that unpaid fee, which gross counts in full while net discounts — so `gross > net` even right after reconcile. Routing pricing through net handles that case and makes execution consistent with the estimate queries.

## Testing
Adds `TestConvertAndNav_PriceNetOfOutstandingAumFee`, which constructs a vault where gross (1005) and net (1000) TVV differ by the outstanding fee and asserts both the deposit and redeem conversions price off net (and strictly diverge from gross in the correct direction). Full keeper suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NAV per share and share pricing now use net vault value (gross value minus outstanding AUM fees) for more accurate valuations.

* **Bug Fixes**
  * Deposit-to-shares and redeem pricing, paused-balance calculations, and auto-pause behavior now reflect outstanding fee liabilities; net value floors at zero when fees exceed gross.

* **Tests**
  * Added tests covering net-value pricing, zero-flooring, and paused-vault scenarios.

* **Changelog**
  * Entry added describing net-TV V valuation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->