### PR TITLE
Pending swap-out can be lost on critical payout/refund failure, stranding escrowed shares

### DIFF
--- a/.changelog/unreleased/bug-fixes/226-preserve-swap-out-on-critical-failure.md
+++ b/.changelog/unreleased/bug-fixes/226-preserve-swap-out-on-critical-failure.md
@@ -1,0 +1,1 @@
+* Preserve a pending swap-out and its escrowed shares when a payout or refund fails critically, removing the queue entry only when its payout or refund commits [#226](https://github.com/provlabs/vault/issues/226).

--- a/keeper/injectable_keepers_test.go
+++ b/keeper/injectable_keepers_test.go
@@ -1,0 +1,60 @@
+package keeper_test
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/provlabs/vault/types"
+)
+
+// faultBankKeeper wraps a real types.BankKeeper and lets a test force a targeted
+// SendCoins call to fail. All other methods delegate to the embedded keeper. It
+// exists so tests can deterministically trigger the critical-failure branches in
+// the swap-out payout and refund paths without manipulating real chain state.
+type faultBankKeeper struct {
+	types.BankKeeper
+	failSendCoins func(from, to sdk.AccAddress, amt sdk.Coins) error
+}
+
+// SendCoins returns the configured failure when the predicate matches the call;
+// otherwise it delegates to the wrapped keeper.
+func (f faultBankKeeper) SendCoins(ctx context.Context, from, to sdk.AccAddress, amt sdk.Coins) error {
+	if f.failSendCoins != nil {
+		if err := f.failSendCoins(from, to, amt); err != nil {
+			return err
+		}
+	}
+	return f.BankKeeper.SendCoins(ctx, from, to, amt)
+}
+
+// faultMarkerKeeper wraps a real types.MarkerKeeper and lets a test force BurnCoin
+// to fail. All other methods delegate to the embedded keeper. It exists so tests
+// can trigger the critical burn-failure branch of processSingleWithdrawal.
+type faultMarkerKeeper struct {
+	types.MarkerKeeper
+	failBurnCoin func(caller sdk.AccAddress, coin sdk.Coin) error
+}
+
+// BurnCoin returns the configured failure when the predicate matches the call;
+// otherwise it delegates to the wrapped keeper.
+func (f faultMarkerKeeper) BurnCoin(ctx sdk.Context, caller sdk.AccAddress, coin sdk.Coin) error {
+	if f.failBurnCoin != nil {
+		if err := f.failBurnCoin(caller, coin); err != nil {
+			return err
+		}
+	}
+	return f.MarkerKeeper.BurnCoin(ctx, caller, coin)
+}
+
+// installBankSendFault replaces the suite keeper's BankKeeper with a fault wrapper
+// that fails any SendCoins for which fail returns a non-nil error.
+func (s *TestSuite) installBankSendFault(fail func(from, to sdk.AccAddress, amt sdk.Coins) error) {
+	s.k.BankKeeper = faultBankKeeper{BankKeeper: s.k.BankKeeper, failSendCoins: fail}
+}
+
+// installMarkerBurnFault replaces the suite keeper's MarkerKeeper with a fault
+// wrapper that fails any BurnCoin for which fail returns a non-nil error.
+func (s *TestSuite) installMarkerBurnFault(fail func(caller sdk.AccAddress, coin sdk.Coin) error) {
+	s.k.MarkerKeeper = faultMarkerKeeper{MarkerKeeper: s.k.MarkerKeeper, failBurnCoin: fail}
+}

--- a/keeper/payout.go
+++ b/keeper/payout.go
@@ -62,6 +62,11 @@ func (k *Keeper) processPendingSwapOuts(ctx sdk.Context, batchSize int) error {
 //  4. Handling critical or unrecoverable failures by auto-pausing the vault and discarding the cache so
 //     the request is preserved. Because paused vaults are skipped, the preserved request waits for an
 //     unpause rather than re-executing, so it is never double-processed.
+//
+// A failed Dequeue is itself treated as a critical, unrecoverable failure for any vault that still exists.
+// Such a failure is deterministic for a given entry, so without intervention the same request would be
+// re-collected and re-attempted every block in an unbounded loop. Auto-pausing the vault breaks that loop,
+// signals operators, and preserves the escrowed shares (the cache is discarded) until the store issue is resolved.
 func (k *Keeper) processSwapOutJobs(ctx sdk.Context, jobsToProcess []types.PayoutJob) {
 	for _, j := range jobsToProcess {
 		vault, ok := k.tryGetVault(ctx, j.VaultAddr)
@@ -90,12 +95,14 @@ func (k *Keeper) processSwapOutJobs(ctx sdk.Context, jobsToProcess []types.Payou
 		err := k.processSingleWithdrawal(cacheCtx, j.ID, j.Req, *vault)
 		if err == nil {
 			if derr := k.PendingSwapOutQueue.Dequeue(cacheCtx, j.Timestamp, j.VaultAddr, j.ID); derr != nil {
+				errMsg := fmt.Sprintf("failed to dequeue withdrawal request %d after successful payout", j.ID)
 				k.getLogger(ctx).Error(
-					"failed to dequeue withdrawal request after successful payout",
+					"CRITICAL: "+errMsg,
 					"request_id", j.ID,
 					"vault_address", j.VaultAddr.String(),
 					"error", derr,
 				)
+				k.autoPauseVault(ctx, vault, errMsg)
 				continue
 			}
 			write()
@@ -117,12 +124,14 @@ func (k *Keeper) processSwapOutJobs(ctx sdk.Context, jobsToProcess []types.Payou
 
 		refundCtx, refundWrite := ctx.CacheContext()
 		if derr := k.PendingSwapOutQueue.Dequeue(refundCtx, j.Timestamp, j.VaultAddr, j.ID); derr != nil {
+			errMsg := fmt.Sprintf("failed to dequeue withdrawal request %d before refund", j.ID)
 			k.getLogger(ctx).Error(
-				"failed to dequeue withdrawal request before refund",
+				"CRITICAL: "+errMsg,
 				"request_id", j.ID,
 				"vault_address", j.VaultAddr.String(),
 				"error", derr,
 			)
+			k.autoPauseVault(ctx, vault, errMsg)
 			continue
 		}
 		if rerr := k.refundWithdrawal(refundCtx, j.ID, j.Req, reason); rerr != nil {

--- a/keeper/payout.go
+++ b/keeper/payout.go
@@ -47,14 +47,21 @@ func (k *Keeper) processPendingSwapOuts(ctx sdk.Context, batchSize int) error {
 
 // processSwapOutJobs iterates pending swap-out jobs collected for this block and executes them.
 //
+// A pending request is removed from the queue only when a durable outcome is committed in the same
+// atomic unit as the deletion: a completed payout or a successful refund. The dequeue therefore shares
+// the cache context with its outcome, so on a critical failure both the work and the deletion roll back
+// together and the request, along with the shares escrowed at request time, is preserved for later
+// settlement. This keeps the payout/burn atomicity intact while ensuring escrow can never be stranded
+// by a partially committed outcome.
+//
 // The processing strategy involves:
 //  1. Verifying the vault exists and is not paused.
-//  2. Dequeuing the job on the main context immediately to ensure it is only attempted once,
-//     preventing infinite retry loops if a failure occurs during processing or refund.
-//  3. Executing the withdrawal logic (reconciliation, payout, and burning) within a single
-//     cache context to ensure atomicity. Changes are only committed to the main state on success.
-//  4. Handling recoverable failures by issuing a refund on the main context.
-//  5. Handling critical or unrecoverable failures by auto-pausing the associated vault.
+//  2. Executing the withdrawal logic (reconciliation, payout, and burning) within a cache context, then
+//     dequeuing in that same cache context and committing only on success.
+//  3. Handling recoverable failures by dequeuing and refunding atomically in a fresh cache context.
+//  4. Handling critical or unrecoverable failures by auto-pausing the vault and discarding the cache so
+//     the request is preserved. Because paused vaults are skipped, the preserved request waits for an
+//     unpause rather than re-executing, so it is never double-processed.
 func (k *Keeper) processSwapOutJobs(ctx sdk.Context, jobsToProcess []types.PayoutJob) {
 	for _, j := range jobsToProcess {
 		vault, ok := k.tryGetVault(ctx, j.VaultAddr)
@@ -78,41 +85,53 @@ func (k *Keeper) processSwapOutJobs(ctx sdk.Context, jobsToProcess []types.Payou
 			continue
 		}
 
-		if err := k.PendingSwapOutQueue.Dequeue(ctx, j.Timestamp, j.VaultAddr, j.ID); err != nil {
-			k.getLogger(ctx).Error(
-				"failed to dequeue withdrawal request",
-				"request_id", j.ID,
-				"vault_address", j.VaultAddr.String(),
-				"error", err,
-			)
+		var cErr *types.CriticalError
+		cacheCtx, write := ctx.CacheContext()
+		err := k.processSingleWithdrawal(cacheCtx, j.ID, j.Req, *vault)
+		if err == nil {
+			if derr := k.PendingSwapOutQueue.Dequeue(cacheCtx, j.Timestamp, j.VaultAddr, j.ID); derr != nil {
+				k.getLogger(ctx).Error(
+					"failed to dequeue withdrawal request after successful payout",
+					"request_id", j.ID,
+					"vault_address", j.VaultAddr.String(),
+					"error", derr,
+				)
+				continue
+			}
+			write()
 			continue
 		}
 
-		cacheCtx, write := ctx.CacheContext()
-
-		if err := k.processSingleWithdrawal(cacheCtx, j.ID, j.Req, *vault); err != nil {
-			var cErr *types.CriticalError
-			if errors.As(err, &cErr) {
-				k.autoPauseVault(ctx, vault, cErr.Reason)
-				continue
-			}
-
-			reason := k.getRefundReason(err)
-			k.getLogger(ctx).Error(
-				"failed to process withdrawal, issuing refund",
-				"withdrawal_id", j.ID,
-				"reason", reason,
-				"error", err,
-			)
-
-			if rerr := k.refundWithdrawal(ctx, j.ID, j.Req, reason); rerr != nil {
-				if errors.As(rerr, &cErr) {
-					k.autoPauseVault(ctx, vault, cErr.Reason)
-				}
-			}
-		} else {
-			write()
+		if errors.As(err, &cErr) {
+			k.autoPauseVault(ctx, vault, cErr.Reason)
+			continue
 		}
+
+		reason := k.getRefundReason(err)
+		k.getLogger(ctx).Error(
+			"failed to process withdrawal, issuing refund",
+			"withdrawal_id", j.ID,
+			"reason", reason,
+			"error", err,
+		)
+
+		refundCtx, refundWrite := ctx.CacheContext()
+		if derr := k.PendingSwapOutQueue.Dequeue(refundCtx, j.Timestamp, j.VaultAddr, j.ID); derr != nil {
+			k.getLogger(ctx).Error(
+				"failed to dequeue withdrawal request before refund",
+				"request_id", j.ID,
+				"vault_address", j.VaultAddr.String(),
+				"error", derr,
+			)
+			continue
+		}
+		if rerr := k.refundWithdrawal(refundCtx, j.ID, j.Req, reason); rerr != nil {
+			if errors.As(rerr, &cErr) {
+				k.autoPauseVault(ctx, vault, cErr.Reason)
+			}
+			continue
+		}
+		refundWrite()
 	}
 }
 

--- a/keeper/payout_test.go
+++ b/keeper/payout_test.go
@@ -432,23 +432,7 @@ func (s *TestSuite) TestKeeper_ProcessSwapOutJobs() {
 		{
 			name: "request is skipped if vault becomes paused after collection",
 			setup: func(shareDenom string, vaultAddr sdk.AccAddress) (sdk.AccAddress, sdk.Coin, uint64, types.PendingSwapOut) {
-				ownerAddr := s.CreateAndFundAccount(assets)
-				vault := s.setupBaseVault(underlyingDenom, shareDenom)
-
-				minted, err := s.k.SwapIn(s.ctx, vaultAddr, ownerAddr, assets)
-				s.Require().NoError(err, "should successfully swap in assets")
-				s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, ownerAddr, vault.GetAddress(), sdk.NewCoins(*minted)), "should escrow shares into vault account")
-
-				req := types.PendingSwapOut{
-					Owner:        ownerAddr.String(),
-					VaultAddress: vaultAddr.String(),
-					RedeemDenom:  underlyingDenom,
-					Shares:       *minted,
-				}
-				id, err := s.k.PendingSwapOutQueue.Enqueue(s.ctx, duePayoutTime, &req)
-				s.Require().NoError(err, "should successfully enqueue request")
-
-				return ownerAddr, *minted, id, req
+				return s.enqueueDueSwapOut(underlyingDenom, shareDenom, assets, duePayoutTime)
 			},
 			act: func(shareDenom string, vaultAddr sdk.AccAddress, ownerAddr sdk.AccAddress, mintedShares sdk.Coin, reqID uint64, req types.PendingSwapOut) {
 				jobs := []types.PayoutJob{
@@ -474,6 +458,107 @@ func (s *TestSuite) TestKeeper_ProcessSwapOutJobs() {
 				s.assertBalance(ownerAddr, underlyingDenom, math.ZeroInt())
 				s.assertBalance(vaultAddr, mintedShares.Denom, mintedShares.Amount)
 				s.Assert().Empty(s.ctx.EventManager().Events(), "no events should be emitted for a job skipped due to pause")
+			},
+		},
+		{
+			name: "critical share-transfer failure preserves entry, escrow, and pauses vault",
+			setup: func(shareDenom string, vaultAddr sdk.AccAddress) (sdk.AccAddress, sdk.Coin, uint64, types.PendingSwapOut) {
+				return s.enqueueDueSwapOut(underlyingDenom, shareDenom, assets, duePayoutTime)
+			},
+			act: func(shareDenom string, vaultAddr sdk.AccAddress, ownerAddr sdk.AccAddress, mintedShares sdk.Coin, reqID uint64, req types.PendingSwapOut) {
+				principalAddress := markertypes.MustGetMarkerAddress(shareDenom)
+				s.installBankSendFault(func(from, to sdk.AccAddress, amt sdk.Coins) error {
+					if from.Equals(vaultAddr) && to.Equals(principalAddress) && amt.AmountOf(shareDenom).Equal(mintedShares.Amount) {
+						return fmt.Errorf("forced share transfer failure")
+					}
+					return nil
+				})
+				s.k.TestAccessor_processSwapOutJobs(s.T(), s.ctx, []types.PayoutJob{types.NewPayoutJob(duePayoutTime, reqID, vaultAddr, req)})
+			},
+			posthandler: func(ownerAddr sdk.AccAddress, reqID uint64, shareDenom string, vaultAddr sdk.AccAddress, mintedShares sdk.Coin) {
+				s.assertSwapOutEntryPreservedAndPaused(reqID, vaultAddr, ownerAddr, mintedShares, underlyingDenom)
+			},
+		},
+		{
+			name: "critical burn failure preserves entry, escrow, and pauses vault",
+			setup: func(shareDenom string, vaultAddr sdk.AccAddress) (sdk.AccAddress, sdk.Coin, uint64, types.PendingSwapOut) {
+				return s.enqueueDueSwapOut(underlyingDenom, shareDenom, assets, duePayoutTime)
+			},
+			act: func(shareDenom string, vaultAddr sdk.AccAddress, ownerAddr sdk.AccAddress, mintedShares sdk.Coin, reqID uint64, req types.PendingSwapOut) {
+				s.installMarkerBurnFault(func(_ sdk.AccAddress, coin sdk.Coin) error {
+					if coin.Denom == shareDenom {
+						return fmt.Errorf("forced burn failure")
+					}
+					return nil
+				})
+				s.k.TestAccessor_processSwapOutJobs(s.T(), s.ctx, []types.PayoutJob{types.NewPayoutJob(duePayoutTime, reqID, vaultAddr, req)})
+			},
+			posthandler: func(ownerAddr sdk.AccAddress, reqID uint64, shareDenom string, vaultAddr sdk.AccAddress, mintedShares sdk.Coin) {
+				s.assertSwapOutEntryPreservedAndPaused(reqID, vaultAddr, ownerAddr, mintedShares, underlyingDenom)
+			},
+		},
+		{
+			name: "critical refund failure preserves entry, escrow, and pauses vault",
+			setup: func(shareDenom string, vaultAddr sdk.AccAddress) (sdk.AccAddress, sdk.Coin, uint64, types.PendingSwapOut) {
+				return s.enqueueDueSwapOut(underlyingDenom, shareDenom, assets, duePayoutTime)
+			},
+			act: func(shareDenom string, vaultAddr sdk.AccAddress, ownerAddr sdk.AccAddress, mintedShares sdk.Coin, reqID uint64, req types.PendingSwapOut) {
+				principalAddress := markertypes.MustGetMarkerAddress(shareDenom)
+				s.installBankSendFault(func(from, to sdk.AccAddress, amt sdk.Coins) error {
+					if from.Equals(principalAddress) && to.Equals(ownerAddr) {
+						return fmt.Errorf("forced payout failure")
+					}
+					if from.Equals(vaultAddr) && to.Equals(ownerAddr) {
+						return fmt.Errorf("forced refund failure")
+					}
+					return nil
+				})
+				s.k.TestAccessor_processSwapOutJobs(s.T(), s.ctx, []types.PayoutJob{types.NewPayoutJob(duePayoutTime, reqID, vaultAddr, req)})
+			},
+			posthandler: func(ownerAddr sdk.AccAddress, reqID uint64, shareDenom string, vaultAddr sdk.AccAddress, mintedShares sdk.Coin) {
+				s.assertSwapOutEntryPreservedAndPaused(reqID, vaultAddr, ownerAddr, mintedShares, underlyingDenom)
+			},
+		},
+		{
+			name: "preserved entry completes after vault is unpaused",
+			setup: func(shareDenom string, vaultAddr sdk.AccAddress) (sdk.AccAddress, sdk.Coin, uint64, types.PendingSwapOut) {
+				return s.enqueueDueSwapOut(underlyingDenom, shareDenom, assets, duePayoutTime)
+			},
+			act: func(shareDenom string, vaultAddr sdk.AccAddress, ownerAddr sdk.AccAddress, mintedShares sdk.Coin, reqID uint64, req types.PendingSwapOut) {
+				principalAddress := markertypes.MustGetMarkerAddress(shareDenom)
+				failOnce := true
+				s.installBankSendFault(func(from, to sdk.AccAddress, amt sdk.Coins) error {
+					if failOnce && from.Equals(vaultAddr) && to.Equals(principalAddress) && amt.AmountOf(shareDenom).Equal(mintedShares.Amount) {
+						failOnce = false
+						return fmt.Errorf("forced one-time share transfer failure")
+					}
+					return nil
+				})
+				jobs := []types.PayoutJob{types.NewPayoutJob(duePayoutTime, reqID, vaultAddr, req)}
+				s.k.TestAccessor_processSwapOutJobs(s.T(), s.ctx, jobs)
+
+				vault, err := s.k.GetVault(s.ctx, vaultAddr)
+				s.Require().NoError(err, "should successfully get vault after critical failure")
+				s.Require().True(vault.Paused, "vault should be paused after the critical failure")
+				vault.Paused = false
+				vault.PausedReason = ""
+				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vault), "should successfully unpause vault")
+
+				s.k.TestAccessor_processSwapOutJobs(s.T(), s.ctx, jobs)
+			},
+			posthandler: func(ownerAddr sdk.AccAddress, reqID uint64, shareDenom string, vaultAddr sdk.AccAddress, mintedShares sdk.Coin) {
+				var entries []uint64
+				err := s.k.PendingSwapOutQueue.Walk(s.ctx, func(_ int64, id uint64, _ sdk.AccAddress, _ types.PendingSwapOut) (bool, error) {
+					entries = append(entries, id)
+					return false, nil
+				})
+				s.Require().NoError(err, "walking the queue should not error")
+				s.Require().Empty(entries, "entry should be removed after a successful payout on the second pass")
+
+				s.assertBalance(ownerAddr, underlyingDenom, assets.Amount)
+				s.assertBalance(vaultAddr, mintedShares.Denom, math.ZeroInt())
+				supply := s.k.BankKeeper.GetSupply(s.ctx, shareDenom)
+				s.Require().True(supply.Amount.IsZero(), "share supply should be zero after the burn completes")
 			},
 		},
 	}

--- a/keeper/suite_test.go
+++ b/keeper/suite_test.go
@@ -608,6 +608,55 @@ func (s *TestSuite) SetCtxBlockTime(t time.Time) {
 	s.ctx = s.ctx.WithBlockTime(t).WithEventManager(sdk.NewEventManager())
 }
 
+// enqueueDueSwapOut creates a funded owner and base vault, swaps assets in, escrows the
+// resulting shares into the vault account, and enqueues a due pending swap-out redeeming
+// the underlying asset. It returns the owner, the escrowed shares, the request id, and the
+// queued request. It consolidates the swap-out setup repeated across the payout tests.
+func (s *TestSuite) enqueueDueSwapOut(underlyingDenom, shareDenom string, assets sdk.Coin, duePayoutTime int64) (sdk.AccAddress, sdk.Coin, uint64, types.PendingSwapOut) {
+	ownerAddr := s.CreateAndFundAccount(assets)
+	vault := s.setupBaseVault(underlyingDenom, shareDenom)
+
+	minted, err := s.k.SwapIn(s.ctx, vault.GetAddress(), ownerAddr, assets)
+	s.Require().NoError(err, "should successfully swap in assets for share denom %s", shareDenom)
+	s.Require().NoError(
+		s.k.BankKeeper.SendCoins(s.ctx, ownerAddr, vault.GetAddress(), sdk.NewCoins(*minted)),
+		"should escrow %s shares into vault account %s", minted, vault.GetAddress(),
+	)
+
+	req := types.PendingSwapOut{
+		Owner:        ownerAddr.String(),
+		VaultAddress: vault.GetAddress().String(),
+		RedeemDenom:  underlyingDenom,
+		Shares:       *minted,
+	}
+	id, err := s.k.PendingSwapOutQueue.Enqueue(s.ctx, duePayoutTime, &req)
+	s.Require().NoError(err, "should successfully enqueue due swap-out for share denom %s", shareDenom)
+
+	return ownerAddr, *minted, id, req
+}
+
+// assertSwapOutEntryPreservedAndPaused verifies the invariant that protects escrowed funds when a
+// swap-out hits a critical, unrecoverable failure: the pending request is still in the queue, the
+// vault is paused, the owner was not paid, and the escrowed shares remain on the vault account. This
+// is the state a fixed processSwapOutJobs must leave behind so the request can be settled after unpause.
+func (s *TestSuite) assertSwapOutEntryPreservedAndPaused(reqID uint64, vaultAddr, ownerAddr sdk.AccAddress, escrowedShares sdk.Coin, underlyingDenom string) {
+	var entries []uint64
+	err := s.k.PendingSwapOutQueue.Walk(s.ctx, func(_ int64, id uint64, _ sdk.AccAddress, _ types.PendingSwapOut) (bool, error) {
+		entries = append(entries, id)
+		return false, nil
+	})
+	s.Require().NoError(err, "walking the queue should not error")
+	s.Require().Equal([]uint64{reqID}, entries, "request %d must remain queued after a critical failure", reqID)
+
+	vault, err := s.k.GetVault(s.ctx, vaultAddr)
+	s.Require().NoError(err, "should successfully get vault %s", vaultAddr)
+	s.Require().NotNil(vault, "vault %s should not be nil", vaultAddr)
+	s.Require().True(vault.Paused, "vault %s must be paused after a critical failure", vaultAddr)
+
+	s.assertBalance(ownerAddr, underlyingDenom, sdkmath.ZeroInt())
+	s.assertBalance(vaultAddr, escrowedShares.Denom, escrowedShares.Amount)
+}
+
 // createMarkerMintCoinEvents builds the expected event sequence for minting
 // marker coins and sending them to a recipient.
 func createMarkerMintCoinEvents(markerModule, admin, recipient sdk.AccAddress, coin sdk.Coin) []sdk.Event {


### PR DESCRIPTION
closes: #226 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap-out payout handling so queued requests are only removed after the outcome is safely recorded.
  * Preserved pending requests when a critical failure occurs, allowing them to be retried later.
  * Auto-paused vaults on unrecoverable errors to prevent further processing until resolved.
  * Added test coverage for failure scenarios and successful completion after unpausing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->