### PR TITLE
Cap abci loop

### DIFF
--- a/.changelog/unreleased/bug-fixes/225-cap-abci-loop.md
+++ b/.changelog/unreleased/bug-fixes/225-cap-abci-loop.md
@@ -1,0 +1,1 @@
+* Enforce per-block visit budgets on all ABCI queue processors (interest timeouts, fee timeouts, payout verification set, and pending swap-outs) and dequeue/refund pending swap-outs for paused vaults so they cannot camp at the front of the queue [#225](https://github.com/provlabs/vault/issues/225).

--- a/keeper/abci.go
+++ b/keeper/abci.go
@@ -7,20 +7,37 @@ import (
 )
 
 const (
-	// MaxSwapOutBatchSize is the maximum number of pending swap-out requests
-	// to process in a single EndBlocker invocation. This prevents a large queue
-	// from consuming excessive block time and memory. This is a temporary value
-	// and we will need to do more analysis on a proper batch size.
-	// See https://github.com/ProvLabs/vault/issues/75.
+	// MaxSwapOutBatchSize is the maximum number of pending swap-out queue entries
+	// to visit in a single EndBlocker invocation. Every visited entry counts against
+	// the budget, including entries for paused vaults (which are dequeued and refunded
+	// rather than processed), so block time stays bounded regardless of queue depth or
+	// composition. This is a temporary value and we will need to do more analysis on a
+	// proper batch size. See https://github.com/ProvLabs/vault/issues/75.
 	MaxSwapOutBatchSize = 100
+
+	// MaxInterestTimeoutsPerBlock is the maximum number of PayoutTimeoutQueue entries
+	// to visit in a single BeginBlocker invocation. Entries beyond the budget remain
+	// due and are picked up in subsequent blocks, keeping interest reconciliation cost
+	// per block bounded regardless of how many vaults time out at once.
+	MaxInterestTimeoutsPerBlock = 100
+
+	// MaxFeeTimeoutsPerBlock is the maximum number of FeeTimeoutQueue entries to visit
+	// in a single BeginBlocker invocation. Entries beyond the budget remain due and are
+	// picked up in subsequent blocks, keeping AUM fee collection cost per block bounded.
+	MaxFeeTimeoutsPerBlock = 100
+
+	// MaxPayoutVerificationsPerBlock is the maximum number of PayoutVerificationSet
+	// entries to visit in a single EndBlocker invocation. Entries beyond the budget
+	// stay in the set and are verified in subsequent blocks.
+	MaxPayoutVerificationsPerBlock = 100
 )
 
 // BeginBlocker is a hook that is called at the beginning of every block.
 func (k *Keeper) BeginBlocker(ctx sdk.Context) error {
-	if err := k.handleVaultInterestTimeouts(ctx); err != nil {
+	if err := k.handleVaultInterestTimeouts(ctx, MaxInterestTimeoutsPerBlock); err != nil {
 		return fmt.Errorf("failed to handle vault interest timeouts: %w", err)
 	}
-	if err := k.handleVaultFeeTimeouts(ctx); err != nil {
+	if err := k.handleVaultFeeTimeouts(ctx, MaxFeeTimeoutsPerBlock); err != nil {
 		return fmt.Errorf("failed to handle vault fee timeouts: %w", err)
 	}
 	return nil
@@ -32,7 +49,7 @@ func (k *Keeper) EndBlocker(ctx sdk.Context) error {
 		return fmt.Errorf("failed to process pending swap outs: %w", err)
 	}
 
-	if err := k.handleReconciledVaults(ctx); err != nil {
+	if err := k.handleReconciledVaults(ctx, MaxPayoutVerificationsPerBlock); err != nil {
 		return fmt.Errorf("failed to handle reconciled vaults: %w", err)
 	}
 

--- a/keeper/abci.go
+++ b/keeper/abci.go
@@ -8,27 +8,22 @@ import (
 
 const (
 	// MaxSwapOutBatchSize is the maximum number of pending swap-out queue entries
-	// to visit in a single EndBlocker invocation. Every visited entry counts against
-	// the budget, including entries for paused vaults (which are dequeued and refunded
-	// rather than processed), so block time stays bounded regardless of queue depth or
-	// composition. This is a temporary value and we will need to do more analysis on a
-	// proper batch size. See https://github.com/ProvLabs/vault/issues/75.
+	// visited per EndBlocker. Entries for paused vaults count against the budget
+	// and are dequeued and refunded. This is a temporary value and we will need to
+	// do more analysis on a proper batch size.
+	// See https://github.com/ProvLabs/vault/issues/75.
 	MaxSwapOutBatchSize = 100
 
-	// MaxInterestTimeoutsPerBlock is the maximum number of PayoutTimeoutQueue entries
-	// to visit in a single BeginBlocker invocation. Entries beyond the budget remain
-	// due and are picked up in subsequent blocks, keeping interest reconciliation cost
-	// per block bounded regardless of how many vaults time out at once.
+	// MaxInterestTimeoutsPerBlock is the maximum number of PayoutTimeoutQueue
+	// entries visited per BeginBlocker.
 	MaxInterestTimeoutsPerBlock = 100
 
-	// MaxFeeTimeoutsPerBlock is the maximum number of FeeTimeoutQueue entries to visit
-	// in a single BeginBlocker invocation. Entries beyond the budget remain due and are
-	// picked up in subsequent blocks, keeping AUM fee collection cost per block bounded.
+	// MaxFeeTimeoutsPerBlock is the maximum number of FeeTimeoutQueue entries
+	// visited per BeginBlocker.
 	MaxFeeTimeoutsPerBlock = 100
 
 	// MaxPayoutVerificationsPerBlock is the maximum number of PayoutVerificationSet
-	// entries to visit in a single EndBlocker invocation. Entries beyond the budget
-	// stay in the set and are verified in subsequent blocks.
+	// entries visited per EndBlocker.
 	MaxPayoutVerificationsPerBlock = 100
 )
 

--- a/keeper/export_test.go
+++ b/keeper/export_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 // TestAccessor_handleReconciledVaults exposes this keeper's handleReconciledVaults function for unit tests.
-func (k Keeper) TestAccessor_handleReconciledVaults(t *testing.T, ctx context.Context) error {
+func (k Keeper) TestAccessor_handleReconciledVaults(t *testing.T, ctx context.Context, limit int) error {
 	t.Helper()
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	return k.handleReconciledVaults(sdkCtx)
+	return k.handleReconciledVaults(sdkCtx, limit)
 }
 
 // TestAccessor_handlePayableVaults exposes this keeper's handlePayableVaults function for unit tests.
@@ -35,17 +35,17 @@ func (k Keeper) TestAccessor_handleDepletedVaults(t *testing.T, ctx context.Cont
 }
 
 // TestAccessor_handleVaultInterestTimeouts exposes this keeper's handleVaultInterestTimeouts function for unit tests.
-func (k Keeper) TestAccessor_handleVaultInterestTimeouts(t *testing.T, ctx context.Context) error {
+func (k Keeper) TestAccessor_handleVaultInterestTimeouts(t *testing.T, ctx context.Context, limit int) error {
 	t.Helper()
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	return k.handleVaultInterestTimeouts(sdkCtx)
+	return k.handleVaultInterestTimeouts(sdkCtx, limit)
 }
 
 // TestAccessor_handleVaultFeeTimeouts exposes this keeper's handleVaultFeeTimeouts function for unit tests.
-func (k Keeper) TestAccessor_handleVaultFeeTimeouts(t *testing.T, ctx context.Context) error {
+func (k Keeper) TestAccessor_handleVaultFeeTimeouts(t *testing.T, ctx context.Context, limit int) error {
 	t.Helper()
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	return k.handleVaultFeeTimeouts(sdkCtx)
+	return k.handleVaultFeeTimeouts(sdkCtx, limit)
 }
 
 // TestAccessor_processSwapOutJobs exposes this keeper's processSwapOutJobs function for unit tests.

--- a/keeper/payout.go
+++ b/keeper/payout.go
@@ -15,23 +15,21 @@ import (
 
 // processPendingSwapOuts processes the queue of pending swap-out requests. Called from the EndBlocker,
 // it iterates through requests due for payout at the current block time. It uses a safe "collect-then-mutate"
-// pattern to comply with the SDK iterator contract. It first collects all due requests up to the provided `batchSize`,
-// then passes them to `processSwapOutJobs` for execution. Critical, unrecoverable errors during job processing
-// will cause the associated vault to be automatically paused.
+// pattern to comply with the SDK iterator contract. It first collects due requests up to the provided `batchSize`,
+// then passes them to `processSwapOutJobs` for execution. Every visited entry counts against the batch budget,
+// including entries for paused vaults, so a queue front-loaded with unprocessable entries cannot extend the
+// per-block iteration cost. Critical, unrecoverable errors during job processing will cause the associated
+// vault to be automatically paused.
 func (k *Keeper) processPendingSwapOuts(ctx sdk.Context, batchSize int) error {
 	now := ctx.BlockTime().Unix()
 	var jobsToProcess []types.PayoutJob
 
-	processed := 0
+	visited := 0
 	err := k.PendingSwapOutQueue.WalkDue(ctx, now, func(timestamp int64, id uint64, vaultAddr sdk.AccAddress, req types.PendingSwapOut) (stop bool, err error) {
-		vault, ok := k.tryGetVault(ctx, vaultAddr)
-		if ok && vault.Paused {
-			return false, nil
-		}
-		if processed == batchSize {
+		if visited == batchSize {
 			return true, nil
 		}
-		processed++
+		visited++
 		jobsToProcess = append(jobsToProcess, types.NewPayoutJob(timestamp, id, vaultAddr, req))
 		return false, nil
 	})
@@ -48,7 +46,8 @@ func (k *Keeper) processPendingSwapOuts(ctx sdk.Context, batchSize int) error {
 // processSwapOutJobs iterates pending swap-out jobs collected for this block and executes them.
 //
 // The processing strategy involves:
-//  1. Verifying the vault exists and is not paused.
+//  1. Verifying the vault exists; jobs for paused vaults are dequeued and refunded so they
+//     cannot permanently occupy the front of the queue and starve processable requests.
 //  2. Dequeuing the job on the main context immediately to ensure it is only attempted once,
 //     preventing infinite retry loops if a failure occurs during processing or refund.
 //  3. Executing the withdrawal logic (reconciliation, payout, and burning) within a single
@@ -75,6 +74,7 @@ func (k *Keeper) processSwapOutJobs(ctx sdk.Context, jobsToProcess []types.Payou
 		}
 
 		if vault.Paused {
+			k.refundPausedVaultSwapOut(ctx, j)
 			continue
 		}
 
@@ -113,6 +113,33 @@ func (k *Keeper) processSwapOutJobs(ctx sdk.Context, jobsToProcess []types.Payou
 		} else {
 			write()
 		}
+	}
+}
+
+// refundPausedVaultSwapOut dequeues a due swap-out job whose vault is paused and returns the
+// escrowed shares to the owner. Leaving these jobs queued would let them camp at the front of
+// the PendingSwapOutQueue (expedited entries are keyed at timestamp zero) and be re-visited
+// every block, consuming the batch budget and starving processable requests behind them.
+// The vault is already paused, so a critically failed refund is only logged; the job is not
+// retried because it was dequeued first, matching the attempt-once strategy of regular jobs.
+func (k *Keeper) refundPausedVaultSwapOut(ctx sdk.Context, j types.PayoutJob) {
+	if err := k.PendingSwapOutQueue.Dequeue(ctx, j.Timestamp, j.VaultAddr, j.ID); err != nil {
+		k.getLogger(ctx).Error(
+			"CRITICAL: failed to dequeue withdrawal request for paused vault",
+			"request_id", j.ID,
+			"vault_address", j.VaultAddr.String(),
+			"error", err,
+		)
+		return
+	}
+
+	if err := k.refundWithdrawal(ctx, j.ID, j.Req, types.RefundReasonVaultPaused); err != nil {
+		k.getLogger(ctx).Error(
+			"CRITICAL: failed to refund withdrawal request for paused vault",
+			"request_id", j.ID,
+			"vault_address", j.VaultAddr.String(),
+			"error", err,
+		)
 	}
 }
 

--- a/keeper/payout.go
+++ b/keeper/payout.go
@@ -16,10 +16,9 @@ import (
 // processPendingSwapOuts processes the queue of pending swap-out requests. Called from the EndBlocker,
 // it iterates through requests due for payout at the current block time. It uses a safe "collect-then-mutate"
 // pattern to comply with the SDK iterator contract. It first collects due requests up to the provided `batchSize`,
-// then passes them to `processSwapOutJobs` for execution. Every visited entry counts against the batch budget,
-// including entries for paused vaults, so a queue front-loaded with unprocessable entries cannot extend the
-// per-block iteration cost. Critical, unrecoverable errors during job processing will cause the associated
-// vault to be automatically paused.
+// counting every visited entry (including ones for paused vaults) against the budget, then passes them to
+// `processSwapOutJobs` for execution. Critical, unrecoverable errors during job processing will cause the
+// associated vault to be automatically paused.
 func (k *Keeper) processPendingSwapOuts(ctx sdk.Context, batchSize int) error {
 	now := ctx.BlockTime().Unix()
 	var jobsToProcess []types.PayoutJob
@@ -46,8 +45,7 @@ func (k *Keeper) processPendingSwapOuts(ctx sdk.Context, batchSize int) error {
 // processSwapOutJobs iterates pending swap-out jobs collected for this block and executes them.
 //
 // The processing strategy involves:
-//  1. Verifying the vault exists; jobs for paused vaults are dequeued and refunded so they
-//     cannot permanently occupy the front of the queue and starve processable requests.
+//  1. Verifying the vault exists; jobs for paused vaults are dequeued and refunded.
 //  2. Dequeuing the job on the main context immediately to ensure it is only attempted once,
 //     preventing infinite retry loops if a failure occurs during processing or refund.
 //  3. Executing the withdrawal logic (reconciliation, payout, and burning) within a single
@@ -116,16 +114,16 @@ func (k *Keeper) processSwapOutJobs(ctx sdk.Context, jobsToProcess []types.Payou
 	}
 }
 
-// refundPausedVaultSwapOut dequeues a due swap-out job whose vault is paused and returns the
-// escrowed shares to the owner. Leaving these jobs queued would let them camp at the front of
-// the PendingSwapOutQueue (expedited entries are keyed at timestamp zero) and be re-visited
-// every block, consuming the batch budget and starving processable requests behind them.
-// The vault is already paused, so a critically failed refund is only logged; the job is not
-// retried because it was dequeued first, matching the attempt-once strategy of regular jobs.
+// refundPausedVaultSwapOut atomically dequeues a due swap-out job for a paused vault and
+// refunds the escrowed shares, so paused entries cannot camp at the front of the queue.
+// On any failure the cache context is discarded, keeping the request queued as the record
+// of who is owed shares; it retries on a later block within the batch budget.
 func (k *Keeper) refundPausedVaultSwapOut(ctx sdk.Context, j types.PayoutJob) {
-	if err := k.PendingSwapOutQueue.Dequeue(ctx, j.Timestamp, j.VaultAddr, j.ID); err != nil {
+	cacheCtx, write := ctx.CacheContext()
+
+	if err := k.PendingSwapOutQueue.Dequeue(cacheCtx, j.Timestamp, j.VaultAddr, j.ID); err != nil {
 		k.getLogger(ctx).Error(
-			"CRITICAL: failed to dequeue withdrawal request for paused vault",
+			"failed to dequeue withdrawal request for paused vault, leaving queued",
 			"request_id", j.ID,
 			"vault_address", j.VaultAddr.String(),
 			"error", err,
@@ -133,14 +131,17 @@ func (k *Keeper) refundPausedVaultSwapOut(ctx sdk.Context, j types.PayoutJob) {
 		return
 	}
 
-	if err := k.refundWithdrawal(ctx, j.ID, j.Req, types.RefundReasonVaultPaused); err != nil {
+	if err := k.refundWithdrawal(cacheCtx, j.ID, j.Req, types.RefundReasonVaultPaused); err != nil {
 		k.getLogger(ctx).Error(
-			"CRITICAL: failed to refund withdrawal request for paused vault",
+			"failed to refund withdrawal request for paused vault, leaving queued",
 			"request_id", j.ID,
 			"vault_address", j.VaultAddr.String(),
 			"error", err,
 		)
+		return
 	}
+
+	write()
 }
 
 // processSingleWithdrawal executes a pending swap-out. It first reconciles the vault (interest and AUM fees), then converts the user's

--- a/keeper/payout_test.go
+++ b/keeper/payout_test.go
@@ -397,6 +397,43 @@ func (s *TestSuite) TestKeeper_ProcessPendingSwapOuts() {
 			batchSize: keeper.MaxSwapOutBatchSize,
 		},
 		{
+			name: "paused vault refund failure leaves request queued",
+			setup: func(shareDenom string, vaultAddr sdk.AccAddress, shares sdk.Coin) (sdk.AccAddress, uint64) {
+				ownerAddr := s.CreateAndFundAccount(assets)
+				vault := s.setupBaseVault(underlyingDenom, shareDenom)
+
+				minted, err := s.k.SwapIn(s.ctx, vaultAddr, ownerAddr, assets)
+				s.Require().NoError(err, "should successfully swap in assets")
+				s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, ownerAddr, vault.GetAddress(), sdk.NewCoins(*minted)), "should escrow shares into vault account")
+
+				req := types.PendingSwapOut{
+					Owner:        ownerAddr.String(),
+					VaultAddress: vaultAddr.String(),
+					RedeemDenom:  underlyingDenom,
+					Shares:       *minted,
+				}
+				id, err := s.k.PendingSwapOutQueue.Enqueue(s.ctx, duePayoutTime, &req)
+				s.Require().NoError(err, "should successfully enqueue request")
+
+				vault, err = s.k.GetVault(s.ctx, vaultAddr)
+				s.Require().NoError(err, "should successfully get vault")
+				vault.Paused = true
+				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vault), "should successfully pause vault")
+
+				s.Require().NoError(
+					s.k.BankKeeper.SendCoins(markertypes.WithBypass(s.ctx), vaultAddr, s.adminAddr, sdk.NewCoins(*minted)),
+					"should drain escrowed shares to force the refund to fail",
+				)
+				return ownerAddr, id
+			},
+			posthandler: func(ownerAddr sdk.AccAddress, reqID uint64, shareDenom string, vaultAddr sdk.AccAddress, principalAddress sdk.AccAddress, shares sdk.Coin, testBlockTime time.Time) {
+				s.assertBalance(ownerAddr, shareDenom, math.ZeroInt())
+				s.Require().Equal(1, s.countPendingSwapOuts(), "request should stay queued when the paused-vault refund fails")
+				s.Assert().Empty(s.ctx.EventManager().Events(), "no events should be committed when the refund cache context is discarded")
+			},
+			batchSize: keeper.MaxSwapOutBatchSize,
+		},
+		{
 			name: "request for non-existent vault is skipped and dequeued",
 			setup: func(shareDenom string, vaultAddr sdk.AccAddress, shares sdk.Coin) (sdk.AccAddress, uint64) {
 				ownerAddr := s.CreateAndFundAccount(sdk.Coin{})

--- a/keeper/payout_test.go
+++ b/keeper/payout_test.go
@@ -260,13 +260,7 @@ func (s *TestSuite) TestKeeper_ProcessPendingSwapOuts() {
 				s.assertBalance(ownerAddr, shareDenom, shares.Amount)
 				reason := types.RefundReasonRecipientMissingAttributes
 
-				var entries []types.PendingSwapOut
-				err := s.k.PendingSwapOutQueue.Walk(s.ctx, func(_ int64, _ uint64, _ sdk.AccAddress, req types.PendingSwapOut) (bool, error) {
-					entries = append(entries, req)
-					return false, nil
-				})
-				s.Require().NoError(err, "walking the queue should not error")
-				s.Require().Empty(entries, "queue should be empty after a failed payout is refunded")
+				s.Require().Zero(s.countPendingSwapOuts(), "queue should be empty after a failed payout is refunded")
 
 				expectedEvents := sdk.Events{}
 				expectedEvents = append(expectedEvents, createSendCoinEvents(vaultAddr.String(), ownerAddr.String(), shares.String())...)
@@ -360,6 +354,49 @@ func (s *TestSuite) TestKeeper_ProcessPendingSwapOuts() {
 			batchSize: keeper.MaxSwapOutBatchSize,
 		},
 		{
+			name: "due request for paused vault is dequeued and refunded",
+			setup: func(shareDenom string, vaultAddr sdk.AccAddress, shares sdk.Coin) (sdk.AccAddress, uint64) {
+				ownerAddr := s.CreateAndFundAccount(assets)
+				vault := s.setupBaseVault(underlyingDenom, shareDenom)
+
+				minted, err := s.k.SwapIn(s.ctx, vaultAddr, ownerAddr, assets)
+				s.Require().NoError(err, "should successfully swap in assets")
+				s.Require().NoError(s.k.BankKeeper.SendCoins(s.ctx, ownerAddr, vault.GetAddress(), sdk.NewCoins(*minted)), "should escrow shares into vault account")
+
+				req := types.PendingSwapOut{
+					Owner:        ownerAddr.String(),
+					VaultAddress: vaultAddr.String(),
+					RedeemDenom:  underlyingDenom,
+					Shares:       *minted,
+				}
+				id, err := s.k.PendingSwapOutQueue.Enqueue(s.ctx, duePayoutTime, &req)
+				s.Require().NoError(err, "should successfully enqueue request")
+
+				vault, err = s.k.GetVault(s.ctx, vaultAddr)
+				s.Require().NoError(err, "should successfully get vault")
+				vault.Paused = true
+				s.Require().NoError(s.k.SetVaultAccount(s.ctx, vault), "should successfully pause vault")
+				return ownerAddr, id
+			},
+			posthandler: func(ownerAddr sdk.AccAddress, reqID uint64, shareDenom string, vaultAddr sdk.AccAddress, principalAddress sdk.AccAddress, shares sdk.Coin, testBlockTime time.Time) {
+				s.assertBalance(ownerAddr, shareDenom, shares.Amount)
+				s.assertBalance(vaultAddr, shareDenom, math.ZeroInt())
+				s.Require().Zero(s.countPendingSwapOuts(), "queue should be empty after the paused-vault request is refunded")
+
+				expectedEvents := sdk.Events{}
+				expectedEvents = append(expectedEvents, createSendCoinEvents(vaultAddr.String(), ownerAddr.String(), shares.String())...)
+				refundEvent, err := sdk.TypedEventToEvent(types.NewEventSwapOutRefunded(vaultAddr.String(), ownerAddr.String(), shares, reqID, types.RefundReasonVaultPaused))
+				s.Require().NoError(err, "should not error converting typed EventSwapOutRefunded")
+				expectedEvents = append(expectedEvents, refundEvent)
+				s.Assert().Equal(
+					normalizeEvents(expectedEvents),
+					normalizeEvents(s.ctx.EventManager().Events()),
+					"a single EventSwapOutRefunded with reason %s should be emitted", types.RefundReasonVaultPaused,
+				)
+			},
+			batchSize: keeper.MaxSwapOutBatchSize,
+		},
+		{
 			name: "request for non-existent vault is skipped and dequeued",
 			setup: func(shareDenom string, vaultAddr sdk.AccAddress, shares sdk.Coin) (sdk.AccAddress, uint64) {
 				ownerAddr := s.CreateAndFundAccount(sdk.Coin{})
@@ -374,13 +411,7 @@ func (s *TestSuite) TestKeeper_ProcessPendingSwapOuts() {
 				return ownerAddr, id
 			},
 			posthandler: func(ownerAddr sdk.AccAddress, reqID uint64, shareDenom string, vaultAddr sdk.AccAddress, principalAddress sdk.AccAddress, shares sdk.Coin, testBlockTime time.Time) {
-				var entries []types.PendingSwapOut
-				err := s.k.PendingSwapOutQueue.Walk(s.ctx, func(_ int64, _ uint64, _ sdk.AccAddress, req types.PendingSwapOut) (bool, error) {
-					entries = append(entries, req)
-					return false, nil
-				})
-				s.Require().NoError(err, "walking the queue should not error")
-				s.Require().Empty(entries, "queue should be empty after processing the non-existent vault request")
+				s.Require().Zero(s.countPendingSwapOuts(), "queue should be empty after processing the non-existent vault request")
 			},
 			batchSize: keeper.MaxSwapOutBatchSize,
 		},
@@ -419,6 +450,61 @@ func (s *TestSuite) TestKeeper_ProcessPendingSwapOuts() {
 	}
 }
 
+func (s *TestSuite) TestKeeper_ProcessPendingSwapOuts_PausedFrontSharesBatchBudget() {
+	testBlockTime := time.Now().UTC()
+	duePayoutTime := testBlockTime.Add(-1 * time.Hour).Unix()
+	expeditedTime := int64(0)
+
+	s.SetupTest()
+	s.ctx = s.ctx.WithBlockTime(testBlockTime)
+
+	enqueueEscrowedSwapOut := func(underlyingDenom, shareDenom string, pendingTime int64) (ownerAddr sdk.AccAddress, assets, minted sdk.Coin) {
+		vaultAddr := types.GetVaultAddress(shareDenom)
+		assets = sdk.NewInt64Coin(underlyingDenom, 50)
+		ownerAddr = s.CreateAndFundAccount(assets)
+		vault := s.setupBaseVault(underlyingDenom, shareDenom)
+
+		mintedShares, err := s.k.SwapIn(s.ctx, vaultAddr, ownerAddr, assets)
+		s.Require().NoError(err, "should swap in assets for share denom %s", shareDenom)
+		s.Require().NoError(
+			s.k.BankKeeper.SendCoins(s.ctx, ownerAddr, vault.GetAddress(), sdk.NewCoins(*mintedShares)),
+			"should escrow shares into vault account for share denom %s", shareDenom,
+		)
+
+		req := types.PendingSwapOut{
+			Owner:        ownerAddr.String(),
+			VaultAddress: vaultAddr.String(),
+			RedeemDenom:  underlyingDenom,
+			Shares:       *mintedShares,
+		}
+		_, err = s.k.PendingSwapOutQueue.Enqueue(s.ctx, pendingTime, &req)
+		s.Require().NoError(err, "should enqueue swap out for share denom %s at time %d", shareDenom, pendingTime)
+		return ownerAddr, assets, *mintedShares
+	}
+
+	pausedShareDenom := "vsharefrontpaused"
+	activeShareDenom := "vsharebackactive"
+	pausedOwner, _, pausedShares := enqueueEscrowedSwapOut("pausedylds", pausedShareDenom, expeditedTime)
+	activeOwner, activeAssets, _ := enqueueEscrowedSwapOut("activeylds", activeShareDenom, duePayoutTime)
+
+	pausedVaultAddr := types.GetVaultAddress(pausedShareDenom)
+	pausedVault, err := s.k.GetVault(s.ctx, pausedVaultAddr)
+	s.Require().NoError(err, "should get the vault camped at the front of the queue")
+	pausedVault.Paused = true
+	s.Require().NoError(s.k.SetVaultAccount(s.ctx, pausedVault), "should pause the vault camped at the front of the queue")
+
+	s.Require().NoError(s.k.TestAccessor_processPendingSwapOuts(s.T(), s.ctx, 1), "first block with batch size 1 should not error")
+
+	s.assertBalance(pausedOwner, pausedShareDenom, pausedShares.Amount)
+	s.assertBalance(activeOwner, activeAssets.Denom, math.ZeroInt())
+	s.Require().Equal(1, s.countPendingSwapOuts(), "the paused entry should consume the batch budget and be refunded, leaving only the active request queued")
+
+	s.Require().NoError(s.k.TestAccessor_processPendingSwapOuts(s.T(), s.ctx, 1), "second block with batch size 1 should not error")
+
+	s.assertBalance(activeOwner, activeAssets.Denom, activeAssets.Amount)
+	s.Require().Zero(s.countPendingSwapOuts(), "the active request should be paid out once the paused entry no longer camps at the queue front")
+}
+
 func (s *TestSuite) TestKeeper_ProcessSwapOutJobs() {
 	underlyingDenom := "ylds"
 	assets := sdk.NewInt64Coin(underlyingDenom, 50)
@@ -432,7 +518,7 @@ func (s *TestSuite) TestKeeper_ProcessSwapOutJobs() {
 		posthandler func(ownerAddr sdk.AccAddress, reqID uint64, shareDenom string, vaultAddr sdk.AccAddress, mintedShares sdk.Coin)
 	}{
 		{
-			name: "request is skipped if vault becomes paused after collection",
+			name: "request is dequeued and refunded if vault becomes paused after collection",
 			setup: func(shareDenom string, vaultAddr sdk.AccAddress) (sdk.AccAddress, sdk.Coin, uint64, types.PendingSwapOut) {
 				ownerAddr := s.CreateAndFundAccount(assets)
 				vault := s.setupBaseVault(underlyingDenom, shareDenom)
@@ -465,17 +551,22 @@ func (s *TestSuite) TestKeeper_ProcessSwapOutJobs() {
 				s.k.TestAccessor_processSwapOutJobs(s.T(), s.ctx, jobs)
 			},
 			posthandler: func(ownerAddr sdk.AccAddress, reqID uint64, shareDenom string, vaultAddr sdk.AccAddress, mintedShares sdk.Coin) {
-				var entries []uint64
-				err := s.k.PendingSwapOutQueue.Walk(s.ctx, func(_ int64, id uint64, _ sdk.AccAddress, _ types.PendingSwapOut) (bool, error) {
-					entries = append(entries, id)
-					return false, nil
-				})
-				s.Require().NoError(err, "walking the queue should not error")
-				s.Require().Len(entries, 1, "queue should not be empty because the vault was paused")
+				s.Require().Zero(s.countPendingSwapOuts(), "queue should be empty after the paused-vault request is refunded")
 
 				s.assertBalance(ownerAddr, underlyingDenom, math.ZeroInt())
-				s.assertBalance(vaultAddr, mintedShares.Denom, mintedShares.Amount)
-				s.Assert().Empty(s.ctx.EventManager().Events(), "no events should be emitted for a job skipped due to pause")
+				s.assertBalance(ownerAddr, mintedShares.Denom, mintedShares.Amount)
+				s.assertBalance(vaultAddr, mintedShares.Denom, math.ZeroInt())
+
+				expectedEvents := sdk.Events{}
+				expectedEvents = append(expectedEvents, createSendCoinEvents(vaultAddr.String(), ownerAddr.String(), mintedShares.String())...)
+				refundEvent, err := sdk.TypedEventToEvent(types.NewEventSwapOutRefunded(vaultAddr.String(), ownerAddr.String(), mintedShares, reqID, types.RefundReasonVaultPaused))
+				s.Require().NoError(err, "should not error converting typed EventSwapOutRefunded")
+				expectedEvents = append(expectedEvents, refundEvent)
+				s.Assert().Equal(
+					normalizeEvents(expectedEvents),
+					normalizeEvents(s.ctx.EventManager().Events()),
+					"a single EventSwapOutRefunded with reason %s should be emitted", types.RefundReasonVaultPaused,
+				)
 			},
 		},
 	}

--- a/keeper/reconcile.go
+++ b/keeper/reconcile.go
@@ -534,19 +534,27 @@ func (k Keeper) CalculateVaultTotalAssets(ctx sdk.Context, vault *types.VaultAcc
 
 // handleVaultInterestTimeouts checks vaults with expired interest periods and reconciles or disables them.
 // It uses a safe "collect-then-mutate" pattern to comply with the SDK iterator contract.
-func (k Keeper) handleVaultInterestTimeouts(ctx sdk.Context) error {
+//
+// At most limit due entries are visited per invocation so block time stays bounded regardless
+// of backlog size; entries beyond the budget remain due and are handled in subsequent blocks.
+// Paused vaults count against the budget but stay queued until they are unpaused.
+func (k Keeper) handleVaultInterestTimeouts(ctx sdk.Context, limit int) error {
 	now := ctx.BlockTime().Unix()
 
 	var keysToProcess []collections.Pair[uint64, sdk.AccAddress]
 	var depleted []*types.VaultAccount
 
+	visited := 0
 	err := k.PayoutTimeoutQueue.WalkDue(ctx, now, func(timeout uint64, addr sdk.AccAddress) (bool, error) {
-		key := collections.Join(timeout, addr)
+		if visited == limit {
+			return true, nil
+		}
+		visited++
 		vault, ok := k.tryGetVault(ctx, addr)
 		if ok && vault.Paused {
 			return false, nil
 		}
-		keysToProcess = append(keysToProcess, key)
+		keysToProcess = append(keysToProcess, collections.Join(timeout, addr))
 		return false, nil
 	})
 	if err != nil {
@@ -644,13 +652,21 @@ func (k Keeper) tryGetVault(ctx sdk.Context, addr sdk.AccAddress) (*types.VaultA
 // handleReconciledVaults processes vaults from the payout verification queue using a safe
 // "collect-then-mutate" pattern.
 //
-// It first collects keys for all non-paused vaults. It then iterates the collected keys, removing
-// each from the set before partitioning them into payable vs depleted groups.
-func (k Keeper) handleReconciledVaults(ctx sdk.Context) error {
+// It first collects keys for non-paused vaults, visiting at most limit set entries per
+// invocation so block time stays bounded; entries beyond the budget stay in the set for
+// subsequent blocks and paused vaults count against the budget but remain in the set.
+// It then iterates the collected keys, removing each from the set before partitioning
+// them into payable vs depleted groups.
+func (k Keeper) handleReconciledVaults(ctx sdk.Context, limit int) error {
 	var keysToProcess []sdk.AccAddress
 	var vaultsToProcess []*types.VaultAccount
 
+	visited := 0
 	err := k.PayoutVerificationSet.Walk(ctx, nil, func(addr sdk.AccAddress) (bool, error) {
+		if visited == limit {
+			return true, nil
+		}
+		visited++
 		v, ok := k.tryGetVault(ctx, addr)
 		if ok && v.Paused {
 			return false, nil
@@ -722,18 +738,26 @@ func (k Keeper) handleDepletedVaults(ctx sdk.Context, failedPayouts []*types.Vau
 
 // handleVaultFeeTimeouts checks vaults with expired fee periods and reconciles them.
 // It uses a safe "collect-then-mutate" pattern to comply with the SDK iterator contract.
-func (k Keeper) handleVaultFeeTimeouts(ctx sdk.Context) error {
+//
+// At most limit due entries are visited per invocation so block time stays bounded regardless
+// of backlog size; entries beyond the budget remain due and are handled in subsequent blocks.
+// Paused vaults count against the budget but stay queued until they are unpaused.
+func (k Keeper) handleVaultFeeTimeouts(ctx sdk.Context, limit int) error {
 	now := ctx.BlockTime().Unix()
 
 	var keysToProcess []collections.Pair[uint64, sdk.AccAddress]
 
+	visited := 0
 	err := k.FeeTimeoutQueue.WalkDue(ctx, now, func(timeout uint64, addr sdk.AccAddress) (bool, error) {
-		key := collections.Join(timeout, addr)
+		if visited == limit {
+			return true, nil
+		}
+		visited++
 		vault, ok := k.tryGetVault(ctx, addr)
 		if ok && vault.Paused {
 			return false, nil
 		}
-		keysToProcess = append(keysToProcess, key)
+		keysToProcess = append(keysToProcess, collections.Join(timeout, addr))
 		return false, nil
 	})
 	if err != nil {

--- a/keeper/reconcile.go
+++ b/keeper/reconcile.go
@@ -534,10 +534,7 @@ func (k Keeper) CalculateVaultTotalAssets(ctx sdk.Context, vault *types.VaultAcc
 
 // handleVaultInterestTimeouts checks vaults with expired interest periods and reconciles or disables them.
 // It uses a safe "collect-then-mutate" pattern to comply with the SDK iterator contract.
-//
-// At most limit due entries are visited per invocation so block time stays bounded regardless
-// of backlog size; entries beyond the budget remain due and are handled in subsequent blocks.
-// Paused vaults count against the budget but stay queued until they are unpaused.
+// At most limit due entries are visited per block; the remainder stays queued for later blocks.
 func (k Keeper) handleVaultInterestTimeouts(ctx sdk.Context, limit int) error {
 	now := ctx.BlockTime().Unix()
 
@@ -652,11 +649,9 @@ func (k Keeper) tryGetVault(ctx sdk.Context, addr sdk.AccAddress) (*types.VaultA
 // handleReconciledVaults processes vaults from the payout verification queue using a safe
 // "collect-then-mutate" pattern.
 //
-// It first collects keys for non-paused vaults, visiting at most limit set entries per
-// invocation so block time stays bounded; entries beyond the budget stay in the set for
-// subsequent blocks and paused vaults count against the budget but remain in the set.
-// It then iterates the collected keys, removing each from the set before partitioning
-// them into payable vs depleted groups.
+// It first collects keys for non-paused vaults, visiting at most limit entries per block and
+// leaving the remainder in the set for later blocks. It then iterates the collected keys,
+// removing each from the set before partitioning them into payable vs depleted groups.
 func (k Keeper) handleReconciledVaults(ctx sdk.Context, limit int) error {
 	var keysToProcess []sdk.AccAddress
 	var vaultsToProcess []*types.VaultAccount
@@ -738,10 +733,7 @@ func (k Keeper) handleDepletedVaults(ctx sdk.Context, failedPayouts []*types.Vau
 
 // handleVaultFeeTimeouts checks vaults with expired fee periods and reconciles them.
 // It uses a safe "collect-then-mutate" pattern to comply with the SDK iterator contract.
-//
-// At most limit due entries are visited per invocation so block time stays bounded regardless
-// of backlog size; entries beyond the budget remain due and are handled in subsequent blocks.
-// Paused vaults count against the budget but stay queued until they are unpaused.
+// At most limit due entries are visited per block; the remainder stays queued for later blocks.
 func (k Keeper) handleVaultFeeTimeouts(ctx sdk.Context, limit int) error {
 	now := ctx.BlockTime().Unix()
 

--- a/keeper/reconcile_test.go
+++ b/keeper/reconcile_test.go
@@ -2718,41 +2718,44 @@ func (s *TestSuite) TestReconcileVault_BootstrapFeePeriod() {
 	s.Require().Equal(testBlockTime.Unix(), v.FeePeriodStart, "FeePeriodStart should be set to current block time")
 }
 
+// createVaultWithDueInterestTimeout creates a funded vault with a due PayoutTimeoutQueue
+// entry at dueTime, optionally paused, for exercising the per-block visit budget.
+func (s *TestSuite) createVaultWithDueInterestTimeout(info VaultInfo, dueTime int64, paused bool) {
+	s.requireAddFinalizeAndActivateMarker(info.underlying, s.adminAddr)
+	_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+		Admin:           s.adminAddr.String(),
+		ShareDenom:      info.shareDenom,
+		UnderlyingAsset: info.underlying.Denom,
+	})
+	s.Require().NoError(err, "CreateVault should not error for share denom %s", info.shareDenom)
+
+	vault, err := s.k.GetVault(s.ctx, info.vaultAddr)
+	s.Require().NoError(err, "GetVault should not error for vault %s", info.vaultAddr)
+	vault.CurrentInterestRate = "0.1"
+	vault.DesiredInterestRate = "0.1"
+	vault.PeriodStart = dueTime
+	vault.PeriodTimeout = dueTime
+	vault.Paused = paused
+	s.k.AuthKeeper.SetAccount(s.ctx, vault)
+
+	s.Require().NoError(
+		FundAccount(s.ctx, s.simApp.BankKeeper, info.vaultAddr, sdk.NewCoins(sdk.NewInt64Coin(info.underlying.Denom, 1_000_000))),
+		"funding reserves should not error for vault %s", info.vaultAddr,
+	)
+	s.Require().NoError(
+		FundAccount(s.ctx, s.simApp.BankKeeper, markertypes.MustGetMarkerAddress(info.shareDenom), sdk.NewCoins(info.underlying)),
+		"funding principal should not error for marker %s", info.shareDenom,
+	)
+	s.Require().NoError(
+		s.k.PayoutTimeoutQueue.Enqueue(s.ctx, dueTime, info.vaultAddr),
+		"enqueuing due payout timeout should not error for vault %s", info.vaultAddr,
+	)
+}
+
 func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts_PerBlockVisitBudget() {
 	testBlockTime := time.Now().UTC()
 	dueTime := testBlockTime.Add(-1 * time.Hour).Unix()
 	infos := []VaultInfo{NewVaultInfo(1), NewVaultInfo(2), NewVaultInfo(3)}
-
-	enqueueDueInterestTimeout := func(info VaultInfo) {
-		s.requireAddFinalizeAndActivateMarker(info.underlying, s.adminAddr)
-		_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
-			Admin:           s.adminAddr.String(),
-			ShareDenom:      info.shareDenom,
-			UnderlyingAsset: info.underlying.Denom,
-		})
-		s.Require().NoError(err, "CreateVault should not error for share denom %s", info.shareDenom)
-
-		vault, err := s.k.GetVault(s.ctx, info.vaultAddr)
-		s.Require().NoError(err, "GetVault should not error for vault %s", info.vaultAddr)
-		vault.CurrentInterestRate = "0.1"
-		vault.DesiredInterestRate = "0.1"
-		vault.PeriodStart = dueTime
-		vault.PeriodTimeout = dueTime
-		s.k.AuthKeeper.SetAccount(s.ctx, vault)
-
-		s.Require().NoError(
-			FundAccount(s.ctx, s.simApp.BankKeeper, info.vaultAddr, sdk.NewCoins(sdk.NewInt64Coin(info.underlying.Denom, 1_000_000))),
-			"funding reserves should not error for vault %s", info.vaultAddr,
-		)
-		s.Require().NoError(
-			FundAccount(s.ctx, s.simApp.BankKeeper, markertypes.MustGetMarkerAddress(info.shareDenom), sdk.NewCoins(info.underlying)),
-			"funding principal should not error for marker %s", info.shareDenom,
-		)
-		s.Require().NoError(
-			s.k.PayoutTimeoutQueue.Enqueue(s.ctx, dueTime, info.vaultAddr),
-			"enqueuing due payout timeout should not error for vault %s", info.vaultAddr,
-		)
-	}
 
 	tests := []struct {
 		name                string
@@ -2781,7 +2784,7 @@ func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts_PerBlockVisitBudget()
 			s.SetupTest()
 			s.ctx = s.ctx.WithBlockTime(testBlockTime)
 			for _, info := range infos {
-				enqueueDueInterestTimeout(info)
+				s.createVaultWithDueInterestTimeout(info, dueTime, false)
 			}
 
 			for block, expectedDue := range tc.expectedDuePerBlock {
@@ -2792,6 +2795,49 @@ func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts_PerBlockVisitBudget()
 					"due interest timeout backlog mismatch after pass %d with limit %d", block+1, tc.limit,
 				)
 			}
+		})
+	}
+}
+
+func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts_PausedVaultsConsumeVisitBudget() {
+	testBlockTime := time.Now().UTC()
+	pausedDueTime := testBlockTime.Add(-2 * time.Hour).Unix()
+	activeDueTime := testBlockTime.Add(-1 * time.Hour).Unix()
+	pausedInfos := []VaultInfo{NewVaultInfo(1), NewVaultInfo(2)}
+	activeInfo := NewVaultInfo(3)
+
+	tests := []struct {
+		name        string
+		limit       int
+		expectedDue int
+	}{
+		{
+			name:        "budget filled by paused vaults at the queue front starves the active vault",
+			limit:       2,
+			expectedDue: 3,
+		},
+		{
+			name:        "budget larger than the paused front reaches and processes the active vault",
+			limit:       3,
+			expectedDue: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+			s.ctx = s.ctx.WithBlockTime(testBlockTime)
+			for _, info := range pausedInfos {
+				s.createVaultWithDueInterestTimeout(info, pausedDueTime, true)
+			}
+			s.createVaultWithDueInterestTimeout(activeInfo, activeDueTime, false)
+
+			err := s.k.TestAccessor_handleVaultInterestTimeouts(s.T(), s.ctx, tc.limit)
+			s.Require().NoError(err, "handleVaultInterestTimeouts should not error with limit %d", tc.limit)
+			s.Require().Equal(
+				tc.expectedDue, s.countDuePayoutTimeouts(testBlockTime.Unix()),
+				"due backlog mismatch with limit %d: paused entries stay queued and count against the budget", tc.limit,
+			)
 		})
 	}
 }

--- a/keeper/reconcile_test.go
+++ b/keeper/reconcile_test.go
@@ -727,7 +727,7 @@ func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts() {
 		s.Run(tc.name, func() {
 			s.SetupTest()
 			tc.setup()
-			err := s.k.TestAccessor_handleVaultInterestTimeouts(s.T(), s.ctx)
+			err := s.k.TestAccessor_handleVaultInterestTimeouts(s.T(), s.ctx, keeper.MaxInterestTimeoutsPerBlock)
 			s.Require().NoError(err, "test case %s: handleVaultInterestTimeouts should not error", tc.name)
 			if tc.expectRate != "" {
 				vault, err := s.k.GetVault(s.ctx, vaultAddr)
@@ -862,7 +862,7 @@ func (s *TestSuite) TestKeeper_HandleReconciledVaults() {
 			}
 			s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
 
-			err := s.k.TestAccessor_handleReconciledVaults(s.T(), s.ctx)
+			err := s.k.TestAccessor_handleReconciledVaults(s.T(), s.ctx, keeper.MaxPayoutVerificationsPerBlock)
 
 			if tc.expectErr {
 				s.Require().Error(err, "test case %s: expected error from handleReconciledVaults", tc.name)
@@ -2237,7 +2237,7 @@ func (s *TestSuite) TestKeeper_HandleVaultFeeTimeouts() {
 
 	s.Require().NoError(s.k.FeeTimeoutQueue.Enqueue(s.ctx, twoMonthsAgo.Unix(), vaultAddr), "failed to enqueue vault in FeeTimeoutQueue")
 
-	err := s.k.TestAccessor_handleVaultFeeTimeouts(s.T(), s.ctx)
+	err := s.k.TestAccessor_handleVaultFeeTimeouts(s.T(), s.ctx, keeper.MaxFeeTimeoutsPerBlock)
 	s.Require().NoError(err, "handleVaultFeeTimeouts should succeed")
 
 	provlabsAddr, err := s.k.GetAUMFeeAddress(s.ctx)
@@ -2555,7 +2555,7 @@ func (s *TestSuite) TestKeeper_HandleVaultFeeTimeouts_RetryOnFailure() {
 	// We don't fund the marker with 'other' denom here because that would make GetTVVInUnderlyingAsset fail.
 	// Instead, we rely on the missing NAV for 'other' during fee payment conversion in PerformVaultFeeTransfer.
 
-	err := s.k.TestAccessor_handleVaultFeeTimeouts(s.T(), s.ctx)
+	err := s.k.TestAccessor_handleVaultFeeTimeouts(s.T(), s.ctx, keeper.MaxFeeTimeoutsPerBlock)
 	s.Require().NoError(err, "handleVaultFeeTimeouts should not return error even if a vault fails")
 
 	// Verify the vault is RE-ENQUEUED with a NEW timeout because we don't continue on PerformVaultFeeTransfer failure
@@ -2605,7 +2605,7 @@ func (s *TestSuite) TestKeeper_HandleVaultFeeTimeouts_Success() {
 	s.Require().NoError(s.k.FeeTimeoutQueue.Enqueue(s.ctx, twoMonthsAgo.Unix(), vaultAddr), "failed to enqueue vault in FeeTimeoutQueue")
 
 	// Call handleVaultFeeTimeouts. Success this time (uylds.fcc doesn't need NAV)
-	err := s.k.TestAccessor_handleVaultFeeTimeouts(s.T(), s.ctx)
+	err := s.k.TestAccessor_handleVaultFeeTimeouts(s.T(), s.ctx, keeper.MaxFeeTimeoutsPerBlock)
 	s.Require().NoError(err, "handleVaultFeeTimeouts should succeed")
 
 	// Verify the vault is DEQUEUED from old timeout and ENQUEUED with new timeout
@@ -2665,7 +2665,7 @@ func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts_RetryOnFailure() {
 	// This simulates a transient error without making the VaultAccount itself invalid.
 	s.FundMarker(shareDenom, sdk.NewCoins(sdk.NewInt64Coin(paymentDenom, 1000)))
 
-	err := s.k.TestAccessor_handleVaultInterestTimeouts(s.T(), s.ctx)
+	err := s.k.TestAccessor_handleVaultInterestTimeouts(s.T(), s.ctx, keeper.MaxInterestTimeoutsPerBlock)
 	s.Require().NoError(err, "handleVaultInterestTimeouts should not return error")
 
 	// Verify the vault is RE-ENQUEUED with a NEW timeout because we reschedule on failure
@@ -2716,4 +2716,190 @@ func (s *TestSuite) TestReconcileVault_BootstrapFeePeriod() {
 	s.Require().NoError(err)
 	s.Require().NotEqual(int64(0), v.FeePeriodStart, "FeePeriodStart should have been bootstrapped")
 	s.Require().Equal(testBlockTime.Unix(), v.FeePeriodStart, "FeePeriodStart should be set to current block time")
+}
+
+func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts_PerBlockVisitBudget() {
+	testBlockTime := time.Now().UTC()
+	dueTime := testBlockTime.Add(-1 * time.Hour).Unix()
+	infos := []VaultInfo{NewVaultInfo(1), NewVaultInfo(2), NewVaultInfo(3)}
+
+	enqueueDueInterestTimeout := func(info VaultInfo) {
+		s.requireAddFinalizeAndActivateMarker(info.underlying, s.adminAddr)
+		_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+			Admin:           s.adminAddr.String(),
+			ShareDenom:      info.shareDenom,
+			UnderlyingAsset: info.underlying.Denom,
+		})
+		s.Require().NoError(err, "CreateVault should not error for share denom %s", info.shareDenom)
+
+		vault, err := s.k.GetVault(s.ctx, info.vaultAddr)
+		s.Require().NoError(err, "GetVault should not error for vault %s", info.vaultAddr)
+		vault.CurrentInterestRate = "0.1"
+		vault.DesiredInterestRate = "0.1"
+		vault.PeriodStart = dueTime
+		vault.PeriodTimeout = dueTime
+		s.k.AuthKeeper.SetAccount(s.ctx, vault)
+
+		s.Require().NoError(
+			FundAccount(s.ctx, s.simApp.BankKeeper, info.vaultAddr, sdk.NewCoins(sdk.NewInt64Coin(info.underlying.Denom, 1_000_000))),
+			"funding reserves should not error for vault %s", info.vaultAddr,
+		)
+		s.Require().NoError(
+			FundAccount(s.ctx, s.simApp.BankKeeper, markertypes.MustGetMarkerAddress(info.shareDenom), sdk.NewCoins(info.underlying)),
+			"funding principal should not error for marker %s", info.shareDenom,
+		)
+		s.Require().NoError(
+			s.k.PayoutTimeoutQueue.Enqueue(s.ctx, dueTime, info.vaultAddr),
+			"enqueuing due payout timeout should not error for vault %s", info.vaultAddr,
+		)
+	}
+
+	tests := []struct {
+		name                string
+		limit               int
+		expectedDuePerBlock []int
+	}{
+		{
+			name:                "zero budget visits nothing and leaves the backlog due",
+			limit:               0,
+			expectedDuePerBlock: []int{3, 3},
+		},
+		{
+			name:                "budget smaller than backlog drains it across blocks",
+			limit:               2,
+			expectedDuePerBlock: []int{1, 0},
+		},
+		{
+			name:                "budget larger than backlog drains it in one block",
+			limit:               keeper.MaxInterestTimeoutsPerBlock,
+			expectedDuePerBlock: []int{0, 0},
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+			s.ctx = s.ctx.WithBlockTime(testBlockTime)
+			for _, info := range infos {
+				enqueueDueInterestTimeout(info)
+			}
+
+			for block, expectedDue := range tc.expectedDuePerBlock {
+				err := s.k.TestAccessor_handleVaultInterestTimeouts(s.T(), s.ctx, tc.limit)
+				s.Require().NoError(err, "handleVaultInterestTimeouts should not error on pass %d with limit %d", block+1, tc.limit)
+				s.Require().Equal(
+					expectedDue, s.countDuePayoutTimeouts(testBlockTime.Unix()),
+					"due interest timeout backlog mismatch after pass %d with limit %d", block+1, tc.limit,
+				)
+			}
+		})
+	}
+}
+
+func (s *TestSuite) TestKeeper_HandleVaultFeeTimeouts_PerBlockVisitBudget() {
+	underlyingDenom := "underlying"
+	paymentDenom := "uylds.fcc"
+	underlying := sdk.NewInt64Coin(underlyingDenom, 1_000_000_000)
+
+	enqueueDueFeeTimeout := func(shareDenom string, dueTime int64) {
+		vault := s.CreateVaultWithParams(shareDenom, underlyingDenom, paymentDenom)
+		s.SetVaultRatesAndPeriod(vault, "0.0", "0.0", dueTime, dueTime)
+		s.setVaultNAV(vault, paymentDenom, sdk.NewInt64Coin(underlyingDenom, 1), 1)
+		s.FundMarker(shareDenom, sdk.NewCoins(underlying, sdk.NewInt64Coin(paymentDenom, 10_000_000)))
+		s.Require().NoError(
+			s.k.FeeTimeoutQueue.Enqueue(s.ctx, dueTime, vault.GetAddress()),
+			"enqueuing due fee timeout should not error for vault %s", vault.GetAddress(),
+		)
+	}
+
+	tests := []struct {
+		name                string
+		limit               int
+		expectedDuePerBlock []int
+	}{
+		{
+			name:                "zero budget visits nothing and leaves the backlog due",
+			limit:               0,
+			expectedDuePerBlock: []int{3, 3},
+		},
+		{
+			name:                "budget smaller than backlog drains it across blocks",
+			limit:               2,
+			expectedDuePerBlock: []int{1, 0},
+		},
+		{
+			name:                "budget larger than backlog drains it in one block",
+			limit:               keeper.MaxFeeTimeoutsPerBlock,
+			expectedDuePerBlock: []int{0, 0},
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+			now := s.ctx.BlockTime()
+			dueTime := now.Add(-60 * 24 * time.Hour).Unix()
+
+			s.requireAddFinalizeAndActivateMarker(underlying, s.adminAddr)
+			s.requireAddFinalizeAndActivateMarker(sdk.NewInt64Coin(paymentDenom, 1_000_000_000), s.adminAddr)
+			for i := 1; i <= 3; i++ {
+				enqueueDueFeeTimeout(fmt.Sprintf("feebudgetshares%d", i), dueTime)
+			}
+
+			for block, expectedDue := range tc.expectedDuePerBlock {
+				err := s.k.TestAccessor_handleVaultFeeTimeouts(s.T(), s.ctx, tc.limit)
+				s.Require().NoError(err, "handleVaultFeeTimeouts should not error on pass %d with limit %d", block+1, tc.limit)
+				s.Require().Equal(
+					expectedDue, s.countDueFeeTimeouts(now.Unix()),
+					"due fee timeout backlog mismatch after pass %d with limit %d", block+1, tc.limit,
+				)
+			}
+		})
+	}
+}
+
+func (s *TestSuite) TestKeeper_HandleReconciledVaults_PerBlockVisitBudget() {
+	testBlockTime := time.Now().UTC().Truncate(time.Second)
+	infos := []VaultInfo{NewVaultInfo(1), NewVaultInfo(2), NewVaultInfo(3)}
+
+	tests := []struct {
+		name                string
+		limit               int
+		expectedSetPerBlock []int
+	}{
+		{
+			name:                "zero budget visits nothing and leaves the set untouched",
+			limit:               0,
+			expectedSetPerBlock: []int{3, 3},
+		},
+		{
+			name:                "budget smaller than backlog drains the set across blocks",
+			limit:               2,
+			expectedSetPerBlock: []int{1, 0},
+		},
+		{
+			name:                "budget larger than backlog drains the set in one block",
+			limit:               keeper.MaxPayoutVerificationsPerBlock,
+			expectedSetPerBlock: []int{0, 0},
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+			s.ctx = s.ctx.WithBlockTime(testBlockTime)
+			for _, info := range infos {
+				createVaultWithInterest(s, info, "0.1", testBlockTime.Unix(), testBlockTime.Unix(), true, true)
+			}
+
+			for block, expectedRemaining := range tc.expectedSetPerBlock {
+				err := s.k.TestAccessor_handleReconciledVaults(s.T(), s.ctx, tc.limit)
+				s.Require().NoError(err, "handleReconciledVaults should not error on pass %d with limit %d", block+1, tc.limit)
+				s.Require().Equal(
+					expectedRemaining, s.countPayoutVerificationEntries(),
+					"payout verification set backlog mismatch after pass %d with limit %d", block+1, tc.limit,
+				)
+			}
+		})
+	}
 }

--- a/keeper/suite_test.go
+++ b/keeper/suite_test.go
@@ -143,9 +143,7 @@ func (s *TestSuite) assertInPayoutVerificationQueue(vaultAddr sdk.AccAddress, sh
 	s.Assert().Equal(shouldContain, isInQueue, "vault should be enqueued in payout verification queue at expected period start")
 }
 
-// countDuePayoutTimeouts returns the number of PayoutTimeoutQueue entries with a
-// timeout at or before now, so tests can assert how much of an interest-timeout
-// backlog remains after a capped ABCI pass.
+// countDuePayoutTimeouts returns the number of PayoutTimeoutQueue entries due at or before now.
 func (s *TestSuite) countDuePayoutTimeouts(now int64) int {
 	count := 0
 	err := s.k.PayoutTimeoutQueue.WalkDue(s.ctx, now, func(_ uint64, _ sdk.AccAddress) (bool, error) {
@@ -156,9 +154,7 @@ func (s *TestSuite) countDuePayoutTimeouts(now int64) int {
 	return count
 }
 
-// countDueFeeTimeouts returns the number of FeeTimeoutQueue entries with a timeout
-// at or before now, so tests can assert how much of a fee-timeout backlog remains
-// after a capped ABCI pass.
+// countDueFeeTimeouts returns the number of FeeTimeoutQueue entries due at or before now.
 func (s *TestSuite) countDueFeeTimeouts(now int64) int {
 	count := 0
 	err := s.k.FeeTimeoutQueue.WalkDue(s.ctx, now, func(_ uint64, _ sdk.AccAddress) (bool, error) {
@@ -169,9 +165,7 @@ func (s *TestSuite) countDueFeeTimeouts(now int64) int {
 	return count
 }
 
-// countPayoutVerificationEntries returns the number of vault addresses currently in
-// the PayoutVerificationSet, so tests can assert how much of a verification backlog
-// remains after a capped ABCI pass.
+// countPayoutVerificationEntries returns the number of entries in the PayoutVerificationSet.
 func (s *TestSuite) countPayoutVerificationEntries() int {
 	count := 0
 	err := s.k.PayoutVerificationSet.Walk(s.ctx, nil, func(_ sdk.AccAddress) (bool, error) {
@@ -182,8 +176,7 @@ func (s *TestSuite) countPayoutVerificationEntries() int {
 	return count
 }
 
-// countPendingSwapOuts returns the number of entries currently in the
-// PendingSwapOutQueue regardless of due time.
+// countPendingSwapOuts returns the number of entries in the PendingSwapOutQueue.
 func (s *TestSuite) countPendingSwapOuts() int {
 	count := 0
 	err := s.k.PendingSwapOutQueue.Walk(s.ctx, func(_ int64, _ uint64, _ sdk.AccAddress, _ types.PendingSwapOut) (bool, error) {

--- a/keeper/suite_test.go
+++ b/keeper/suite_test.go
@@ -143,6 +143,57 @@ func (s *TestSuite) assertInPayoutVerificationQueue(vaultAddr sdk.AccAddress, sh
 	s.Assert().Equal(shouldContain, isInQueue, "vault should be enqueued in payout verification queue at expected period start")
 }
 
+// countDuePayoutTimeouts returns the number of PayoutTimeoutQueue entries with a
+// timeout at or before now, so tests can assert how much of an interest-timeout
+// backlog remains after a capped ABCI pass.
+func (s *TestSuite) countDuePayoutTimeouts(now int64) int {
+	count := 0
+	err := s.k.PayoutTimeoutQueue.WalkDue(s.ctx, now, func(_ uint64, _ sdk.AccAddress) (bool, error) {
+		count++
+		return false, nil
+	})
+	s.Require().NoError(err, "walking due payout timeouts should not error")
+	return count
+}
+
+// countDueFeeTimeouts returns the number of FeeTimeoutQueue entries with a timeout
+// at or before now, so tests can assert how much of a fee-timeout backlog remains
+// after a capped ABCI pass.
+func (s *TestSuite) countDueFeeTimeouts(now int64) int {
+	count := 0
+	err := s.k.FeeTimeoutQueue.WalkDue(s.ctx, now, func(_ uint64, _ sdk.AccAddress) (bool, error) {
+		count++
+		return false, nil
+	})
+	s.Require().NoError(err, "walking due fee timeouts should not error")
+	return count
+}
+
+// countPayoutVerificationEntries returns the number of vault addresses currently in
+// the PayoutVerificationSet, so tests can assert how much of a verification backlog
+// remains after a capped ABCI pass.
+func (s *TestSuite) countPayoutVerificationEntries() int {
+	count := 0
+	err := s.k.PayoutVerificationSet.Walk(s.ctx, nil, func(_ sdk.AccAddress) (bool, error) {
+		count++
+		return false, nil
+	})
+	s.Require().NoError(err, "walking the payout verification set should not error")
+	return count
+}
+
+// countPendingSwapOuts returns the number of entries currently in the
+// PendingSwapOutQueue regardless of due time.
+func (s *TestSuite) countPendingSwapOuts() int {
+	count := 0
+	err := s.k.PendingSwapOutQueue.Walk(s.ctx, func(_ int64, _ uint64, _ sdk.AccAddress, _ types.PendingSwapOut) (bool, error) {
+		count++
+		return false, nil
+	})
+	s.Require().NoError(err, "walking the pending swap out queue should not error")
+	return count
+}
+
 // assertBalance asserts the balance for the provided address and denom equals
 // the expected amount.
 func (s *TestSuite) assertBalance(addr sdk.AccAddress, denom string, expectedAmt sdkmath.Int) {

--- a/spec/03_messages.md
+++ b/spec/03_messages.md
@@ -271,6 +271,8 @@ Admin or Asset Manager. Immediately processes a specific queued swap-out by ID.
 * **Request:** `MsgExpeditePendingSwapOutRequest { authority, request_id }`
 * **Response:** `MsgExpeditePendingSwapOutResponse {}`
 
+If the vault is paused when the expedited request comes due, the request is dequeued and refunded with `EventSwapOutRefunded{ reason = "vault_paused" }` instead of being paid out.
+
 ---
 
 ## PauseVault

--- a/spec/04_events.md
+++ b/spec/04_events.md
@@ -190,7 +190,7 @@ Swap-outs are **asynchronous** and complete in `EndBlocker` after the vault’s 
 
 **Operational tips**
 
-* If the vault is **paused** after your request, payout will not occur until unpaused; you may see `EventVaultPaused` followed by a future `EventVaultUnpaused`. Your request will ultimately end in `Completed` or `Refunded`.
+* If the vault is **paused** after your request, the request is not paid out. When the request comes due it is dequeued and refunded with `EventSwapOutRefunded{ reason = "vault_paused" }`; submit a new `MsgSwapOut` after the vault is unpaused.
 * For monitoring systems, index events by `request_id` and `vault_address`, and set a timeout expectation based on `withdrawal_delay_seconds` plus normal block timings.
 
 ---

--- a/spec/06_blocker.md
+++ b/spec/06_blocker.md
@@ -59,8 +59,8 @@ At the start of each block, the module reconciles interest for vaults whose **ti
 Processing model (safe “collect-then-mutate”):
 
 1. **Collect due entries** from `PayoutTimeoutQueue` with `timeout <= now`, visiting at most
-   `MaxInterestTimeoutsPerBlock` (currently 100) entries per block. Entries beyond the budget
-   remain due and are handled in subsequent blocks.
+   `MaxInterestTimeoutsPerBlock` (currently 100) entries per block; the remainder stays due
+   for later blocks.
 
    * Skip paused vaults (they count against the visit budget).
 2. **Dequeue** each collected `(timeout, vault)` before processing (prevents iterator invalidation).
@@ -83,8 +83,8 @@ Processing model (safe “collect-then-mutate”):
 Reconciles the 15 bps AUM technology fee for vaults whose fee timeout has elapsed.
 
 1. **Collect due entries** from `VaultFeeTimeoutQueue` with `timeout <= now`, visiting at most
-   `MaxFeeTimeoutsPerBlock` (currently 100) entries per block. Entries beyond the budget remain
-   due and are handled in subsequent blocks; paused vaults are skipped but count against the budget.
+   `MaxFeeTimeoutsPerBlock` (currently 100) entries per block; the remainder stays due for
+   later blocks and paused vaults count against the budget.
 2. **Dequeue** each collected entry from the main context before processing to ensure it is not retried if a transient error occurs.
 3. **Attempt Atomic Reconciliation** (via `atomicallyReconcileFee` using `CacheContext`):
    - **PerformVaultFeeTransfer**:
@@ -108,7 +108,7 @@ Ordering is intentional:
 
 At block end, the module fulfills **due swap-out requests**:
 
-To prevent a large queue from consuming excessive block time and memory, a maximum of `MaxSwapOutBatchSize` (currently 100) queue entries are visited per block. Every visited entry counts against the budget, including entries for paused vaults, so a queue front-loaded with unprocessable entries cannot extend the per-block iteration cost.
+To prevent a large queue from consuming excessive block time and memory, a maximum of `MaxSwapOutBatchSize` (currently 100) queue entries are visited per block. Every visited entry counts against the budget, including entries for paused vaults.
 
 1. **Collect due requests** from `PendingSwapOutQueue` with `dueTime <= now`, up to the batch budget.
 2. **Process each job** (see “Payout Processing Details”).
@@ -118,7 +118,7 @@ To prevent a large queue from consuming excessive block time and memory, a maxim
    - This ensures failures do not leave the vault in an inconsistent state and do not interfere with other jobs in the same block.
 
    * Missing vault → dequeue & skip (logged).
-   * Paused vault → dequeue & refund escrowed shares (`EventSwapOutRefunded{ reason = "vault_paused" }`), so paused entries cannot camp at the front of the queue and starve processable requests.
+   * Paused vault → atomically dequeue & refund escrowed shares (`EventSwapOutRefunded{ reason = "vault_paused" }`), so paused entries cannot camp at the front of the queue and starve processable requests. If the refund fails, nothing is committed and the request stays queued to retry on a later block.
 3. Errors:
 
    * **Recoverable** (e.g., insufficient funds, attribute check failure) → attempt **refund** and emit `EventSwapOutRefunded`.
@@ -130,7 +130,6 @@ This advances vaults from the **verification set**:
 
 1. **Collect keys** from `PayoutVerificationSet`, visiting at most `MaxPayoutVerificationsPerBlock`
    (currently 100) entries per block; skip paused vaults (they count against the visit budget).
-   Entries beyond the budget stay in the set for subsequent blocks.
 2. **Remove** each from the set (before processing).
 3. **Partition** into:
 
@@ -231,7 +230,7 @@ Submit `MsgSwapOut` → capture `request_id` → watch for `Completed` or `Refun
 ## Safety & Invariants
 
 * **Collect-then-mutate** iteration for all queues/sets (prevents iterator invalidation).
-* **Per-block visit budgets** on every queue/set walk (interest timeouts, fee timeouts, verification set, pending swap-outs) keep block execution time bounded regardless of backlog size.
+* **Per-block visit budgets** on every queue/set walk keep block execution time bounded regardless of backlog size.
 * **Dequeue before mutate** when processing due items; paused timeout/verification entries remain enqueued, while paused swap-out jobs are dequeued and refunded.
 * **Reconcile before supply-affecting ops** (e.g., swap-out payout) to keep NAV and TVV consistent.
 * **Flooring** in conversions prevents over-distribution or share inflation.

--- a/spec/06_blocker.md
+++ b/spec/06_blocker.md
@@ -58,9 +58,11 @@ At the start of each block, the module reconciles interest for vaults whose **ti
 
 Processing model (safe “collect-then-mutate”):
 
-1. **Collect due entries** from `PayoutTimeoutQueue` with `timeout <= now`.
+1. **Collect due entries** from `PayoutTimeoutQueue` with `timeout <= now`, visiting at most
+   `MaxInterestTimeoutsPerBlock` (currently 100) entries per block. Entries beyond the budget
+   remain due and are handled in subsequent blocks.
 
-   * Skip paused vaults.
+   * Skip paused vaults (they count against the visit budget).
 2. **Dequeue** each collected `(timeout, vault)` before processing (prevents iterator invalidation).
 3. **For each vault**:
 
@@ -80,7 +82,9 @@ Processing model (safe “collect-then-mutate”):
 
 Reconciles the 15 bps AUM technology fee for vaults whose fee timeout has elapsed.
 
-1. **Collect due entries** from `VaultFeeTimeoutQueue` with `timeout <= now`.
+1. **Collect due entries** from `VaultFeeTimeoutQueue` with `timeout <= now`, visiting at most
+   `MaxFeeTimeoutsPerBlock` (currently 100) entries per block. Entries beyond the budget remain
+   due and are handled in subsequent blocks; paused vaults are skipped but count against the budget.
 2. **Dequeue** each collected entry from the main context before processing to ensure it is not retried if a transient error occurs.
 3. **Attempt Atomic Reconciliation** (via `atomicallyReconcileFee` using `CacheContext`):
    - **PerformVaultFeeTransfer**:
@@ -104,11 +108,9 @@ Ordering is intentional:
 
 At block end, the module fulfills **due swap-out requests**:
 
-To prevent a large queue from consuming excessive block time and memory, a maximum of `MaxSwapOutBatchSize` (currently 100) requests are processed per block.
+To prevent a large queue from consuming excessive block time and memory, a maximum of `MaxSwapOutBatchSize` (currently 100) queue entries are visited per block. Every visited entry counts against the budget, including entries for paused vaults, so a queue front-loaded with unprocessable entries cannot extend the per-block iteration cost.
 
-1. **Collect due requests** from `PendingSwapOutQueue` with `dueTime <= now`.
-
-   * Skip paused vaults; they remain queued.
+1. **Collect due requests** from `PendingSwapOutQueue` with `dueTime <= now`, up to the batch budget.
 2. **Process each job** (see “Payout Processing Details”).
    - Each job is processed within its own **CacheContext**.
    - Failed payouts (recoverable) are rolled back atomically and the user is refunded.
@@ -116,7 +118,7 @@ To prevent a large queue from consuming excessive block time and memory, a maxim
    - This ensures failures do not leave the vault in an inconsistent state and do not interfere with other jobs in the same block.
 
    * Missing vault → dequeue & skip (logged).
-   * Paused vault → leave queued (not dequeued).
+   * Paused vault → dequeue & refund escrowed shares (`EventSwapOutRefunded{ reason = "vault_paused" }`), so paused entries cannot camp at the front of the queue and starve processable requests.
 3. Errors:
 
    * **Recoverable** (e.g., insufficient funds, attribute check failure) → attempt **refund** and emit `EventSwapOutRefunded`.
@@ -126,7 +128,9 @@ To prevent a large queue from consuming excessive block time and memory, a maxim
 
 This advances vaults from the **verification set**:
 
-1. **Collect keys** from `PayoutVerificationSet`; skip paused vaults.
+1. **Collect keys** from `PayoutVerificationSet`, visiting at most `MaxPayoutVerificationsPerBlock`
+   (currently 100) entries per block; skip paused vaults (they count against the visit budget).
+   Entries beyond the budget stay in the set for subsequent blocks.
 2. **Remove** each from the set (before processing).
 3. **Partition** into:
 
@@ -191,10 +195,11 @@ This advances vaults from the **verification set**:
 
 ## Paused Vault Behavior
 
-* **BeginBlocker / EndBlocker** both **skip** paused vaults:
+* **BeginBlocker / EndBlocker** do not process paused vaults:
 
-  * Interest is **not** reconciled while paused.
-  * Pending swap-outs remain **queued** (not dequeued) until unpaused.
+  * Interest is **not** reconciled while paused; timeout entries remain in place until unpaused.
+  * Pending swap-outs that come due while paused are **dequeued and refunded** with
+    `EventSwapOutRefunded{ reason = "vault_paused" }`; owners resubmit after unpause.
 * A paused vault freezes its value at the `PausedBalance` snapshot, so operations that would change that value are rejected:
 
   * **UpdateVaultNAV** is rejected — a NAV write would assert a price the frozen vault ignores until unpause.
@@ -203,7 +208,7 @@ This advances vaults from the **verification set**:
 * Admins can still:
 
   * **Deposit/Withdraw principal** (only while paused).
-  * **ExpeditePendingSwapOut** (has no effect until unpaused; job stays queued).
+  * **ExpeditePendingSwapOut** (an expedited job on a paused vault becomes due immediately and is refunded at the next block).
 
 ---
 
@@ -226,7 +231,8 @@ Submit `MsgSwapOut` → capture `request_id` → watch for `Completed` or `Refun
 ## Safety & Invariants
 
 * **Collect-then-mutate** iteration for all queues/sets (prevents iterator invalidation).
-* **Dequeue before mutate** when processing due items; skipped/paused items remain enqueued.
+* **Per-block visit budgets** on every queue/set walk (interest timeouts, fee timeouts, verification set, pending swap-outs) keep block execution time bounded regardless of backlog size.
+* **Dequeue before mutate** when processing due items; paused timeout/verification entries remain enqueued, while paused swap-out jobs are dequeued and refunded.
 * **Reconcile before supply-affecting ops** (e.g., swap-out payout) to keep NAV and TVV consistent.
 * **Flooring** in conversions prevents over-distribution or share inflation.
 * **Auto-pause on critical errors** creates a safe dead-stop until an admin resolves the issue.

--- a/types/events.go
+++ b/types/events.go
@@ -17,6 +17,7 @@ const (
 	RefundReasonRecipientInvalid           = "recipient_invalid"
 	RefundReasonNavNotFound                = "nav_not_found"
 	RefundReasonReconcileFailure           = "reconcile_failure"
+	RefundReasonVaultPaused                = "vault_paused"
 	RefundReasonUnknown                    = "unknown_error"
 )
 


### PR DESCRIPTION
closes: #225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-block visit/batch budgets for interest timeouts, AUM fee timeouts, payout verifications, and due swap-out processing.
* **Bug Fixes**
  * Paused-vault swap-out requests are now dequeued and refunded when due, preventing them from stalling or skipping order; swap-out refund events now include a dedicated `vault_paused` reason.
  * Updated pending/paused handling to ensure remaining due work is left for later blocks.
* **Documentation**
  * Refreshed swap-out/expedite guidance to reflect the new “dequeued and refunded when due” paused behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->