### PR TITLE
Split ExchangeQueryServer out of the ExchangeKeeper expected interface

### DIFF
--- a/.changelog/unreleased/improvements/247-split-exchange-query-server.md
+++ b/.changelog/unreleased/improvements/247-split-exchange-query-server.md
@@ -1,0 +1,1 @@
+* Split the expected `ExchangeKeeper` interface into a keeper part and a new `ExchangeQueryServer` dependency so consuming apps can wire the exchange keeper and `exchangekeeper.NewQueryServer` directly instead of writing an adapter struct [#247](https://github.com/provlabs/vault/issues/247).

--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -26,12 +26,13 @@ type Keeper struct {
 	AddressCodec address.Codec
 	authority    []byte
 
-	AuthKeeper     types.AccountKeeper
-	MarkerKeeper   types.MarkerKeeper
-	BankKeeper     types.BankKeeper
-	NameKeeper     types.NameKeeper
-	AttrKeeper     types.AttributeKeeper
-	ExchangeKeeper types.ExchangeKeeper
+	AuthKeeper          types.AccountKeeper
+	MarkerKeeper        types.MarkerKeeper
+	BankKeeper          types.BankKeeper
+	NameKeeper          types.NameKeeper
+	AttrKeeper          types.AttributeKeeper
+	ExchangeKeeper      types.ExchangeKeeper
+	ExchangeQueryServer types.ExchangeQueryServer
 
 	Params                collections.Item[types.Params]
 	Vaults                collections.Map[sdk.AccAddress, []byte]
@@ -55,6 +56,7 @@ func NewKeeper(
 	namekeeper types.NameKeeper,
 	attributekeeper types.AttributeKeeper,
 	exchangekeeper types.ExchangeKeeper,
+	exchangeQueryServer types.ExchangeQueryServer,
 ) *Keeper {
 	if _, err := addressCodec.BytesToString(authority); err != nil {
 		panic(fmt.Sprintf("invalid authority address %s: %s", authority, err))
@@ -81,6 +83,7 @@ func NewKeeper(
 		NameKeeper:            namekeeper,
 		AttrKeeper:            attributekeeper,
 		ExchangeKeeper:        exchangekeeper,
+		ExchangeQueryServer:   exchangeQueryServer,
 	}
 
 	schema, err := builder.Build()

--- a/keeper/query_server.go
+++ b/keeper/query_server.go
@@ -445,7 +445,7 @@ func (k queryServer) VaultPayments(goCtx context.Context, req *types.QueryVaultP
 		return nil, status.Errorf(codes.Internal, "failed to find vault account %s: %v", req.Id, err)
 	}
 
-	res, err := k.ExchangeKeeper.GetPaymentsWithTarget(goCtx, &exchange.QueryGetPaymentsWithTargetRequest{
+	res, err := k.ExchangeQueryServer.GetPaymentsWithTarget(goCtx, &exchange.QueryGetPaymentsWithTargetRequest{
 		Target:     vault.GetAddress().String(),
 		Pagination: req.Pagination,
 	})

--- a/module.go
+++ b/module.go
@@ -725,18 +725,19 @@ func init() {
 // ModuleInputs defines the inputs required to initialize the vault module.
 type ModuleInputs struct {
 	depinject.In
-	Config         *modulev1.Module
-	StoreService   store.KVStoreService
-	HeaderService  header.Service
-	EventService   event.Service
-	Codec          codec.Codec
-	AddressCodec   address.Codec
-	AuthKeeper     types.AccountKeeper
-	MarkerKeeper   types.MarkerKeeper
-	BankKeeper     types.BankKeeper
-	NameKeeper     types.NameKeeper
-	AttrKeeper     types.AttributeKeeper
-	ExchangeKeeper types.ExchangeKeeper
+	Config              *modulev1.Module
+	StoreService        store.KVStoreService
+	HeaderService       header.Service
+	EventService        event.Service
+	Codec               codec.Codec
+	AddressCodec        address.Codec
+	AuthKeeper          types.AccountKeeper
+	MarkerKeeper        types.MarkerKeeper
+	BankKeeper          types.BankKeeper
+	NameKeeper          types.NameKeeper
+	AttrKeeper          types.AttributeKeeper
+	ExchangeKeeper      types.ExchangeKeeper
+	ExchangeQueryServer types.ExchangeQueryServer
 }
 
 // ModuleOutputs defines the outputs of the vault module provider.
@@ -765,6 +766,7 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		in.NameKeeper,
 		in.AttrKeeper,
 		in.ExchangeKeeper,
+		in.ExchangeQueryServer,
 	)
 	m := NewAppModule(k, in.MarkerKeeper, in.BankKeeper, in.NameKeeper, in.AttrKeeper, in.AddressCodec)
 	return ModuleOutputs{Keeper: k, Module: m}

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -365,16 +365,9 @@ func ProvideExchangeKeeperStub() vaulttypes.ExchangeKeeper {
 	return exchangekeeper.Keeper{}
 }
 
-// ProvideExchangeQueryServerStub returns an empty types.ExchangeQueryServer
-// instance.
-//
-// This stub is used to satisfy dependency injection requirements when wiring
-// the Vault module in the app module configuration. The real query server is
+// ProvideExchangeQueryServerStub returns an empty types.ExchangeQueryServer to
+// satisfy dependency injection during app wiring. The real query server is
 // installed by RegisterProvenanceModules once the exchange keeper exists.
-//
-// This function should only be used during app setup and should not be relied
-// on at runtime, as the returned query server is not fully configured and will
-// panic if used.
 func ProvideExchangeQueryServerStub() vaulttypes.ExchangeQueryServer {
 	return exchangekeeper.QueryServer{}
 }

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -193,6 +193,7 @@ func AppConfig() depinject.Config {
 			ProvideNameKeeperStub,
 			ProvideAttributeKeeperStub,
 			ProvideExchangeKeeperStub,
+			ProvideExchangeQueryServerStub,
 		),
 		depinject.Supply(
 			map[string]module.AppModuleBasic{
@@ -357,15 +358,25 @@ func ProvideAttributeKeeperStub() *attributekeeper.Keeper {
 // to be included in the dependency graph even though the actual ExchangeKeeper
 // is initialized separately using the legacy Provenance wiring in SimApp.
 //
-// It returns the vaultExchangeKeeper adapter so the stub satisfies the full
-// types.ExchangeKeeper interface, including the GetPaymentsWithTarget lookup that
-// the raw exchange keeper exposes only through its query server.
-//
 // This function should only be used during app setup and should not be relied
 // on at runtime, as the returned keeper is not fully configured and will panic
 // if used.
 func ProvideExchangeKeeperStub() vaulttypes.ExchangeKeeper {
-	return vaultExchangeKeeper{}
+	return exchangekeeper.Keeper{}
+}
+
+// ProvideExchangeQueryServerStub returns an empty types.ExchangeQueryServer
+// instance.
+//
+// This stub is used to satisfy dependency injection requirements when wiring
+// the Vault module in the app module configuration. The real query server is
+// installed by RegisterProvenanceModules once the exchange keeper exists.
+//
+// This function should only be used during app setup and should not be relied
+// on at runtime, as the returned query server is not fully configured and will
+// panic if used.
+func ProvideExchangeQueryServerStub() vaulttypes.ExchangeQueryServer {
+	return exchangekeeper.QueryServer{}
 }
 
 func (app *SimApp) AppCodec() codec.Codec {

--- a/simapp/provenance.go
+++ b/simapp/provenance.go
@@ -1,8 +1,6 @@
 package simapp
 
 import (
-	"context"
-
 	storetypes "cosmossdk.io/store/types"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -26,21 +24,6 @@ import (
 	namekeeper "github.com/provenance-io/provenance/x/name/keeper"
 	nametypes "github.com/provenance-io/provenance/x/name/types"
 )
-
-// vaultExchangeKeeper adapts the Provenance exchange keeper to the vault module's
-// ExchangeKeeper interface. The embedded keeper supplies the payment settlement methods
-// directly, while GetPaymentsWithTarget is served through the exchange module's query
-// server, which is the only place that exposes the target-indexed payment lookup the
-// vault's VaultPayments query relies on.
-type vaultExchangeKeeper struct {
-	exchangekeeper.Keeper
-}
-
-// GetPaymentsWithTarget returns the payments whose target is the requested account,
-// delegating to the exchange query server for index-backed pagination.
-func (k vaultExchangeKeeper) GetPaymentsWithTarget(goCtx context.Context, req *exchange.QueryGetPaymentsWithTargetRequest) (*exchange.QueryGetPaymentsWithTargetResponse, error) {
-	return exchangekeeper.NewQueryServer(k.Keeper).GetPaymentsWithTarget(goCtx, req)
-}
 
 // RegisterProvenanceModules sets up and registers the Provenance modules
 // used by the SimApp, including name, attribute, marker, and vault modules.
@@ -127,7 +110,8 @@ func (app *SimApp) RegisterProvenanceModules() error {
 	app.VaultKeeper.MarkerKeeper = app.MarkerKeeper
 	app.VaultKeeper.NameKeeper = app.NameKeeper
 	app.VaultKeeper.AttrKeeper = app.AttributeKeeper
-	app.VaultKeeper.ExchangeKeeper = vaultExchangeKeeper{app.ExchangeKeeper}
+	app.VaultKeeper.ExchangeKeeper = app.ExchangeKeeper
+	app.VaultKeeper.ExchangeQueryServer = exchangekeeper.NewQueryServer(app.ExchangeKeeper)
 
 	return app.RegisterModules(
 		name.NewAppModule(app.appCodec, app.NameKeeper, app.AccountKeeper, app.BankKeeper),

--- a/types/expected_keepers.go
+++ b/types/expected_keepers.go
@@ -67,10 +67,7 @@ type ExchangeKeeper interface {
 
 // ExchangeQueryServer defines the subset of the Provenance exchange module
 // query server that the vault module relies on to list pending payments
-// targeting a vault. It is a separate dependency from ExchangeKeeper because
-// the exchange keeper does not expose a target-indexed payment lookup; only
-// its query server does. Satisfy it with
-// exchangekeeper.NewQueryServer(exchangeKeeper).
+// targeting a vault. Satisfy it with exchangekeeper.NewQueryServer.
 type ExchangeQueryServer interface {
 	GetPaymentsWithTarget(ctx context.Context, req *exchange.QueryGetPaymentsWithTargetRequest) (*exchange.QueryGetPaymentsWithTargetResponse, error)
 }

--- a/types/expected_keepers.go
+++ b/types/expected_keepers.go
@@ -58,10 +58,19 @@ type AttributeKeeper interface {
 }
 
 // ExchangeKeeper defines the subset of the Provenance exchange module keeper
-// that the vault module relies on to settle and inspect peer-to-peer asset payments.
+// that the vault module relies on to settle peer-to-peer asset payments.
 type ExchangeKeeper interface {
 	GetPayment(ctx sdk.Context, source sdk.AccAddress, externalID string) (*exchange.Payment, error)
 	AcceptPayment(ctx sdk.Context, payment *exchange.Payment) error
 	RejectPayment(ctx sdk.Context, target, source sdk.AccAddress, externalID string) error
+}
+
+// ExchangeQueryServer defines the subset of the Provenance exchange module
+// query server that the vault module relies on to list pending payments
+// targeting a vault. It is a separate dependency from ExchangeKeeper because
+// the exchange keeper does not expose a target-indexed payment lookup; only
+// its query server does. Satisfy it with
+// exchangekeeper.NewQueryServer(exchangeKeeper).
+type ExchangeQueryServer interface {
 	GetPaymentsWithTarget(ctx context.Context, req *exchange.QueryGetPaymentsWithTargetRequest) (*exchange.QueryGetPaymentsWithTargetResponse, error)
 }

--- a/utils/mocks/vault.go
+++ b/utils/mocks/vault.go
@@ -117,6 +117,7 @@ func NewVaultKeeper(
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	ctx := wrapper.Ctx.WithHeaderInfo(header.Info{Time: time.Now().UTC()})


### PR DESCRIPTION
closes: #247 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Split exchange responsibilities into separate keeper (settlement) and query services.
  - Added a dedicated query dependency for vault payment lookups, so pending payments are retrieved via the new query service.
  - Updated module wiring and app setup to pass the query service directly, removing the prior adapter-based routing.
  - Adjusted stubs used during setup and updated test/mocking wiring to match the new dependency shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->