### PR TITLE
Remove paused vaults from blocker queues

### DIFF
--- a/.changelog/unreleased/bug-fixes/219-paused-vault-fee-period.md
+++ b/.changelog/unreleased/bug-fixes/219-paused-vault-fee-period.md
@@ -1,0 +1,1 @@
+* Reset the AUM fee period on pause and unpause so a paused vault accrues no fees for the paused span [#219](https://github.com/provlabs/vault/issues/219).

--- a/.changelog/unreleased/improvements/257-paused-vault-queue-budget.md
+++ b/.changelog/unreleased/improvements/257-paused-vault-queue-budget.md
@@ -1,0 +1,1 @@
+* Remove paused vaults from the payout timeout, fee timeout, and payout verification queues so they no longer consume the per-block visit budget and starve active vaults [PR 257](https://github.com/provlabs/vault/pull/257).

--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -554,6 +554,8 @@ func (k msgServer) ExpeditePendingSwapOut(goCtx context.Context, msg *types.MsgE
 // and the account is persisted with validation first, falling back to an
 // unvalidated persist (also surfaced via forced_error) so an invalid-state vault
 // can still be frozen and the saved inconsistency remains auditable.
+//
+// Both paths call haltVaultAccrual so a paused vault holds no reconciliation queue entries.
 func (k msgServer) PauseVault(goCtx context.Context, msg *types.MsgPauseVaultRequest) (*types.MsgPauseVaultResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
@@ -588,6 +590,10 @@ func (k msgServer) PauseVault(goCtx context.Context, msg *types.MsgPauseVaultReq
 	vault.Paused = true
 	vault.PausedReason = msg.Reason
 
+	if err := k.haltVaultAccrual(ctx, vault); err != nil {
+		return nil, fmt.Errorf("failed to halt vault accrual before pausing: %w", err)
+	}
+
 	if err := k.UpdateInterestRates(ctx, vault, types.ZeroInterestRate, vault.DesiredInterestRate); err != nil {
 		return nil, fmt.Errorf("failed to update interest rates: %w", err)
 	}
@@ -602,6 +608,8 @@ func (k msgServer) PauseVault(goCtx context.Context, msg *types.MsgPauseVaultReq
 }
 
 // UnpauseVault unpauses a vault, re-enabling all user-facing operations after a NAV recalculation.
+// It re-arms what pausing cleared: payout verification for interest and the fee timeout for AUM
+// fees, both starting at the current block time so the paused span is never charged.
 func (k msgServer) UnpauseVault(goCtx context.Context, msg *types.MsgUnpauseVaultRequest) (*types.MsgUnpauseVaultResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
@@ -636,6 +644,10 @@ func (k msgServer) UnpauseVault(goCtx context.Context, msg *types.MsgUnpauseVaul
 
 	if err := k.SafeAddPayoutVerification(ctx, vault); err != nil {
 		return nil, fmt.Errorf("failed to enqueue vault payout verification: %w", err)
+	}
+
+	if err := k.SafeEnqueueFeeTimeout(ctx, vault); err != nil {
+		return nil, fmt.Errorf("failed to enqueue vault fee timeout: %w", err)
 	}
 
 	k.emitEvent(ctx, types.NewEventVaultUnpaused(msg.VaultAddress, msg.Authority, sdk.NewCoin(vault.UnderlyingAsset, tvv)))

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -4632,6 +4632,32 @@ func (s *TestSuite) TestPauseVault_ClearsReconciliationQueues() {
 	}
 }
 
+func (s *TestSuite) TestPauseVault_LeavesStaleQueueEntryToTheBlockerBackstop() {
+	underlying := "under"
+	share := "vaultshares"
+	vaultAddr := types.GetVaultAddress(share)
+
+	s.CreateAndActivateVault(s.adminAddr, share, underlying)
+	staleTimeout := s.ctx.BlockTime().Add(-time.Hour).Unix()
+	s.Require().NoError(s.k.PayoutTimeoutQueue.Enqueue(s.ctx, staleTimeout, vaultAddr), "enqueuing a stale payout timeout should not error")
+
+	_, err := keeper.NewMsgServer(s.simApp.VaultKeeper).PauseVault(s.ctx, &types.MsgPauseVaultRequest{
+		Authority:    s.adminAddr.String(),
+		VaultAddress: vaultAddr.String(),
+		Reason:       "maintenance",
+	})
+	s.Require().NoError(err, "pause should not error")
+
+	now := s.ctx.BlockTime().Unix()
+	s.Require().Equal(1, s.countDuePayoutTimeouts(now), "pause removes only the entry keyed by the vault's recorded timeout, so an entry filed under another key survives")
+
+	s.Require().NoError(
+		s.k.TestAccessor_handleVaultInterestTimeouts(s.T(), s.ctx, keeper.MaxInterestTimeoutsPerBlock),
+		"handleVaultInterestTimeouts should not error",
+	)
+	s.Assert().Equal(0, s.countDuePayoutTimeouts(now), "the blocker backstop should dequeue the stale entry left behind by pause")
+}
+
 func (s *TestSuite) TestMsgServer_UnpauseVault_RearmsReconciliationQueues() {
 	underlying := "under"
 	share := "vaultshares"

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -4658,6 +4658,76 @@ func (s *TestSuite) TestPauseVault_LeavesStaleQueueEntryToTheBlockerBackstop() {
 	s.Assert().Equal(0, s.countDuePayoutTimeouts(now), "the blocker backstop should dequeue the stale entry left behind by pause")
 }
 
+func (s *TestSuite) TestUnpauseVault_StaleQueueEntryIsDequeuedWhenProcessed() {
+	underlying := "under"
+	share := "vaultshares"
+	vaultAddr := types.GetVaultAddress(share)
+
+	tests := []struct {
+		name     string
+		enqueue  func(dueTime int64)
+		process  func()
+		countDue func(now int64) int
+	}{
+		{
+			name: "stale payout timeout",
+			enqueue: func(dueTime int64) {
+				s.Require().NoError(s.k.PayoutTimeoutQueue.Enqueue(s.ctx, dueTime, vaultAddr), "enqueuing a stale payout timeout should not error")
+			},
+			process: func() {
+				s.Require().NoError(
+					s.k.TestAccessor_handleVaultInterestTimeouts(s.T(), s.ctx, keeper.MaxInterestTimeoutsPerBlock),
+					"handleVaultInterestTimeouts should not error",
+				)
+			},
+			countDue: func(now int64) int { return s.countDuePayoutTimeouts(now) },
+		},
+		{
+			name: "stale fee timeout",
+			enqueue: func(dueTime int64) {
+				s.Require().NoError(s.k.FeeTimeoutQueue.Enqueue(s.ctx, dueTime, vaultAddr), "enqueuing a stale fee timeout should not error")
+			},
+			process: func() {
+				s.Require().NoError(
+					s.k.TestAccessor_handleVaultFeeTimeouts(s.T(), s.ctx, keeper.MaxFeeTimeoutsPerBlock),
+					"handleVaultFeeTimeouts should not error",
+				)
+			},
+			countDue: func(now int64) int { return s.countDueFeeTimeouts(now) },
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+			s.CreateAndActivateVault(s.adminAddr, share, underlying)
+			tc.enqueue(s.ctx.BlockTime().Add(-time.Hour).Unix())
+
+			msgServer := keeper.NewMsgServer(s.simApp.VaultKeeper)
+			_, err := msgServer.PauseVault(s.ctx, &types.MsgPauseVaultRequest{
+				Authority:    s.adminAddr.String(),
+				VaultAddress: vaultAddr.String(),
+				Reason:       "maintenance",
+			})
+			s.Require().NoError(err, "pause should not error")
+			_, err = msgServer.UnpauseVault(s.ctx, &types.MsgUnpauseVaultRequest{
+				Authority:    s.adminAddr.String(),
+				VaultAddress: vaultAddr.String(),
+			})
+			s.Require().NoError(err, "unpause should not error")
+
+			now := s.ctx.BlockTime().Unix()
+			s.Require().Equal(1, tc.countDue(now), "the stale entry should survive pause and unpause, since removal is keyed on the vault's recorded timeout")
+
+			tc.process()
+			s.Assert().Equal(0, tc.countDue(now), "processing an unpaused vault should dequeue the key its entry was walked under")
+
+			tc.process()
+			s.Assert().Equal(0, tc.countDue(now), "the stale entry should not return on later blocks")
+		})
+	}
+}
+
 func (s *TestSuite) TestMsgServer_UnpauseVault_RearmsReconciliationQueues() {
 	underlying := "under"
 	share := "vaultshares"

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -4566,6 +4566,110 @@ func (s *TestSuite) TestMsgServer_PauseVault_ForceVsStrict() {
 	}
 }
 
+func (s *TestSuite) TestPauseVault_ClearsReconciliationQueues() {
+	underlying := "under"
+	share := "vaultshares"
+	vaultAddr := types.GetVaultAddress(share)
+	reason := "maintenance"
+
+	pauseRequest := func(force bool) *types.MsgPauseVaultRequest {
+		return &types.MsgPauseVaultRequest{
+			Authority:    s.adminAddr.String(),
+			VaultAddress: vaultAddr.String(),
+			Reason:       reason,
+			Force:        force,
+		}
+	}
+
+	tests := []struct {
+		name  string
+		pause func(vault *types.VaultAccount)
+	}{
+		{
+			name: "strict pause",
+			pause: func(_ *types.VaultAccount) {
+				_, err := keeper.NewMsgServer(s.simApp.VaultKeeper).PauseVault(s.ctx, pauseRequest(false))
+				s.Require().NoError(err, "strict pause should not error")
+			},
+		},
+		{
+			name: "forced pause",
+			pause: func(_ *types.VaultAccount) {
+				_, err := keeper.NewMsgServer(s.simApp.VaultKeeper).PauseVault(s.ctx, pauseRequest(true))
+				s.Require().NoError(err, "forced pause should not error")
+			},
+		},
+		{
+			name: "auto pause",
+			pause: func(vault *types.VaultAccount) {
+				s.k.TestAccessor_autoPauseVault(s.T(), s.ctx, vault, reason)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+			s.CreateAndActivateVault(s.adminAddr, share, underlying)
+			vault, err := s.k.GetVault(s.ctx, vaultAddr)
+			s.Require().NoError(err, "GetVault should not error before pausing")
+			s.Require().NoError(s.k.SafeEnqueuePayoutTimeout(s.ctx, vault), "enqueuing the payout timeout should not error")
+			s.Require().NoError(s.k.SafeEnqueueFeeTimeout(s.ctx, vault), "enqueuing the fee timeout should not error")
+			s.Require().NoError(s.k.PayoutVerificationSet.Set(s.ctx, vaultAddr), "seeding the payout verification set should not error")
+			s.assertInReconciliationQueues(vaultAddr, true)
+
+			tc.pause(vault)
+
+			paused, err := s.k.GetVault(s.ctx, vaultAddr)
+			s.Require().NoError(err, "GetVault should not error after pausing")
+			s.Require().True(paused.Paused, "vault should be paused")
+			s.assertInReconciliationQueues(vaultAddr, false)
+			s.Assert().Zero(paused.PeriodStart, "interest period start should be cleared while paused")
+			s.Assert().Zero(paused.PeriodTimeout, "interest period timeout should be cleared while paused")
+			s.Assert().Zero(paused.FeePeriodStart, "fee period start should be cleared while paused")
+			s.Assert().Zero(paused.FeePeriodTimeout, "fee period timeout should be cleared while paused")
+		})
+	}
+}
+
+func (s *TestSuite) TestMsgServer_UnpauseVault_RearmsReconciliationQueues() {
+	underlying := "under"
+	share := "vaultshares"
+	vaultAddr := types.GetVaultAddress(share)
+	msgServer := keeper.NewMsgServer(s.simApp.VaultKeeper)
+
+	s.CreateAndActivateVault(s.adminAddr, share, underlying)
+	_, err := msgServer.PauseVault(s.ctx, &types.MsgPauseVaultRequest{
+		Authority:    s.adminAddr.String(),
+		VaultAddress: vaultAddr.String(),
+		Reason:       "maintenance",
+	})
+	s.Require().NoError(err, "pause should not error")
+	s.assertInReconciliationQueues(vaultAddr, false)
+
+	unpauseTime := s.ctx.BlockTime().Add(48 * time.Hour)
+	s.ctx = s.ctx.WithBlockTime(unpauseTime)
+
+	_, err = msgServer.UnpauseVault(s.ctx, &types.MsgUnpauseVaultRequest{
+		Authority:    s.adminAddr.String(),
+		VaultAddress: vaultAddr.String(),
+	})
+	s.Require().NoError(err, "unpause should not error")
+
+	vault, err := s.k.GetVault(s.ctx, vaultAddr)
+	s.Require().NoError(err, "GetVault should not error after unpausing")
+	s.Require().False(vault.Paused, "vault should be unpaused")
+
+	s.assertInPayoutVerificationQueue(vaultAddr, true)
+	s.Assert().Equal(unpauseTime.Unix(), vault.PeriodStart, "interest period should restart at the unpause time")
+	s.Assert().Zero(vault.PeriodTimeout, "interest is tracked by the verification set, not a payout timeout")
+	s.Assert().Equal(0, s.countDuePayoutTimeouts(unpauseTime.Unix()+keeper.AutoReconcileTimeout), "unpause should not enqueue a payout timeout")
+
+	s.Assert().Equal(unpauseTime.Unix(), vault.FeePeriodStart, "fee period should restart at the unpause time so the paused span is not charged")
+	s.Assert().Equal(unpauseTime.Unix()+keeper.AutoReconcileTimeout, vault.FeePeriodTimeout, "fee timeout should be re-armed one auto-reconcile window out")
+	s.Assert().Equal(1, s.countDueFeeTimeouts(vault.FeePeriodTimeout), "unpause should re-enqueue exactly one fee timeout")
+}
+
 func (s *TestSuite) TestMsgServer_UnpauseVault() {
 	type postCheckArgs struct {
 		VaultAddress          sdk.AccAddress

--- a/keeper/queue.go
+++ b/keeper/queue.go
@@ -109,6 +109,38 @@ func (k Keeper) SafeEnqueueFeeTimeout(ctx sdk.Context, vault *types.VaultAccount
 	return nil
 }
 
+// haltVaultAccrual removes a vault from the payout timeout queue, the fee timeout queue, and the
+// payout verification set, and clears its interest and fee accrual periods. Queue processors skip
+// paused vaults, so an entry left behind would consume the per-block visit budget forever. Both
+// periods are re-armed on unpause, so the paused span accrues no interest and no AUM fees.
+//
+// Like applyPausedState, this does not persist the account; the caller chooses SetVaultAccount
+// (validated) or SetAccount (validation-skipped).
+func (k Keeper) haltVaultAccrual(ctx sdk.Context, vault *types.VaultAccount) error {
+	vaultAddr := vault.GetAddress()
+	cacheCtx, write := ctx.CacheContext()
+
+	if err := k.PayoutTimeoutQueue.RemoveAllForVault(cacheCtx, vaultAddr); err != nil {
+		return fmt.Errorf("failed to remove payout timeout entries for vault %s: %w", vaultAddr, err)
+	}
+
+	if err := k.FeeTimeoutQueue.RemoveAllForVault(cacheCtx, vaultAddr); err != nil {
+		return fmt.Errorf("failed to remove fee timeout entries for vault %s: %w", vaultAddr, err)
+	}
+
+	if err := k.PayoutVerificationSet.Remove(cacheCtx, vaultAddr); err != nil {
+		return fmt.Errorf("failed to remove payout verification entry for vault %s: %w", vaultAddr, err)
+	}
+
+	write()
+
+	vault.PeriodStart = 0
+	vault.PeriodTimeout = 0
+	vault.FeePeriodStart = 0
+	vault.FeePeriodTimeout = 0
+	return nil
+}
+
 // ReschedulePayoutTimeout updates a vault's payout timeout to the next window (now + AutoReconcileTimeout)
 // without resetting the PeriodStart. This is used for transient reconciliation failures to
 // preserve accrued interest while preventing block-to-block retry loops.

--- a/keeper/queue.go
+++ b/keeper/queue.go
@@ -114,18 +114,22 @@ func (k Keeper) SafeEnqueueFeeTimeout(ctx sdk.Context, vault *types.VaultAccount
 // paused vaults, so an entry left behind would consume the per-block visit budget forever. Both
 // periods are re-armed on unpause, so the paused span accrues no interest and no AUM fees.
 //
+// Removal uses the vault's recorded timeouts as keys so it stays constant-time; auto-pause calls
+// this from the EndBlocker, where scanning a queue would grow block time with the backlog. An entry
+// filed under any other key is left for the blocker processors to dequeue when it comes due.
+//
 // Like applyPausedState, this does not persist the account; the caller chooses SetVaultAccount
 // (validated) or SetAccount (validation-skipped).
 func (k Keeper) haltVaultAccrual(ctx sdk.Context, vault *types.VaultAccount) error {
 	vaultAddr := vault.GetAddress()
 	cacheCtx, write := ctx.CacheContext()
 
-	if err := k.PayoutTimeoutQueue.RemoveAllForVault(cacheCtx, vaultAddr); err != nil {
-		return fmt.Errorf("failed to remove payout timeout entries for vault %s: %w", vaultAddr, err)
+	if err := k.PayoutTimeoutQueue.Dequeue(cacheCtx, vault.PeriodTimeout, vaultAddr); err != nil {
+		return fmt.Errorf("failed to dequeue payout timeout for vault %s: %w", vaultAddr, err)
 	}
 
-	if err := k.FeeTimeoutQueue.RemoveAllForVault(cacheCtx, vaultAddr); err != nil {
-		return fmt.Errorf("failed to remove fee timeout entries for vault %s: %w", vaultAddr, err)
+	if err := k.FeeTimeoutQueue.Dequeue(cacheCtx, vault.FeePeriodTimeout, vaultAddr); err != nil {
+		return fmt.Errorf("failed to dequeue fee timeout for vault %s: %w", vaultAddr, err)
 	}
 
 	if err := k.PayoutVerificationSet.Remove(cacheCtx, vaultAddr); err != nil {

--- a/keeper/reconcile.go
+++ b/keeper/reconcile.go
@@ -580,7 +580,7 @@ func (k Keeper) handleVaultInterestTimeouts(ctx sdk.Context, limit int) error {
 			continue
 		}
 
-		if err := k.atomicallyReconcileInterest(ctx, vault); err != nil {
+		if err := k.atomicallyReconcileInterest(ctx, vault, timeoutUnix); err != nil {
 			k.getLogger(ctx).Error("failed to reconcile interest atomically, rescheduling", "vault", addr.String(), "err", err)
 			k.reschedulePayoutTimeout(ctx, vault, timeoutUnix)
 			continue
@@ -594,12 +594,19 @@ func (k Keeper) handleVaultInterestTimeouts(ctx sdk.Context, limit int) error {
 // atomicallyReconcileInterest performs the interest transfer, dequeues the current
 // timeout, and enqueues the next period timeout within a single atomic cache context.
 // If any step fails, the entire operation is reverted.
-func (k Keeper) atomicallyReconcileInterest(ctx sdk.Context, vault *types.VaultAccount) error {
+//
+// walkedTimeout is the key the entry was found under. It can differ from the vault's recorded
+// timeout, so both are dequeued and no entry is left behind to stay due forever.
+func (k Keeper) atomicallyReconcileInterest(ctx sdk.Context, vault *types.VaultAccount, walkedTimeout int64) error {
 	cacheCtx, write := ctx.CacheContext()
 	v := vault.Clone()
 
 	if err := k.PerformVaultInterestTransfer(cacheCtx, v); err != nil {
 		return fmt.Errorf("failed to perform vault interest transfer: %w", err)
+	}
+
+	if err := k.PayoutTimeoutQueue.Dequeue(cacheCtx, walkedTimeout, v.GetAddress()); err != nil {
+		return fmt.Errorf("failed to dequeue walked payout timeout: %w", err)
 	}
 
 	if err := k.SafeEnqueuePayoutTimeout(cacheCtx, v); err != nil {
@@ -778,7 +785,7 @@ func (k Keeper) handleVaultFeeTimeouts(ctx sdk.Context, limit int) error {
 			continue
 		}
 
-		if err := k.atomicallyReconcileFee(ctx, vault); err != nil {
+		if err := k.atomicallyReconcileFee(ctx, vault, timeoutUnix); err != nil {
 			k.getLogger(ctx).Error("failed to collect AUM fee atomically, rescheduling", "vault", addr.String(), "err", err)
 			k.rescheduleFeeTimeout(ctx, vault, timeoutUnix)
 			continue
@@ -791,12 +798,19 @@ func (k Keeper) handleVaultFeeTimeouts(ctx sdk.Context, limit int) error {
 // atomicallyReconcileFee performs the AUM fee collection, dequeues the current
 // fee timeout, and enqueues the next fee period timeout within a single atomic
 // cache context. If any step fails, the entire operation is reverted.
-func (k Keeper) atomicallyReconcileFee(ctx sdk.Context, vault *types.VaultAccount) error {
+//
+// walkedTimeout is the key the entry was found under. It can differ from the vault's recorded
+// fee timeout, so both are dequeued and no entry is left behind to stay due forever.
+func (k Keeper) atomicallyReconcileFee(ctx sdk.Context, vault *types.VaultAccount, walkedTimeout int64) error {
 	cacheCtx, write := ctx.CacheContext()
 	v := vault.Clone()
 
 	if err := k.PerformVaultFeeTransfer(cacheCtx, v); err != nil {
 		return fmt.Errorf("failed to perform vault fee transfer: %w", err)
+	}
+
+	if err := k.FeeTimeoutQueue.Dequeue(cacheCtx, walkedTimeout, v.GetAddress()); err != nil {
+		return fmt.Errorf("failed to dequeue walked fee timeout: %w", err)
 	}
 
 	if err := k.SafeEnqueueFeeTimeout(cacheCtx, v); err != nil {

--- a/keeper/reconcile.go
+++ b/keeper/reconcile.go
@@ -515,10 +515,12 @@ func (k Keeper) CalculateVaultTotalAssets(ctx sdk.Context, vault *types.VaultAcc
 // handleVaultInterestTimeouts checks vaults with expired interest periods and reconciles or disables them.
 // It uses a safe "collect-then-mutate" pattern to comply with the SDK iterator contract.
 // At most limit due entries are visited per block; the remainder stays queued for later blocks.
+// Paused vaults are dequeued rather than skipped so they cannot hold the front of the queue.
 func (k Keeper) handleVaultInterestTimeouts(ctx sdk.Context, limit int) error {
 	now := ctx.BlockTime().Unix()
 
 	var keysToProcess []collections.Pair[uint64, sdk.AccAddress]
+	var pausedKeys []collections.Pair[uint64, sdk.AccAddress]
 	var depleted []*types.VaultAccount
 
 	visited := 0
@@ -529,6 +531,7 @@ func (k Keeper) handleVaultInterestTimeouts(ctx sdk.Context, limit int) error {
 		visited++
 		vault, ok := k.tryGetVault(ctx, addr)
 		if ok && vault.Paused {
+			pausedKeys = append(pausedKeys, collections.Join(timeout, addr))
 			return false, nil
 		}
 		keysToProcess = append(keysToProcess, collections.Join(timeout, addr))
@@ -536,6 +539,14 @@ func (k Keeper) handleVaultInterestTimeouts(ctx sdk.Context, limit int) error {
 	})
 	if err != nil {
 		return fmt.Errorf("walk failed: %w", err)
+	}
+
+	for _, key := range pausedKeys {
+		timeoutUnix := int64(key.K1()) //nolint:gosec // G115: queue key is a bounded unix-second timestamp.
+		addr := key.K2()
+		if err := k.PayoutTimeoutQueue.Dequeue(ctx, timeoutUnix, addr); err != nil {
+			k.getLogger(ctx).Error("failed to dequeue paused vault from payout timeout queue", "vault", addr.String(), "err", err)
+		}
 	}
 
 	for _, key := range keysToProcess {
@@ -632,8 +643,10 @@ func (k Keeper) tryGetVault(ctx sdk.Context, addr sdk.AccAddress) (*types.VaultA
 // It first collects keys for non-paused vaults, visiting at most limit entries per block and
 // leaving the remainder in the set for later blocks. It then iterates the collected keys,
 // removing each from the set before partitioning them into payable vs depleted groups.
+// Paused vaults are removed from the set rather than skipped so they cannot consume the budget.
 func (k Keeper) handleReconciledVaults(ctx sdk.Context, limit int) error {
 	var keysToProcess []sdk.AccAddress
+	var pausedKeys []sdk.AccAddress
 	var vaultsToProcess []*types.VaultAccount
 
 	visited := 0
@@ -644,6 +657,7 @@ func (k Keeper) handleReconciledVaults(ctx sdk.Context, limit int) error {
 		visited++
 		v, ok := k.tryGetVault(ctx, addr)
 		if ok && v.Paused {
+			pausedKeys = append(pausedKeys, addr)
 			return false, nil
 		}
 		keysToProcess = append(keysToProcess, addr)
@@ -651,6 +665,12 @@ func (k Keeper) handleReconciledVaults(ctx sdk.Context, limit int) error {
 	})
 	if err != nil {
 		return fmt.Errorf("walk failed: %w", err)
+	}
+
+	for _, addr := range pausedKeys {
+		if err := k.PayoutVerificationSet.Remove(ctx, addr); err != nil {
+			k.getLogger(ctx).Error("failed to remove paused vault from payout verification set", "vault", addr.String(), "err", err)
+		}
 	}
 
 	for _, addr := range keysToProcess {
@@ -714,10 +734,12 @@ func (k Keeper) handleDepletedVaults(ctx sdk.Context, failedPayouts []*types.Vau
 // handleVaultFeeTimeouts checks vaults with expired fee periods and reconciles them.
 // It uses a safe "collect-then-mutate" pattern to comply with the SDK iterator contract.
 // At most limit due entries are visited per block; the remainder stays queued for later blocks.
+// Paused vaults are dequeued rather than skipped so they cannot hold the front of the queue.
 func (k Keeper) handleVaultFeeTimeouts(ctx sdk.Context, limit int) error {
 	now := ctx.BlockTime().Unix()
 
 	var keysToProcess []collections.Pair[uint64, sdk.AccAddress]
+	var pausedKeys []collections.Pair[uint64, sdk.AccAddress]
 
 	visited := 0
 	err := k.FeeTimeoutQueue.WalkDue(ctx, now, func(timeout uint64, addr sdk.AccAddress) (bool, error) {
@@ -727,6 +749,7 @@ func (k Keeper) handleVaultFeeTimeouts(ctx sdk.Context, limit int) error {
 		visited++
 		vault, ok := k.tryGetVault(ctx, addr)
 		if ok && vault.Paused {
+			pausedKeys = append(pausedKeys, collections.Join(timeout, addr))
 			return false, nil
 		}
 		keysToProcess = append(keysToProcess, collections.Join(timeout, addr))
@@ -734,6 +757,14 @@ func (k Keeper) handleVaultFeeTimeouts(ctx sdk.Context, limit int) error {
 	})
 	if err != nil {
 		return fmt.Errorf("walk failed: %w", err)
+	}
+
+	for _, key := range pausedKeys {
+		timeoutUnix := int64(key.K1()) //nolint:gosec // G115: queue key is a bounded unix-second timestamp.
+		addr := key.K2()
+		if err := k.FeeTimeoutQueue.Dequeue(ctx, timeoutUnix, addr); err != nil {
+			k.getLogger(ctx).Error("failed to dequeue paused vault from fee timeout queue", "vault", addr.String(), "err", err)
+		}
 	}
 
 	for _, key := range keysToProcess {

--- a/keeper/reconcile_test.go
+++ b/keeper/reconcile_test.go
@@ -526,9 +526,7 @@ func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts() {
 	tests := []struct {
 		name           string
 		setup          func()
-		checkAddr      sdk.AccAddress
-		expectExists   bool
-		expectDeleted  bool
+		postCheck      func()
 		expectRate     string
 		expectedEvents sdk.Events
 	}{
@@ -554,10 +552,7 @@ func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts() {
 				s.Require().NoError(s.k.PayoutTimeoutQueue.Enqueue(s.ctx, testBlockTime.Unix(), vault.GetAddress()), "happy path: enqueuing payout timeout should not error")
 				s.ctx = s.ctx.WithBlockTime(testBlockTime).WithEventManager(sdk.NewEventManager())
 			},
-			checkAddr:     vaultAddr,
-			expectExists:  true,
-			expectDeleted: false,
-			expectRate:    "0.25",
+			expectRate: "0.25",
 			expectedEvents: func() sdk.Events {
 				markerAddr := markertypes.MustGetMarkerAddress(shareDenom)
 				evs := sdk.Events{
@@ -609,10 +604,7 @@ func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts() {
 				s.Require().NoError(s.k.PayoutTimeoutQueue.Enqueue(s.ctx, testBlockTime.Unix(), vault.GetAddress()), "vault cannot pay: enqueuing payout timeout should not error")
 				s.ctx = s.ctx.WithBlockTime(testBlockTime).WithEventManager(sdk.NewEventManager())
 			},
-			checkAddr:     vaultAddr,
-			expectExists:  false,
-			expectDeleted: true,
-			expectRate:    types.ZeroInterestRate,
+			expectRate: types.ZeroInterestRate,
 			expectedEvents: sdk.Events{
 				sdk.NewEvent("provlabs.vault.v1.EventVaultInterestChange",
 					sdk.NewAttribute("current_rate", types.ZeroInterestRate),
@@ -622,7 +614,7 @@ func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts() {
 			},
 		},
 		{
-			name: "paused vault is skipped and remains in queue",
+			name: "paused vault is not reconciled and is dequeued",
 			setup: func() {
 				s.requireAddFinalizeAndActivateMarker(underlying, s.adminAddr)
 				_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
@@ -638,9 +630,9 @@ func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts() {
 				s.Require().NoError(s.k.PayoutTimeoutQueue.Enqueue(s.ctx, testBlockTime.Unix(), vault.GetAddress()), "paused vault: enqueuing payout timeout should not error")
 				s.ctx = s.ctx.WithBlockTime(testBlockTime).WithEventManager(sdk.NewEventManager())
 			},
-			checkAddr:      vaultAddr,
-			expectExists:   true,
-			expectDeleted:  false,
+			postCheck: func() {
+				s.Assert().Equal(0, s.countDuePayoutTimeouts(testBlockTime.Unix()), "paused vault should be dequeued from the payout timeout queue")
+			},
 			expectedEvents: sdk.Events{},
 		},
 		{
@@ -650,10 +642,6 @@ func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts() {
 				s.Require().NoError(s.k.PayoutTimeoutQueue.Enqueue(s.ctx, testBlockTime.Unix(), markerAddr), "non-vault: enqueuing payout timeout should not error")
 				s.ctx = s.ctx.WithBlockTime(testBlockTime).WithEventManager(sdk.NewEventManager())
 			},
-			checkAddr:      markerAddr,
-			expectExists:   true,
-			expectDeleted:  false,
-			expectRate:     "",
 			expectedEvents: sdk.Events{},
 		},
 	}
@@ -675,6 +663,9 @@ func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts() {
 				normalizeEvents(em.Events()),
 				"test case %s: beginblocker events mismatch", tc.name,
 			)
+			if tc.postCheck != nil {
+				tc.postCheck()
+			}
 		})
 	}
 }
@@ -769,14 +760,14 @@ func (s *TestSuite) TestKeeper_HandleReconciledVaults() {
 			},
 		},
 		{
-			name: "paused vault is skipped",
+			name: "paused vault is not reconciled and is removed from the verification set",
 			setup: func() {
 				vault := createVaultWithInterest(s, v1, "0.1", testBlockTime.Unix(), testBlockTime.Unix(), true, true)
 				vault.Paused = true
 				s.k.AuthKeeper.SetAccount(s.ctx, vault)
 			},
 			postCheck: func() {
-				s.assertInPayoutVerificationQueue(v1.vaultAddr, true)
+				s.assertInPayoutVerificationQueue(v1.vaultAddr, false)
 			},
 			expectErr:      false,
 			expectedEvents: sdk.Events{},
@@ -2574,7 +2565,7 @@ func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts_PerBlockVisitBudget()
 	}
 }
 
-func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts_PausedVaultsConsumeVisitBudget() {
+func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts_PausedVaultsDoNotStarveActiveVaults() {
 	testBlockTime := time.Now().UTC()
 	pausedDueTime := testBlockTime.Add(-2 * time.Hour).Unix()
 	activeDueTime := testBlockTime.Add(-1 * time.Hour).Unix()
@@ -2582,19 +2573,19 @@ func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts_PausedVaultsConsumeVi
 	activeInfo := NewVaultInfo(3)
 
 	tests := []struct {
-		name        string
-		limit       int
-		expectedDue int
+		name                string
+		limit               int
+		expectedDuePerBlock []int
 	}{
 		{
-			name:        "budget filled by paused vaults at the queue front starves the active vault",
-			limit:       2,
-			expectedDue: 3,
+			name:                "budget filled by the paused front dequeues it and the active vault is served the next block",
+			limit:               2,
+			expectedDuePerBlock: []int{1, 0},
 		},
 		{
-			name:        "budget larger than the paused front reaches and processes the active vault",
-			limit:       3,
-			expectedDue: 2,
+			name:                "budget larger than the paused front dequeues it and serves the active vault in the same block",
+			limit:               3,
+			expectedDuePerBlock: []int{0, 0},
 		},
 	}
 
@@ -2607,29 +2598,34 @@ func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts_PausedVaultsConsumeVi
 			}
 			s.createVaultWithDueInterestTimeout(activeInfo, activeDueTime, false)
 
-			err := s.k.TestAccessor_handleVaultInterestTimeouts(s.T(), s.ctx, tc.limit)
-			s.Require().NoError(err, "handleVaultInterestTimeouts should not error with limit %d", tc.limit)
-			s.Require().Equal(
-				tc.expectedDue, s.countDuePayoutTimeouts(testBlockTime.Unix()),
-				"due backlog mismatch with limit %d: paused entries stay queued and count against the budget", tc.limit,
-			)
+			for block, expectedDue := range tc.expectedDuePerBlock {
+				err := s.k.TestAccessor_handleVaultInterestTimeouts(s.T(), s.ctx, tc.limit)
+				s.Require().NoError(err, "handleVaultInterestTimeouts should not error on pass %d with limit %d", block+1, tc.limit)
+				s.Require().Equal(
+					expectedDue, s.countDuePayoutTimeouts(testBlockTime.Unix()),
+					"due backlog mismatch after pass %d with limit %d: paused entries must be dequeued instead of starving the active vault", block+1, tc.limit,
+				)
+			}
 		})
 	}
+}
+
+// createVaultWithDueFeeTimeout creates a funded vault with a due FeeTimeoutQueue entry at
+// dueTime, optionally paused, for exercising the per-block visit budget.
+func (s *TestSuite) createVaultWithDueFeeTimeout(shareDenom, underlyingDenom string, dueTime int64, paused bool) {
+	vault := s.CreateVaultWithParams(shareDenom, underlyingDenom)
+	vault.Paused = paused
+	s.SetVaultRatesAndPeriod(vault, "0.0", "0.0", dueTime, dueTime)
+	s.FundMarker(shareDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 1_000_000_000)))
+	s.Require().NoError(
+		s.k.FeeTimeoutQueue.Enqueue(s.ctx, dueTime, vault.GetAddress()),
+		"enqueuing due fee timeout should not error for vault %s", vault.GetAddress(),
+	)
 }
 
 func (s *TestSuite) TestKeeper_HandleVaultFeeTimeouts_PerBlockVisitBudget() {
 	underlyingDenom := "underlying"
 	underlying := sdk.NewInt64Coin(underlyingDenom, 1_000_000_000)
-
-	enqueueDueFeeTimeout := func(shareDenom string, dueTime int64) {
-		vault := s.CreateVaultWithParams(shareDenom, underlyingDenom)
-		s.SetVaultRatesAndPeriod(vault, "0.0", "0.0", dueTime, dueTime)
-		s.FundMarker(shareDenom, sdk.NewCoins(underlying))
-		s.Require().NoError(
-			s.k.FeeTimeoutQueue.Enqueue(s.ctx, dueTime, vault.GetAddress()),
-			"enqueuing due fee timeout should not error for vault %s", vault.GetAddress(),
-		)
-	}
 
 	tests := []struct {
 		name                string
@@ -2661,7 +2657,7 @@ func (s *TestSuite) TestKeeper_HandleVaultFeeTimeouts_PerBlockVisitBudget() {
 
 			s.requireAddFinalizeAndActivateMarker(underlying, s.adminAddr)
 			for i := 1; i <= 3; i++ {
-				enqueueDueFeeTimeout(fmt.Sprintf("feebudgetshares%d", i), dueTime)
+				s.createVaultWithDueFeeTimeout(fmt.Sprintf("feebudgetshares%d", i), underlyingDenom, dueTime, false)
 			}
 
 			for block, expectedDue := range tc.expectedDuePerBlock {
@@ -2670,6 +2666,51 @@ func (s *TestSuite) TestKeeper_HandleVaultFeeTimeouts_PerBlockVisitBudget() {
 				s.Require().Equal(
 					expectedDue, s.countDueFeeTimeouts(now.Unix()),
 					"due fee timeout backlog mismatch after pass %d with limit %d", block+1, tc.limit,
+				)
+			}
+		})
+	}
+}
+
+func (s *TestSuite) TestKeeper_HandleVaultFeeTimeouts_PausedVaultsDoNotStarveActiveVaults() {
+	underlyingDenom := "underlying"
+	underlying := sdk.NewInt64Coin(underlyingDenom, 1_000_000_000)
+
+	tests := []struct {
+		name                string
+		limit               int
+		expectedDuePerBlock []int
+	}{
+		{
+			name:                "budget filled by the paused front dequeues it and the active vault is served the next block",
+			limit:               2,
+			expectedDuePerBlock: []int{1, 0},
+		},
+		{
+			name:                "budget larger than the paused front dequeues it and serves the active vault in the same block",
+			limit:               3,
+			expectedDuePerBlock: []int{0, 0},
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+			now := s.ctx.BlockTime()
+			pausedDueTime := now.Add(-60 * 24 * time.Hour).Unix()
+			activeDueTime := now.Add(-30 * 24 * time.Hour).Unix()
+
+			s.requireAddFinalizeAndActivateMarker(underlying, s.adminAddr)
+			s.createVaultWithDueFeeTimeout("feepausedshares1", underlyingDenom, pausedDueTime, true)
+			s.createVaultWithDueFeeTimeout("feepausedshares2", underlyingDenom, pausedDueTime, true)
+			s.createVaultWithDueFeeTimeout("feeactiveshares", underlyingDenom, activeDueTime, false)
+
+			for block, expectedDue := range tc.expectedDuePerBlock {
+				err := s.k.TestAccessor_handleVaultFeeTimeouts(s.T(), s.ctx, tc.limit)
+				s.Require().NoError(err, "handleVaultFeeTimeouts should not error on pass %d with limit %d", block+1, tc.limit)
+				s.Require().Equal(
+					expectedDue, s.countDueFeeTimeouts(now.Unix()),
+					"due fee backlog mismatch after pass %d with limit %d: paused entries must be dequeued instead of starving the active vault", block+1, tc.limit,
 				)
 			}
 		})

--- a/keeper/reconcile_test.go
+++ b/keeper/reconcile_test.go
@@ -2484,40 +2484,6 @@ func (s *TestSuite) TestReconcileVault_BootstrapFeePeriod() {
 	s.Require().Equal(testBlockTime.Unix(), v.FeePeriodStart, "FeePeriodStart should be set to current block time")
 }
 
-// createVaultWithDueInterestTimeout creates a funded vault with a due PayoutTimeoutQueue
-// entry at dueTime, optionally paused, for exercising the per-block visit budget.
-func (s *TestSuite) createVaultWithDueInterestTimeout(info VaultInfo, dueTime int64, paused bool) {
-	s.requireAddFinalizeAndActivateMarker(info.underlying, s.adminAddr)
-	_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
-		Admin:           s.adminAddr.String(),
-		ShareDenom:      info.shareDenom,
-		UnderlyingAsset: info.underlying.Denom,
-	})
-	s.Require().NoError(err, "CreateVault should not error for share denom %s", info.shareDenom)
-
-	vault, err := s.k.GetVault(s.ctx, info.vaultAddr)
-	s.Require().NoError(err, "GetVault should not error for vault %s", info.vaultAddr)
-	vault.CurrentInterestRate = "0.1"
-	vault.DesiredInterestRate = "0.1"
-	vault.PeriodStart = dueTime
-	vault.PeriodTimeout = dueTime
-	vault.Paused = paused
-	s.k.AuthKeeper.SetAccount(s.ctx, vault)
-
-	s.Require().NoError(
-		FundAccount(s.ctx, s.simApp.BankKeeper, info.vaultAddr, sdk.NewCoins(sdk.NewInt64Coin(info.underlying.Denom, 1_000_000))),
-		"funding reserves should not error for vault %s", info.vaultAddr,
-	)
-	s.Require().NoError(
-		FundAccount(s.ctx, s.simApp.BankKeeper, markertypes.MustGetMarkerAddress(info.shareDenom), sdk.NewCoins(info.underlying)),
-		"funding principal should not error for marker %s", info.shareDenom,
-	)
-	s.Require().NoError(
-		s.k.PayoutTimeoutQueue.Enqueue(s.ctx, dueTime, info.vaultAddr),
-		"enqueuing due payout timeout should not error for vault %s", info.vaultAddr,
-	)
-}
-
 func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts_PerBlockVisitBudget() {
 	testBlockTime := time.Now().UTC()
 	dueTime := testBlockTime.Add(-1 * time.Hour).Unix()
@@ -2608,19 +2574,6 @@ func (s *TestSuite) TestKeeper_HandleVaultInterestTimeouts_PausedVaultsDoNotStar
 			}
 		})
 	}
-}
-
-// createVaultWithDueFeeTimeout creates a funded vault with a due FeeTimeoutQueue entry at
-// dueTime, optionally paused, for exercising the per-block visit budget.
-func (s *TestSuite) createVaultWithDueFeeTimeout(shareDenom, underlyingDenom string, dueTime int64, paused bool) {
-	vault := s.CreateVaultWithParams(shareDenom, underlyingDenom)
-	vault.Paused = paused
-	s.SetVaultRatesAndPeriod(vault, "0.0", "0.0", dueTime, dueTime)
-	s.FundMarker(shareDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 1_000_000_000)))
-	s.Require().NoError(
-		s.k.FeeTimeoutQueue.Enqueue(s.ctx, dueTime, vault.GetAddress()),
-		"enqueuing due fee timeout should not error for vault %s", vault.GetAddress(),
-	)
 }
 
 func (s *TestSuite) TestKeeper_HandleVaultFeeTimeouts_PerBlockVisitBudget() {

--- a/keeper/suite_test.go
+++ b/keeper/suite_test.go
@@ -143,6 +143,28 @@ func (s *TestSuite) assertInPayoutVerificationQueue(vaultAddr sdk.AccAddress, sh
 	s.Assert().Equal(shouldContain, isInQueue, "vault should be enqueued in payout verification queue at expected period start")
 }
 
+// assertInReconciliationQueues asserts whether a vault is present in the payout timeout queue,
+// the fee timeout queue, and the payout verification set, matching the expectation flag.
+func (s *TestSuite) assertInReconciliationQueues(vaultAddr sdk.AccAddress, shouldContain bool) {
+	payoutQueued := false
+	err := s.k.PayoutTimeoutQueue.Walk(s.ctx, func(_ uint64, addr sdk.AccAddress) (bool, error) {
+		payoutQueued = payoutQueued || addr.Equals(vaultAddr)
+		return false, nil
+	})
+	s.Require().NoError(err, "walking the payout timeout queue should not error")
+	s.Assert().Equal(shouldContain, payoutQueued, "payout timeout queue membership for vault %s", vaultAddr)
+
+	feeQueued := false
+	err = s.k.FeeTimeoutQueue.Walk(s.ctx, func(_ uint64, addr sdk.AccAddress) (bool, error) {
+		feeQueued = feeQueued || addr.Equals(vaultAddr)
+		return false, nil
+	})
+	s.Require().NoError(err, "walking the fee timeout queue should not error")
+	s.Assert().Equal(shouldContain, feeQueued, "fee timeout queue membership for vault %s", vaultAddr)
+
+	s.assertInPayoutVerificationQueue(vaultAddr, shouldContain)
+}
+
 // countDuePayoutTimeouts returns the number of PayoutTimeoutQueue entries due at or before now.
 func (s *TestSuite) countDuePayoutTimeouts(now int64) int {
 	count := 0

--- a/keeper/suite_test.go
+++ b/keeper/suite_test.go
@@ -165,6 +165,53 @@ func (s *TestSuite) assertInReconciliationQueues(vaultAddr sdk.AccAddress, shoul
 	s.assertInPayoutVerificationQueue(vaultAddr, shouldContain)
 }
 
+// createVaultWithDueInterestTimeout creates a funded vault with a due PayoutTimeoutQueue
+// entry at dueTime, optionally paused, for exercising the per-block visit budget.
+func (s *TestSuite) createVaultWithDueInterestTimeout(info VaultInfo, dueTime int64, paused bool) {
+	s.requireAddFinalizeAndActivateMarker(info.underlying, s.adminAddr)
+	_, err := s.k.CreateVault(s.ctx, &types.MsgCreateVaultRequest{
+		Admin:           s.adminAddr.String(),
+		ShareDenom:      info.shareDenom,
+		UnderlyingAsset: info.underlying.Denom,
+	})
+	s.Require().NoError(err, "CreateVault should not error for share denom %s", info.shareDenom)
+
+	vault, err := s.k.GetVault(s.ctx, info.vaultAddr)
+	s.Require().NoError(err, "GetVault should not error for vault %s", info.vaultAddr)
+	vault.CurrentInterestRate = "0.1"
+	vault.DesiredInterestRate = "0.1"
+	vault.PeriodStart = dueTime
+	vault.PeriodTimeout = dueTime
+	vault.Paused = paused
+	s.k.AuthKeeper.SetAccount(s.ctx, vault)
+
+	s.Require().NoError(
+		FundAccount(s.ctx, s.simApp.BankKeeper, info.vaultAddr, sdk.NewCoins(sdk.NewInt64Coin(info.underlying.Denom, 1_000_000))),
+		"funding reserves should not error for vault %s", info.vaultAddr,
+	)
+	s.Require().NoError(
+		FundAccount(s.ctx, s.simApp.BankKeeper, markertypes.MustGetMarkerAddress(info.shareDenom), sdk.NewCoins(info.underlying)),
+		"funding principal should not error for marker %s", info.shareDenom,
+	)
+	s.Require().NoError(
+		s.k.PayoutTimeoutQueue.Enqueue(s.ctx, dueTime, info.vaultAddr),
+		"enqueuing due payout timeout should not error for vault %s", info.vaultAddr,
+	)
+}
+
+// createVaultWithDueFeeTimeout creates a funded vault with a due FeeTimeoutQueue entry at
+// dueTime, optionally paused, for exercising the per-block visit budget.
+func (s *TestSuite) createVaultWithDueFeeTimeout(shareDenom, underlyingDenom string, dueTime int64, paused bool) {
+	vault := s.CreateVaultWithParams(shareDenom, underlyingDenom)
+	vault.Paused = paused
+	s.SetVaultRatesAndPeriod(vault, "0.0", "0.0", dueTime, dueTime)
+	s.FundMarker(shareDenom, sdk.NewCoins(sdk.NewInt64Coin(underlyingDenom, 1_000_000_000)))
+	s.Require().NoError(
+		s.k.FeeTimeoutQueue.Enqueue(s.ctx, dueTime, vault.GetAddress()),
+		"enqueuing due fee timeout should not error for vault %s", vault.GetAddress(),
+	)
+}
+
 // countDuePayoutTimeouts returns the number of PayoutTimeoutQueue entries due at or before now.
 func (s *TestSuite) countDuePayoutTimeouts(now int64) int {
 	count := 0

--- a/keeper/vault.go
+++ b/keeper/vault.go
@@ -514,6 +514,11 @@ func (k *Keeper) autoPauseVault(ctx sdk.Context, vault *types.VaultAccount, reas
 	}
 
 	k.applyPausedState(ctx, vault, reason, sdk.Coin{Denom: vault.UnderlyingAsset, Amount: tvv})
+
+	if err := k.haltVaultAccrual(ctx, vault); err != nil {
+		k.getLogger(ctx).Error("failed to halt vault accrual during auto-pause", "vault_address", vault.GetAddress().String(), "error", err)
+	}
+
 	k.AuthKeeper.SetAccount(ctx, vault) // Updating via SetAccount to skip validation since auto-pausing is triggered by invalid state
 
 	k.emitEvent(ctx, types.NewEventVaultPaused(vault.GetAddress().String(), vault.GetAddress().String(), reason, vault.PausedBalance, true, ""))
@@ -528,7 +533,8 @@ func (k *Keeper) autoPauseVault(ctx sdk.Context, vault *types.VaultAccount, reas
 // failure so the resulting inconsistency saved to state is auditable. Every tolerated
 // failure is joined and surfaced via EventVaultPaused.forced_error. It shares
 // applyPausedState with autoPauseVault so both emergency pause paths perform an
-// identical in-memory paused-state transition.
+// identical in-memory paused-state transition, and calls haltVaultAccrual so the frozen
+// vault holds no reconciliation queue entries.
 func (k *Keeper) forcePauseVault(ctx sdk.Context, vault *types.VaultAccount, authority, reason string) {
 	var forcedErrors []string
 
@@ -553,6 +559,15 @@ func (k *Keeper) forcePauseVault(ctx sdk.Context, vault *types.VaultAccount, aut
 	}
 
 	k.applyPausedState(ctx, vault, reason, sdk.NewCoin(vault.UnderlyingAsset, tvv))
+
+	if err := k.haltVaultAccrual(ctx, vault); err != nil {
+		forcedErrors = append(forcedErrors, fmt.Sprintf("halt accrual failed: %v", err))
+		k.getLogger(ctx).Error(
+			"failed to halt vault accrual during forced pause; queue entries may remain",
+			"vault", vault.GetAddress().String(),
+			"err", err,
+		)
+	}
 
 	if err := k.SetVaultAccount(ctx, vault); err != nil {
 		forcedErrors = append(forcedErrors, fmt.Sprintf("set vault account failed: %v", err))

--- a/queue/fee_timeout.go
+++ b/queue/fee_timeout.go
@@ -78,25 +78,3 @@ func (p *FeeTimeoutQueue) Walk(ctx sdk.Context, fn func(feeTimeout uint64, vault
 	}
 	return nil
 }
-
-// RemoveAllForVault deletes all fee timeout entries in the
-// FeeTimeoutQueue for the given vault address.
-func (p *FeeTimeoutQueue) RemoveAllForVault(ctx sdk.Context, vaultAddr sdk.AccAddress) error {
-	var keys []collections.Pair[uint64, sdk.AccAddress]
-
-	if err := p.keyset.Walk(ctx, nil, func(kv collections.Pair[uint64, sdk.AccAddress]) (bool, error) {
-		if kv.K2().Equals(vaultAddr) {
-			keys = append(keys, kv)
-		}
-		return false, nil
-	}); err != nil {
-		return fmt.Errorf("walk fee timeouts: %w", err)
-	}
-
-	for _, key := range keys {
-		if err := p.keyset.Remove(ctx, key); err != nil {
-			return fmt.Errorf("remove fee timeout: %w", err)
-		}
-	}
-	return nil
-}

--- a/queue/fee_timeout_test.go
+++ b/queue/fee_timeout_test.go
@@ -90,27 +90,3 @@ func TestFeeTimeoutQueueWalkDueTimeouts(t *testing.T) {
 	}), "walking due fee timeouts <= 100 should not error")
 	assert.ElementsMatch(t, []uint64{50, 75}, seen, "walk should visit exactly timeouts <= 100; got %v", seen)
 }
-
-func TestFeeTimeoutQueueRemoveAllTimeoutsForVault(t *testing.T) {
-	ctx, q := newTestFeeTimeoutQueue(t)
-
-	a1 := sdk.MustAccAddressFromBech32(utils.TestProvlabsAddress().Bech32)
-	a2 := sdk.MustAccAddressFromBech32(utils.TestProvlabsAddress().Bech32)
-
-	require.NoError(t, q.Enqueue(ctx, 100, a1), "enqueue fee timeout (100) for a1 should succeed")
-	require.NoError(t, q.Enqueue(ctx, 150, a1), "enqueue fee timeout (150) for a1 should succeed")
-	require.NoError(t, q.Enqueue(ctx, 200, a2), "enqueue fee timeout (200) for a2 should succeed")
-
-	require.NoError(t, q.RemoveAllForVault(ctx, a1), "remove all fee timeouts for a1 should succeed")
-
-	seenA2 := false
-	err := q.Walk(ctx, func(timestamp uint64, address sdk.AccAddress) (bool, error) {
-		if address.Equals(a2) {
-			seenA2 = true
-		}
-		require.False(t, address.Equals(a1), "fee timeout queue should not include any entries for a1 after removal")
-		return false, nil
-	})
-	require.NoError(t, err, "walking the fee timeout queue after removal should not error")
-	require.True(t, seenA2, "fee timeout for a2 should still exist in the queue after a1 removal")
-}

--- a/spec/03_messages.md
+++ b/spec/03_messages.md
@@ -291,6 +291,8 @@ By default the pause is **strict**: it reconciles outstanding interest and fees 
 
 Setting `force = true` makes the pause an **emergency control**: a reconcile or valuation failure is logged and tolerated rather than blocking the freeze. The frozen `PausedBalance` is the net TVV when the vault can be valued, or zero when the valuation itself is what failed, so it may be approximate. Persistence is also best-effort: the handler first writes the paused account with validation, and if that validation fails it falls back to writing without validation so an already-inconsistent vault can still be frozen. Every tolerated failure (reconcile, valuation, and persistence) is recorded on `EventVaultPaused.forced_error`.
 
+Both paths remove the vault from the `PayoutTimeoutQueue`, the `VaultFeeTimeoutQueue`, and the `PayoutVerificationSet`, and clear its interest and fee period starts, so a paused vault holds no queue entries and accrues neither interest nor AUM fees while frozen.
+
 * **Request:** `MsgPauseVaultRequest { authority, vault_address, reason, force }`
 * **Response:** `MsgPauseVaultResponse {}`
 
@@ -299,6 +301,8 @@ Setting `force = true` makes the pause an **emergency control**: a reconcile or 
 ## UnpauseVault
 
 Admin or Asset Manager. Resumes a paused vault, clears paused balance, and recalculates NAV.
+
+It also re-arms what pausing cleared: the vault is added back to the `PayoutVerificationSet` and a fresh fee timeout is enqueued, with both period starts set to the unpause block time so the paused span is never charged interest or AUM fees.
 
 * **Request:** `MsgUnpauseVaultRequest { authority, vault_address }`
 * **Response:** `MsgUnpauseVaultResponse {}`

--- a/spec/03_messages.md
+++ b/spec/03_messages.md
@@ -291,7 +291,7 @@ By default the pause is **strict**: it reconciles outstanding interest and fees 
 
 Setting `force = true` makes the pause an **emergency control**: a reconcile or valuation failure is logged and tolerated rather than blocking the freeze. The frozen `PausedBalance` is the net TVV when the vault can be valued, or zero when the valuation itself is what failed, so it may be approximate. Persistence is also best-effort: the handler first writes the paused account with validation, and if that validation fails it falls back to writing without validation so an already-inconsistent vault can still be frozen. Every tolerated failure (reconcile, valuation, and persistence) is recorded on `EventVaultPaused.forced_error`.
 
-Both paths remove the vault from the `PayoutTimeoutQueue`, the `VaultFeeTimeoutQueue`, and the `PayoutVerificationSet`, and clear its interest and fee period starts, so a paused vault holds no queue entries and accrues neither interest nor AUM fees while frozen.
+Both paths remove the vault from the `PayoutVerificationSet` and from its `PayoutTimeoutQueue` and `VaultFeeTimeoutQueue` entries, and clear its interest and fee period starts, so a paused vault accrues neither interest nor AUM fees while frozen. Removal is keyed on the vault's recorded timeouts to keep it constant-time; a forced or automatic pause tolerates a failed removal, and any surviving entry is dequeued by the blocker that next visits it.
 
 * **Request:** `MsgPauseVaultRequest { authority, vault_address, reason, force }`
 * **Response:** `MsgPauseVaultResponse {}`

--- a/spec/06_blocker.md
+++ b/spec/06_blocker.md
@@ -76,9 +76,9 @@ Processing model (safe “collect-then-mutate”):
    * For **reconciled** vaults → `SafeEnqueuePayoutTimeout` (starts new period and enqueues next timeout).
    * For **depleted** vaults → `handleDepletedVaults` (sets `current_rate = "0"`; interest disabled, desired preserved).
 
-**Never reconciles paused vaults.** Pausing already removes a vault from this queue; any entry still
-present (legacy state, or a vault paused after the walk began) is dequeued on sight so it cannot camp
-at the front of the queue and starve the vaults behind it.
+**Never reconciles paused vaults.** Pausing already dequeues the vault; any entry still present
+(filed under another key, or a vault paused after the walk began) is dequeued on sight so it does not
+camp at the front of the queue. A failed dequeue is logged and the entry is retried on a later block.
 
 ### handleVaultFeeTimeouts
 
@@ -86,7 +86,8 @@ Reconciles the 15 bps AUM technology fee for vaults whose fee timeout has elapse
 
 1. **Collect due entries** from `VaultFeeTimeoutQueue` with `timeout <= now`, visiting at most
    `MaxFeeTimeoutsPerBlock` (currently 100) entries per block; the remainder stays due for
-   later blocks. Paused vaults count against the budget and are dequeued without collecting a fee.
+   later blocks. Paused vaults count against the budget and are dequeued without collecting a fee;
+   a failed dequeue is logged and retried on a later block.
 2. **Dequeue** each collected entry from the main context before processing to ensure it is not retried if a transient error occurs.
 3. **Attempt Atomic Reconciliation** (via `atomicallyReconcileFee` using `CacheContext`):
    - **PerformVaultFeeTransfer**:
@@ -132,7 +133,7 @@ This advances vaults from the **verification set**:
 
 1. **Collect keys** from `PayoutVerificationSet`, visiting at most `MaxPayoutVerificationsPerBlock`
    (currently 100) entries per block; paused vaults are removed from the set without being processed
-   (they count against the visit budget).
+   (they count against the visit budget), and a failed removal is logged and retried on a later block.
 2. **Remove** each from the set (before processing).
 3. **Partition** into:
 
@@ -199,11 +200,14 @@ This advances vaults from the **verification set**:
 
 * **BeginBlocker / EndBlocker** do not process paused vaults:
 
-  * Interest and AUM fees are **not** reconciled while paused. Pausing removes the vault from the
-    `PayoutTimeoutQueue`, the `VaultFeeTimeoutQueue`, and the `PayoutVerificationSet`, and clears both
-    period starts, so a paused vault holds no queue entries and accrues nothing. Unpausing re-arms
-    both: payout verification for interest and a fresh fee timeout, each starting at the unpause
-    block time, so the paused span is never charged.
+  * Interest and AUM fees are **not** reconciled while paused. Pausing clears both period starts and
+    removes the vault from the `PayoutVerificationSet` and from the `PayoutTimeoutQueue` and
+    `VaultFeeTimeoutQueue` entries keyed by its recorded timeouts, so a paused vault normally holds no
+    queue entries and accrues nothing. Removal is keyed rather than scanned to keep pause
+    constant-time, so an entry filed under any other key survives until a blocker dequeues it. Forced
+    and automatic pauses tolerate a failed removal, logging it rather than aborting the pause.
+    Unpausing re-arms both: payout verification for interest and a fresh fee timeout, each starting at
+    the unpause block time, so the paused span is never charged.
   * Pending swap-outs that come due while paused are **dequeued and refunded** with
     `EventSwapOutRefunded{ reason = "vault_paused" }`; owners resubmit after unpause.
 * A paused vault freezes its value at the `PausedBalance` snapshot, so operations that would change that value are rejected:
@@ -238,7 +242,7 @@ Submit `MsgSwapOut` → capture `request_id` → watch for `Completed` or `Refun
 
 * **Collect-then-mutate** iteration for all queues/sets (prevents iterator invalidation).
 * **Per-block visit budgets** on every queue/set walk keep block execution time bounded regardless of backlog size.
-* **Dequeue before mutate** when processing due items; paused vaults hold no timeout/verification entries, and paused swap-out jobs are dequeued and refunded.
+* **Dequeue before mutate** when processing due items; paused vaults are dequeued at pause and again by the blockers if any entry survives, and paused swap-out jobs are dequeued and refunded.
 * **Reconcile before supply-affecting ops** (e.g., swap-out payout) to keep NAV and TVV consistent.
 * **Flooring** in conversions prevents over-distribution or share inflation.
 * **Auto-pause on critical errors** creates a safe dead-stop until an admin resolves the issue.

--- a/spec/06_blocker.md
+++ b/spec/06_blocker.md
@@ -62,7 +62,7 @@ Processing model (safe “collect-then-mutate”):
    `MaxInterestTimeoutsPerBlock` (currently 100) entries per block; the remainder stays due
    for later blocks.
 
-   * Skip paused vaults (they count against the visit budget).
+   * Dequeue paused vaults without reconciling them (they count against the visit budget).
 2. **Dequeue** each collected `(timeout, vault)` before processing (prevents iterator invalidation).
 3. **For each vault**:
 
@@ -76,7 +76,9 @@ Processing model (safe “collect-then-mutate”):
    * For **reconciled** vaults → `SafeEnqueuePayoutTimeout` (starts new period and enqueues next timeout).
    * For **depleted** vaults → `handleDepletedVaults` (sets `current_rate = "0"`; interest disabled, desired preserved).
 
-**Skips paused vaults.** They remain in place until unpaused.
+**Never reconciles paused vaults.** Pausing already removes a vault from this queue; any entry still
+present (legacy state, or a vault paused after the walk began) is dequeued on sight so it cannot camp
+at the front of the queue and starve the vaults behind it.
 
 ### handleVaultFeeTimeouts
 
@@ -84,7 +86,7 @@ Reconciles the 15 bps AUM technology fee for vaults whose fee timeout has elapse
 
 1. **Collect due entries** from `VaultFeeTimeoutQueue` with `timeout <= now`, visiting at most
    `MaxFeeTimeoutsPerBlock` (currently 100) entries per block; the remainder stays due for
-   later blocks and paused vaults count against the budget.
+   later blocks. Paused vaults count against the budget and are dequeued without collecting a fee.
 2. **Dequeue** each collected entry from the main context before processing to ensure it is not retried if a transient error occurs.
 3. **Attempt Atomic Reconciliation** (via `atomicallyReconcileFee` using `CacheContext`):
    - **PerformVaultFeeTransfer**:
@@ -129,7 +131,8 @@ To prevent a large queue from consuming excessive block time and memory, a maxim
 This advances vaults from the **verification set**:
 
 1. **Collect keys** from `PayoutVerificationSet`, visiting at most `MaxPayoutVerificationsPerBlock`
-   (currently 100) entries per block; skip paused vaults (they count against the visit budget).
+   (currently 100) entries per block; paused vaults are removed from the set without being processed
+   (they count against the visit budget).
 2. **Remove** each from the set (before processing).
 3. **Partition** into:
 
@@ -196,7 +199,11 @@ This advances vaults from the **verification set**:
 
 * **BeginBlocker / EndBlocker** do not process paused vaults:
 
-  * Interest is **not** reconciled while paused; timeout entries remain in place until unpaused.
+  * Interest and AUM fees are **not** reconciled while paused. Pausing removes the vault from the
+    `PayoutTimeoutQueue`, the `VaultFeeTimeoutQueue`, and the `PayoutVerificationSet`, and clears both
+    period starts, so a paused vault holds no queue entries and accrues nothing. Unpausing re-arms
+    both: payout verification for interest and a fresh fee timeout, each starting at the unpause
+    block time, so the paused span is never charged.
   * Pending swap-outs that come due while paused are **dequeued and refunded** with
     `EventSwapOutRefunded{ reason = "vault_paused" }`; owners resubmit after unpause.
 * A paused vault freezes its value at the `PausedBalance` snapshot, so operations that would change that value are rejected:
@@ -231,7 +238,7 @@ Submit `MsgSwapOut` → capture `request_id` → watch for `Completed` or `Refun
 
 * **Collect-then-mutate** iteration for all queues/sets (prevents iterator invalidation).
 * **Per-block visit budgets** on every queue/set walk keep block execution time bounded regardless of backlog size.
-* **Dequeue before mutate** when processing due items; paused timeout/verification entries remain enqueued, while paused swap-out jobs are dequeued and refunded.
+* **Dequeue before mutate** when processing due items; paused vaults hold no timeout/verification entries, and paused swap-out jobs are dequeued and refunded.
 * **Reconcile before supply-affecting ops** (e.g., swap-out payout) to keep NAV and TVV consistent.
 * **Flooring** in conversions prevents over-distribution or share inflation.
 * **Auto-pause on critical errors** creates a safe dead-stop until an admin resolves the issue.


### PR DESCRIPTION
closes: #219 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Paused vaults no longer accrue interest or AUM fees during the paused period.
  * Pausing removes vaults from reconciliation tracking, while unpausing restores scheduling from the unpause time.
  * Paused vaults are removed from processing queues without blocking active vaults from being reconciled.

* **Documentation**
  * Updated pause, unpause, and reconciliation behavior documentation to reflect these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->