### PR TITLE
Fix outdated documentation comments

### DIFF
--- a/keeper/nav.go
+++ b/keeper/nav.go
@@ -49,9 +49,12 @@ func validateVaultNAVFields(vault *types.VaultAccount, nav types.VaultNAV) error
 }
 
 // SetVaultNAV creates or updates the internal net asset value entry for a denom
-// held by the given vault. The nav argument supplies the denom, price, volume,
-// and source; the updated block height and time are stamped from ctx before the
-// entry is stored.
+// on the given vault. The denom need not be one the vault already holds: pricing an
+// unheld denom is what authorizes the asset manager to acquire it, and the entry
+// contributes nothing to total vault value until the asset arrives at the principal
+// marker (see GetTVV). The nav argument supplies the denom, price, volume, and
+// source; the updated block height and time are stamped from ctx before the entry
+// is stored.
 //
 // The denom may not be the vault's share denom, whose value is derived from
 // the vault's total holdings rather than set externally. The denom must also

--- a/keeper/queue.go
+++ b/keeper/queue.go
@@ -110,9 +110,10 @@ func (k Keeper) SafeEnqueueFeeTimeout(ctx sdk.Context, vault *types.VaultAccount
 }
 
 // haltVaultAccrual removes a vault from the payout timeout queue, the fee timeout queue, and the
-// payout verification set, and clears its interest and fee accrual periods. Queue processors skip
-// paused vaults, so an entry left behind would consume the per-block visit budget forever. Both
-// periods are re-armed on unpause, so the paused span accrues no interest and no AUM fees.
+// payout verification set, and clears its interest and fee accrual periods. Removing at pause time
+// keeps a paused vault from occupying a per-block visit slot at all; the blocker processors also
+// dequeue any paused entry they encounter, so this is the cheap path rather than the only safeguard.
+// Both periods are re-armed on unpause, so the paused span accrues no interest and no AUM fees.
 //
 // Removal uses the vault's recorded timeouts as keys so it stays constant-time; auto-pause calls
 // this from the EndBlocker, where scanning a queue would grow block time with the backlog. An entry

--- a/keeper/valuation_engine.go
+++ b/keeper/valuation_engine.go
@@ -177,7 +177,7 @@ func (k Keeper) ToUnderlyingAssetAmount(ctx sdk.Context, vault types.VaultAccoun
 //   - Sum the converted amounts (floor at each multiplication/division step).
 //
 // Iterating the NAV table (a protocol-controlled key set written only by SetVaultNAV
-// and settlement) rather than every principal balance makes the cost O(valued denoms):
+// and genesis import) rather than every principal balance makes the cost O(valued denoms):
 // a denom parked at the principal with no NAV entry is never visited, so it is neither
 // valued nor able to inflate the per-call work. This preserves the prior behavior in
 // which such denoms were skipped.
@@ -253,14 +253,13 @@ func (k Keeper) GetNetTVV(ctx sdk.Context, vault types.VaultAccount) (math.Int, 
 // GetNAVPerShare returns the floor NAV per share in units of
 // vault.UnderlyingAsset.
 //
-// Paused fast-path:
-//   - If vault.Paused is true, this function short-circuits and returns
-//     vault.PausedBalance.Amount (ignores live TVV and share supply).
-//
-// Computation (when not paused):
+// Computation:
 //   - TVV(underlying) is obtained from GetNetTVV (net of the OutstandingAumFee liability).
 //   - totalShareSupply is taken from vault.TotalShares.Amount (the recorded share supply).
 //   - If total shares == 0, returns 0. Otherwise returns TVV / totalShareSupply (floor).
+//
+// For a paused vault, GetNetTVV supplies the frozen vault.PausedBalance.Amount,
+// so the result is that frozen balance divided by the share supply.
 func (k Keeper) GetNAVPerShare(ctx sdk.Context, vault types.VaultAccount) (math.Int, error) {
 	tvv, err := k.GetNetTVV(ctx, vault)
 	if err != nil {

--- a/module.go
+++ b/module.go
@@ -34,7 +34,7 @@ import (
 //
 // Bumped from 1 to 2 to accompany Migrator.Migrate1to2, which flattens every
 // vault to single-denom on its underlying asset (defaulting nav_authority to the
-// vault admin) and enables deposit protection on every vault's share marker. A
+// vault admin) and enables deposit protection when a vault's share marker can be loaded. A
 // v1->v2 migration handler is registered in RegisterServices so the SDK module
 // manager can drive the migration via RunMigrations when an upstream upgrade
 // handler advances the chain.

--- a/module.go
+++ b/module.go
@@ -568,7 +568,7 @@ func (AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "update-vault-nav [signer] [vault_address] [denom] [price] [volume] [source]",
 					Alias:     []string{"uvn"},
 					Short:     "Create or update a vault's internal NAV entry for a denom",
-					Long:      "Set the internal net asset value for a denom held by a vault. price is the total value of volume units, denominated in the vault's underlying asset. Must be signed by the vault's NAV authority. The denom cannot be the vault's share denom or underlying asset.",
+					Long:      "Set the internal net asset value for a denom on a vault. The denom need not be held yet; pricing it is what authorizes the asset manager to acquire it. price is the total value of volume units, denominated in the vault's underlying asset. Must be signed by the vault's NAV authority. The denom cannot be the vault's share denom or underlying asset.",
 					Example:   fmt.Sprintf("%s update-vault-nav %s %s usdc 1000000nhash 1000000 my-oracle", txStart, exampleAuthorityAddr, exampleVaultAddr),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: fieldSigner},

--- a/module.go
+++ b/module.go
@@ -32,11 +32,12 @@ import (
 
 // ConsensusVersion defines the current x/vault module consensus version.
 //
-// Bumped from 1 to 2 to accompany Migrator.Migrate1to2, which seeds the
-// Internal NAV table from the Marker module's NAV store and defaults
-// nav_authority to the vault admin. A v1->v2 migration handler is registered
-// in RegisterServices so the SDK module manager can drive the migration via
-// RunMigrations when an upstream upgrade handler advances the chain.
+// Bumped from 1 to 2 to accompany Migrator.Migrate1to2, which flattens every
+// vault to single-denom on its underlying asset (defaulting nav_authority to the
+// vault admin) and enables deposit protection on every vault's share marker. A
+// v1->v2 migration handler is registered in RegisterServices so the SDK module
+// manager can drive the migration via RunMigrations when an upstream upgrade
+// handler advances the chain.
 const ConsensusVersion = 2
 
 var (


### PR DESCRIPTION
Corrects six comments that no longer match the code: the `ConsensusVersion` migration summary, `GetNAVPerShare`'s nonexistent paused fast-path, the NAV table's writer list and `SetVaultNAV`'s already-held claim (both stale after #259), `haltVaultAccrual`'s rationale (stale after #257), and the `update-vault-nav` CLI help. This is comment and help text only with no behavior change, so it does not require a changelog entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that vaults may price assets they do not currently hold, authorizing future acquisition.
  - Updated guidance on paused vaults and queue processing.
  - Clarified valuation and NAV-per-share behavior for paused vaults and supported NAV sources.
  - Documented the v1-to-v2 upgrade changes, including vault configuration updates and migration support.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->